### PR TITLE
pin python, databases and sqlalchemy

### DIFF
--- a/.github/workflows/test_on_pr.yaml
+++ b/.github/workflows/test_on_pr.yaml
@@ -4,14 +4,14 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  tests:
     name: "Tests"
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.8'
           architecture: 'x64'
       - name: "Install tox"
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,19 +10,19 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6.8"
+python = ">=3.8,<4.0"
 asyncpg = ""
 aws-psycopg2 = ""
 boto3 = { version = "", optional = true }
 click = { version = "", optional = true }
-databases = ""
+databases = "0.4.1"
 fastapi = ""
 fastapi-utils = ""
 httpx = { version = "", optional = true }
 jinja2 = { version = "", optional = true }
 mangum = ""
 pyjwt = { version = "", optional = true }
-sqlalchemy = "^1.3.23"
+sqlalchemy = "1.3.23"
 # sqlalchemy = "~1.4"  # waiting for https://github.com/encode/databases/issues/298
 
 # soft-required by databases:

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,20 @@
 [tox]
 envlist = lint, mypy, unit
 
+
 # required for pyproject.toml
 isolated_build = True
 
 [testenv]
-basepython = python3
+basepython = python3.8
 extras =
     dev
     lm-create-jwt
     agent
 setenv =
+
+deps =
+    pytest
 
 [testenv:mypy]
 commands = mypy {posargs} src/licensemanager2/ jawthorizer/


### PR DESCRIPTION
Tests were failing on local due to python not pinned to >3.8,<4.0 and
due to databases and sqlalchemy version incompatibility.

These changes ensure python version is >3.8,<4.0, databases==0.4.1
and sqlalchemy==1.3.23.

Also add pytest to tox testenv deps to ensure we have pytest
in the testenv.

Fixes: 1211393461