### PR TITLE
V1 additional dev david

### DIFF
--- a/src/licensemanager2/agent/settings.py
+++ b/src/licensemanager2/agent/settings.py
@@ -16,6 +16,11 @@ from pydantic.error_wrappers import ValidationError
 logger = logging.getLogger("licensemanager2.agent.setting")
 
 
+PRODUCT_FEATURE_RX = r"^.+?\..+$"
+ENCODING = "UTF8"
+TOOL_TIMEOUT = 6  # seconds
+
+
 class LogLevelEnum(str, Enum):
     """
     Log level name enforcement

--- a/src/licensemanager2/agent/tokenstat.py
+++ b/src/licensemanager2/agent/tokenstat.py
@@ -22,7 +22,7 @@ from licensemanager2.agent.settings import (
 from licensemanager2.agent.backend_utils import get_license_server_features
 
 from licensemanager2.workload_managers.slurm.cmd_utils import (
-    get_used_tokens_for_license,
+    get_tokens_for_license,
     sacctmgr_modify_resource,
 )
 
@@ -189,7 +189,7 @@ async def attempt_tool_checks(
             slurm_license = f"{product}.{feature}@{tool_options.name}"
 
             # Get the used licenses from the scontrol output
-            slurm_used = await get_used_tokens_for_license(slurm_license)
+            slurm_used = await get_tokens_for_license(slurm_license, "Used")
 
             # If slurm is already tracking the license, update slurmdbd
             # with a modified view of the total licenses.

--- a/src/licensemanager2/agent/tokenstat.py
+++ b/src/licensemanager2/agent/tokenstat.py
@@ -12,19 +12,19 @@ from pydantic import BaseModel, Field
 
 from licensemanager2.agent import log as logger
 from licensemanager2.agent.parsing import flexlm
-from licensemanager2.agent.settings import SETTINGS
+from licensemanager2.agent.settings import (
+    SETTINGS,
+    PRODUCT_FEATURE_RX,
+    ENCODING,
+    TOOL_TIMEOUT
+)
+
 from licensemanager2.agent.backend_utils import get_license_server_features
 
 from licensemanager2.workload_managers.slurm.cmd_utils import (
     get_used_tokens_for_license,
     sacctmgr_modify_resource,
 )
-
-
-PRODUCT_FEATURE_RX = r"^.+?\..+$"
-ENCODING = "UTF8"
-
-TOOL_TIMEOUT = 6  # seconds
 
 
 class LicenseService(BaseModel):

--- a/src/licensemanager2/test/agent/test_slurmctld_prolog.py
+++ b/src/licensemanager2/test/agent/test_slurmctld_prolog.py
@@ -1,0 +1,48 @@
+"""
+Tests of Prolog
+"""
+
+from typing import List
+# from unittest.mock import patch
+from pytest import fixture, mark
+
+
+@fixture
+def scontrol_parsed_output_good() -> List[str]:
+    return [
+        "TESTPRODUCT.TESTFEATURE@flexlm:11",
+        "TESTPRODUCT2.TESTFEATURE2@flexlm:22",
+        "TESTPRODUCT3.TESTFEATURE3@flexlm:33",
+    ]
+
+
+@fixture
+def scontrol_parsed_output_bad() -> List[str]:
+    return [
+        "TESTFEATURE@flexlm:11",
+        "TESTPRODUCT2@22",
+        "TESTFEATURE3@flexlm",
+    ]
+
+
+@mark.asyncio
+async def test_get_required_licenses_for_job():
+    """
+    Do I collect the requested structured data from running all these dang tools?
+    """
+    p0 = patch.object(
+        cmd_utils,
+        "scontrol_show_lic",
+        scontrol_output_good_format
+    )
+    with p0:
+        licenses = await slurmctld_prolog._get_required_licenses_for_job()
+        assert len(licenses) == 3
+    
+
+@mark.asyncio
+async def test_get_required_licenses_for_job():
+    """
+    Do I collect the requested structured data from running all these dang tools?
+    """
+    assert (0 == 1)

--- a/src/licensemanager2/test/agent/test_slurmctld_prolog.py
+++ b/src/licensemanager2/test/agent/test_slurmctld_prolog.py
@@ -2,10 +2,9 @@
 Tests of Prolog
 """
 from typing import List
-# from unittest.mock import patch
 from pytest import fixture, mark
-from unittest.mock import patch
-from licensemanager2.workload_managers.slurm.slurmctld_prolog import (
+from unittest import mock
+from licensemanager2.workload_managers.slurm.cmd_utils import (
     get_required_licenses_for_job,
 )
 
@@ -34,32 +33,33 @@ def slurm_job_id() -> str:
 
 
 @mark.asyncio
-async def test_get_required_licenses_for_job_good(slurm_job_id: str, scontrol_parsed_output_good: List[str]):
+@mock.patch("licensemanager2.workload_managers.slurm.cmd_utils.get_licenses_for_job")
+async def test_get_required_licenses_for_job_good(
+    get_licenses_for_job_mock: mock.MagicMock,
+    slurm_job_id: str, scontrol_parsed_output_good: List[str]
+):
     """
     Do I return the correct licenses when the license format matches?
     """
-    p1 = patch(
-        'licensemanager2.workload_managers.slurm.slurmctld_prolog.get_licenses_for_job',
-        return_value=scontrol_parsed_output_good
+    get_licenses_for_job_mock.return_value = scontrol_parsed_output_good
+    license_booking_request = await get_required_licenses_for_job(
+        slurm_job_id
     )
-    with p1:
-        license_booking_request = await get_required_licenses_for_job(
-            slurm_job_id
-        )
-        assert len(license_booking_request.bookings) == 3
+    assert len(license_booking_request.bookings) == 3
 
 
 @mark.asyncio
-async def test_get_required_licenses_for_job_bad(slurm_job_id: str, scontrol_parsed_output_bad: List[str]):
+@mock.patch("licensemanager2.workload_managers.slurm.cmd_utils.get_licenses_for_job")
+async def test_get_required_licenses_for_job_bad(
+    get_licenses_for_job_mock: mock.MagicMock,
+    slurm_job_id: str, scontrol_parsed_output_bad: List[str]
+):
     """
     Do I return the correct licenses when the license format doesn't match?
     """
-    p1 = patch(
-        'licensemanager2.workload_managers.slurm.slurmctld_prolog.get_licenses_for_job',
-        return_value=scontrol_parsed_output_bad
+
+    get_licenses_for_job_mock.return_value = scontrol_parsed_output_bad
+    license_booking_request = await get_required_licenses_for_job(
+        slurm_job_id
     )
-    with p1:
-        license_booking_request = await get_required_licenses_for_job(
-            slurm_job_id
-        )
-        assert len(license_booking_request.bookings) == 0
+    assert len(license_booking_request.bookings) == 0

--- a/src/licensemanager2/test/agent/test_tokenstat.py
+++ b/src/licensemanager2/test/agent/test_tokenstat.py
@@ -135,7 +135,7 @@ async def test_report(tool_opts: tokenstat.ToolOptions, service_env_string: str)
     # Patch the objects needed to generate a report.
     p0 = patch.object(
         cmd_utils,
-        "get_used_tokens_for_license",
+        "get_tokens_for_license",
         0
     )
     p1 = patch.dict(

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -1,9 +1,8 @@
 """Utilities that interact with slurm."""
 import asyncio
+import httpx
 import re
 import shlex
-import httpx
-
 
 from pydantic import BaseModel, Field
 from licensemanager2.workload_managers.slurm.common import (
@@ -177,10 +176,11 @@ async def get_licenses_for_job(slurm_job_id: str) -> List:
     return license_list
 
 
-async def get_used_tokens_for_license(
-        product_feature_server: str) -> Optional[int]:
+async def get_tokens_for_license(
+        product_feature_server: str,
+        output_type: str) -> Optional[int]:
     """
-    Return used tokens from scontrol output.
+    Return tokens from scontrol output.
     """
 
     def match_product_feature_server() -> Optional[str]:
@@ -203,7 +203,7 @@ async def get_used_tokens_for_license(
     if token_str is not None:
         for item in token_str.split():
             k, v = item.split("=")
-            if k == "Used":
+            if k == output_type:
                 return int(v)
     return None
 

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -81,7 +81,7 @@ async def get_required_licenses_for_job(slurm_job_id: str) -> LicenseBookingRequ
     return license_booking_request
 
 
-async def _check_feature_token_availablity(lbr: LicenseBookingRequest) -> bool:
+async def check_feature_token_availablity(lbr: LicenseBookingRequest) -> bool:
     """Determine if there are sufficient tokens to fill the request."""
 
     # We currently only have an "/all" endpoint.
@@ -103,7 +103,7 @@ async def _check_feature_token_availablity(lbr: LicenseBookingRequest) -> bool:
     return False
 
 
-async def _make_booking_request(lbr: LicenseBookingRequest) -> bool:
+async def make_booking_request(lbr: LicenseBookingRequest) -> bool:
     """Book the feature tokens."""
 
     features = [
@@ -126,7 +126,7 @@ async def _make_booking_request(lbr: LicenseBookingRequest) -> bool:
     return False
 
 
-async def _force_reconciliation():
+async def reconcile():
     """Force a reconciliation."""
 
     with httpx.Client() as client:

--- a/src/licensemanager2/workload_managers/slurm/slurmctld_epilog.py
+++ b/src/licensemanager2/workload_managers/slurm/slurmctld_epilog.py
@@ -6,11 +6,17 @@ that have been booked for a job back to the pool after a job has completed.
 import asyncio
 import httpx
 
+from licensemanager2.agent.backend_utils import get_license_server_features
 from licensemanager2.agent import log, init_logging
 from licensemanager2.agent.settings import SETTINGS
 from licensemanager2.workload_managers.slurm.common import (
     LM2_AGENT_HEADERS,
     get_job_context
+)
+from licensemanager2.workload_managers.slurm.cmd_utils import (
+    get_tokens_for_license,
+    sacctmgr_modify_resource,
+    get_required_licenses_for_job,
 )
 
 
@@ -36,13 +42,40 @@ async def main():
     ctxt = get_job_context()
     job_id = ctxt["job_id"]
 
+    license_booking_request = await get_required_licenses_for_job(job_id)
+
+    # Create a list of tracked licenses in the form <product>.<feature>
+    tracked_licenses = list()
+    for license in get_license_server_features():
+        for feature in license["features"]:
+            tracked_licenses.append(f"{license['product']}.{feature}")
+
+    # If a license booking's product feature is tracked,
+    # update slurm's view of the token totals
+    for license_booking in license_booking_request:
+        product_feature = license_booking.product_feature
+        product, feature = product_feature.split(".")
+        license_server_type = license_booking.license_server_type
+        tokens_to_remove = license_booking.tokens
+        license = f"{product_feature}@{license_server_type}"
+
+        if product_feature in tracked_licenses:
+            total = get_tokens_for_license(license, "Total")
+            update_resource = await sacctmgr_modify_resource(
+                product, feature, total - tokens_to_remove
+            )
+
+            if update_resource:
+                log.info("Slurmdbd updated successfully.")
+            else:
+                log.info("Slurmdbd update unsuccessful.")
+
     # Attempt to remove the booking and log the result.
     booking_removed = await _remove_booking_for_job(job_id)
     if booking_removed:
         log.debug(f"Booking for job id: {job_id} successfully deleted.")
     else:
         log.debug(f"Booking for job id: {job_id} not removed.")
-
 
 # Initialize the logger
 init_logging("slurmctld-epilog")

--- a/src/licensemanager2/workload_managers/slurm/slurmctld_prolog.py
+++ b/src/licensemanager2/workload_managers/slurm/slurmctld_prolog.py
@@ -12,15 +12,16 @@ if the exit status is anything other then 0, e.g. 1.
 """
 import asyncio
 import sys
+
+from licensemanager2.agent import init_logging, log
 from licensemanager2.agent.backend_utils import get_license_server_features
-from licensemanager2.agent import log, init_logging
 from licensemanager2.workload_managers.slurm.common import get_job_context
 from licensemanager2.workload_managers.slurm.cmd_utils import (
     LicenseBookingRequest,
-    _force_reconciliation,
-    _check_feature_token_availablity,
-    _make_booking_request,
-    get_required_licenses_for_job
+    check_feature_token_availablity,
+    get_required_licenses_for_job,
+    make_booking_request,
+    reconcile,
 )
 
 
@@ -49,15 +50,15 @@ async def main():
 
     if len(tracked_license_booking_request.bookings) > 0:
         # Force a reconciliation before we check the feature tokenavailability.
-        await _force_reconciliation()
+        await reconcile()
         # Check that there are sufficient feature tokens for the job.
-        feature_token_availability = _check_feature_token_availablity(
+        feature_token_availability = check_feature_token_availablity(
             tracked_license_booking_request
         )
         if feature_token_availability:
             # If we have sufficient tokens for features that are
             # requested, proceed with booking the tokens for each feature.
-            booking_request = await _make_booking_request(
+            booking_request = await make_booking_request(
                 tracked_license_booking_request
             )
             if booking_request:

--- a/tox.ini
+++ b/tox.ini
@@ -15,11 +15,11 @@ whitelist_externals = poetry
 
 [testenv:mypy]
 commands =
-    poetry run mypy {posargs} src/licensemanager2/ jawthorizer/ --exclude src/licensemanager2/workload_managers
+    poetry run mypy {posargs} src/licensemanager2/ jawthorizer/
 
 [testenv:lint]
 commands =
-    poetry run flake8 {posargs} --ignore=D400,W605,W503 src/licensemanager2/ jawthorizer/
+    poetry run flake8 {posargs} --ignore=W292,D400,W605,W503 src/licensemanager2/ jawthorizer/
 
 [testenv:unit]
 commands =


### PR DESCRIPTION
https://omnivector-solutions.monday.com/boards/1204470680/pulses/1299676711

These changes introduce enhanced license tracking in the slurmctld
prolog that enforce only tracking licenses that meet the protocol:
`<product>.<feature>@<license_server>:<num_tokens>`

* test that no licenses returned when correct protocol not used
* test that correct license count is returned when correct
protocol is used
* move call to scontrol and output parsing to cmd_utils.py
* enhance slurmctldProlog to only track licenses that match the
protocol