### PR TITLE
ensure epilog exits 0

### DIFF
--- a/src/licensemanager2/workload_managers/slurm/slurmctld_epilog.py
+++ b/src/licensemanager2/workload_managers/slurm/slurmctld_epilog.py
@@ -4,6 +4,8 @@ This epilog is responsible for releasing the feature tokens
 that have been booked for a job back to the pool after a job has completed.
 """
 import asyncio
+import sys
+
 import httpx
 
 from licensemanager2.agent.backend_utils import get_license_server_features
@@ -44,38 +46,41 @@ async def main():
 
     license_booking_request = await get_required_licenses_for_job(job_id)
 
-    # Create a list of tracked licenses in the form <product>.<feature>
-    tracked_licenses = list()
-    for license in get_license_server_features():
-        for feature in license["features"]:
-            tracked_licenses.append(f"{license['product']}.{feature}")
+    if len(license_booking_request.bookings) > 0:
+        # Create a list of tracked licenses in the form <product>.<feature>
+        tracked_licenses = list()
+        for license in get_license_server_features():
+            for feature in license["features"]:
+                tracked_licenses.append(f"{license['product']}.{feature}")
+    
+        # If a license booking's product feature is tracked,
+        # update slurm's view of the token totals
+        for license_booking in license_booking_request.bookings:
+            product_feature = license_booking.product_feature
+            product, feature = product_feature.split(".")
+            license_server_type = license_booking.license_server_type
+            tokens_to_remove = license_booking.tokens
+            license = f"{product_feature}@{license_server_type}"
+    
+            if product_feature in tracked_licenses:
+                total = await get_tokens_for_license(license, "Total")
+                update_resource = await sacctmgr_modify_resource(
+                    product, feature, total - tokens_to_remove
+                )
+    
+                if update_resource:
+                    log.info("Slurmdbd updated successfully.")
+                else:
+                    log.info("Slurmdbd update unsuccessful.")
+    
+        # Attempt to remove the booking and log the result.
+        booking_removed = await _remove_booking_for_job(job_id)
+        if booking_removed:
+            log.debug(f"Booking for job id: {job_id} successfully deleted.")
+        else:
+            log.debug(f"Booking for job id: {job_id} not removed.")
+    sys.exit(0)
 
-    # If a license booking's product feature is tracked,
-    # update slurm's view of the token totals
-    for license_booking in license_booking_request.bookings:
-        product_feature = license_booking.product_feature
-        product, feature = product_feature.split(".")
-        license_server_type = license_booking.license_server_type
-        tokens_to_remove = license_booking.tokens
-        license = f"{product_feature}@{license_server_type}"
-
-        if product_feature in tracked_licenses:
-            total = await get_tokens_for_license(license, "Total")
-            update_resource = await sacctmgr_modify_resource(
-                product, feature, total - tokens_to_remove
-            )
-
-            if update_resource:
-                log.info("Slurmdbd updated successfully.")
-            else:
-                log.info("Slurmdbd update unsuccessful.")
-
-    # Attempt to remove the booking and log the result.
-    booking_removed = await _remove_booking_for_job(job_id)
-    if booking_removed:
-        log.debug(f"Booking for job id: {job_id} successfully deleted.")
-    else:
-        log.debug(f"Booking for job id: {job_id} not removed.")
 
 # Initialize the logger
 init_logging("slurmctld-epilog")


### PR DESCRIPTION
These changes ensure that the epilog always exists 0 by
enforcing a sys.exit(0) in main().