### PR TITLE
add cluster_name to booking endpoints

### DIFF
--- a/src/licensemanager2/backend/schema.py
+++ b/src/licensemanager2/backend/schema.py
@@ -17,7 +17,7 @@ metadata = sqlalchemy.MetaData()
 license_table = Table(
     "license",
     metadata,
-    Column("id", Integer, primary_key=True),
+    Column("id", Integer, primary_key=True, nullable=True),
     Column("product_feature", String, primary_key=True),
     Column("used", Integer, CheckConstraint("used>=0")),
     Column("total", Integer, CheckConstraint("total>=0")),
@@ -37,7 +37,7 @@ booking_table = Table(
     Column("user_name", String),
     Column("cluster_name", String),
     Column("created_at", DateTime, default=datetime.datetime.utcnow),
-    Column('config_id', Integer, ForeignKey("config.id"), nullable=False),
+    Column('config_id', Integer, ForeignKey("config.id"), nullable=True),
     sqlite_autoincrement=True
 )
 

--- a/src/licensemanager2/test/backend/conftest.py
+++ b/src/licensemanager2/test/backend/conftest.py
@@ -44,16 +44,19 @@ def some_licenses():
     """
     inserts = [
         LUR(
+            id=1,
             product_feature="hello.world",
             total=100,
             used=19,
         ),
         LUR(
+            id=2,
             product_feature="hello.dolly",
             total=80,
             used=11,
         ),
         LUR(
+            id=3,
             product_feature="cool.beans",
             total=11,
             used=11,

--- a/src/licensemanager2/test/backend/test_booking.py
+++ b/src/licensemanager2/test/backend/test_booking.py
@@ -19,16 +19,28 @@ def some_booking_rows():
             job_id="hellodollybeans",
             product_feature="hello.world",
             booked=19,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
         ),
         booking.BookingRow(
             job_id="hellodollybeans",
             product_feature="hello.dolly",
             booked=11,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
         ),
         booking.BookingRow(
             job_id="coolbeans",
             product_feature="cool.beans",
             booked=11,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
         ),
     ]
     return inserts
@@ -37,17 +49,27 @@ def some_booking_rows():
 @mark.asyncio
 @database.transaction(force_rollback=True)
 async def test_get_bookings_job(
-    backend_client: AsyncClient, some_licenses, some_booking_rows
+    backend_client: AsyncClient, one_configuration_row, some_licenses, some_booking_rows
 ):
     """
     Do I fetch a booking?
     """
+    await insert_objects(one_configuration_row, schema.config_table)
     await insert_objects(some_licenses, schema.license_table)
     await insert_objects(some_booking_rows, schema.booking_table)
-    resp = await backend_client.get("/api/v1/booking/job/coolbeans")
+    cluster_name = "testcluster"
+    resp = await backend_client.get("/api/v1/booking/job/coolbeans", params={'cluster_name': cluster_name})
     assert resp.status_code == 200
     assert resp.json() == [
-        dict(job_id="coolbeans", product_feature="cool.beans", booked=11),
+        dict(
+            job_id="coolbeans",
+            product_feature="cool.beans",
+            booked=11,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
+        ),
     ]
 
 
@@ -68,15 +90,27 @@ async def test_bookings_all(
             job_id="coolbeans",
             product_feature="cool.beans",
             booked=11,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
         ),
         dict(
             job_id="hellodollybeans",
             product_feature="hello.dolly",
             booked=11,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
         ),
         dict(
             job_id="hellodollybeans",
             product_feature="hello.world",
             booked=19,
+            lead_host="testlead",
+            user_name="testusername",
+            cluster_name="testcluster",
+            config_id=100,
         ),
     ]


### PR DESCRIPTION
add cluster_name argument into schema, get, get_all, post, and delete
endpoints, and into test_booking and the test fixtures for booking.
These changes address this task: https://omnivector-solutions.monday.com/boards/1204470680


This PR is only meant as a place to discuss these changes and will not actually be merged into the branch 129969....get_config_from_backend. 

