### PR TITLE
get squeue formatted output and parse it

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### What
+Please provide a short description of the purpose of this pull request.
+
+#### Why
+Explain why the proposed change is necessary.
+
+`Task`: https://omnivector-solutions.monday.com/boards/XXXX/pulses/YYYY
+
+---
+
+#### Peer Review
+Please follow the upstream omnivector documentation concerning
+[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).

--- a/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
+++ b/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
@@ -8,5 +8,11 @@ def test_squeue_parser_returns_correct_output_format():
         {"job_id": 2, "run_time_in_seconds": 184981, "state": "RUNNING"},
         {"job_id": 3, "run_time_in_seconds": 17084, "state": "RUNNING"},
     ]
-    squeue_parsed = squeue_parser("1|5:00|RUNNING\n2|2-3:23:01|RUNNING\n3|4:44:44|RUNNING")
+    squeue_parsed = squeue_parser(
+        "\n".join([
+            "1|5:00|RUNNING",
+            "2|2-3:23:01|RUNNING",
+            "3|4:44:44|RUNNING",
+        ])
+    )
     assert squeue_parsed == squeue_parsed_output

--- a/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
+++ b/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
@@ -1,4 +1,13 @@
-from licensemanager2.workload_managers.slurm.cmd_utils import squeue_parser
+from licensemanager2.workload_managers.slurm.cmd_utils import (
+    squeue_parser,
+    SqueueParserUnexpectedInputError,
+)
+
+
+def test_squeue_with_bad_input():
+    """Test that squeue throws the correct exception given incorrect input."""
+    with raises(SqueueParserUnexpectedInputError):
+        squeue_parsed = squeue_parser("bad input")
 
 
 def test_squeue_parser_returns_correct_output_format():

--- a/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
+++ b/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
@@ -2,7 +2,7 @@ from licensemanager2.workload_managers.slurm.cmd_utils import squeue_parser
 
 
 def test_squeue_parser_returns_correct_output_format():
-    """Test that the squeue_parsed() returns correct output."""
+    """Given the squeue formatted output, ensure the `squeue_parsed()` returns the expected values."""
     squeue_parsed_output = [
         {"job_id": 1, "run_time_in_seconds": 300, "state": "RUNNING"},
         {"job_id": 2, "run_time_in_seconds": 184981, "state": "RUNNING"},

--- a/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
+++ b/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
@@ -1,0 +1,12 @@
+from licensemanager2.workload_managers.slurm.cmd_utils import squeue_parser
+
+
+def test_squeue_parser_returns_correct_output_format():
+    """Test that the squeue_parsed() returns correct output."""
+    squeue_parsed_output = [
+        {"job_id": 1, "run_time_in_seconds": 300, "state": "RUNNING"},
+        {"job_id": 2, "run_time_in_seconds": 184981, "state": "RUNNING"},
+        {"job_id": 3, "run_time_in_seconds": 17084, "state": "RUNNING"},
+    ]
+    squeue_parsed = squeue_parser("1|5:00|RUNNING\n2|2-3:23:01|RUNNING\n3|4:44:44|RUNNING")
+    assert squeue_parsed == squeue_parsed_output

--- a/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
+++ b/src/licensemanager2/test/workload_managers/slurm/cmd_test_utils.py
@@ -1,3 +1,5 @@
+from pytest import raises
+
 from licensemanager2.workload_managers.slurm.cmd_utils import (
     squeue_parser,
     SqueueParserUnexpectedInputError,
@@ -7,7 +9,7 @@ from licensemanager2.workload_managers.slurm.cmd_utils import (
 def test_squeue_with_bad_input():
     """Test that squeue throws the correct exception given incorrect input."""
     with raises(SqueueParserUnexpectedInputError):
-        squeue_parsed = squeue_parser("bad input")
+        _ = squeue_parser("bad input")
 
 
 def test_squeue_parser_returns_correct_output_format():

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -22,6 +22,11 @@ from licensemanager2.agent.settings import (
 )
 
 
+class SqueueParserUnexpectedInputError(Exception):
+    """Unexpected squeue output."""
+    pass
+
+
 class ScontrolRetrievalFailure(Exception):
     """
     Could not get SLURM data for job id.
@@ -350,8 +355,18 @@ def squeue_parser(squeue_formatted_output) -> List[Dict]:
 
     squeue_parsed_output = list()
 
+    def parse_squeue_line():
+        """Parse a line from squeue formatted output."""
+        try:
+            job_id, run_time, state = line.split("|")
+        except SqueueParserUnexpectedInputError as e:
+            logger.error(e)
+            raise(e)
+        return job_id, run_time, state
+ 
+
     for line in squeue_formatted_output.split():
-        job_id, run_time, state = line.split("|")
+        job_id, run_time, state = parse_squeue_line()
         squeue_parsed_output.append(
             {
                 "job_id": int(job_id),

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -299,10 +299,10 @@ async def sacctmgr_modify_resource(
 
 
 def return_formated_squeue_out() -> str:
-     """Call squeue via Popen and return the output."""
+    """Call squeue via Popen and return the output."""
 
     result = subprocess.run(
-        [SQUEUE_PATH + " --noheader --format='%A|%M|%T'"],
+        [SQUEUE_PATH, "--noheader", "--format='%A|%M|%T'"],
         capture_output=True,
         shell=True,
         encoding="utf-8"

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -306,7 +306,7 @@ async def sacctmgr_modify_resource(
 def return_formated_squeue_out() -> str:
     """
     Call squeue via Popen and return the formatted output.
-    
+
     Return the squeue output in the form "<job_id>|<run_time>|<state>".
     """
 
@@ -326,7 +326,7 @@ def return_formated_squeue_out() -> str:
 def _total_time_in_seconds(time_string: str) -> int:
     """
     Return the runtime in seconds for a job.
-    
+
     This function takes a slurm time string ("<days>-<hours>:<minutes>:<seconds>") as input, parses
     and converts each of the units in the time string to seconds and returns a computed value, the sum of the days,
     hours, minutes and seconds (in seconds).
@@ -363,7 +363,6 @@ def squeue_parser(squeue_formatted_output) -> List[Dict]:
             logger.error(e)
             raise(e)
         return job_id, run_time, state
- 
 
     for line in squeue_formatted_output.split():
         job_id, run_time, state = parse_squeue_line()

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -24,7 +24,6 @@ from licensemanager2.agent.settings import (
 
 class SqueueParserUnexpectedInputError(Exception):
     """Unexpected squeue output."""
-    pass
 
 
 class ScontrolRetrievalFailure(Exception):

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -361,7 +361,7 @@ def squeue_parser(squeue_formatted_output) -> List[Dict]:
             job_id, run_time, state = line.split("|")
         except SqueueParserUnexpectedInputError as e:
             logger.error(e)
-            raise(e)
+            raise e
         return job_id, run_time, state
 
     for line in squeue_formatted_output.split():

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -299,20 +299,19 @@ async def sacctmgr_modify_resource(
 
 
 def return_formated_squeue_out() -> str:
-    """Call squeue via Popen and return the output.
+     """Call squeue via Popen and return the output."""
 
-    return type: str
-    """
+    result = subprocess.run(
+        [SQUEUE_PATH + " --noheader --format='%A|%M|%T'"],
+        capture_output=True,
+        shell=True,
+        encoding="utf-8"
+    )
+    if result.returncode != 0:
+        logger.error(result.stderr)
+        raise Exception(result.stderr)
 
-    try:
-        stdout, _ = subprocess.Popen(
-            [SQUEUE_PATH, "--noheader", "--format='%A|%M|%T'"]
-        )
-    except subprocess.CalledProcessError as e:
-        logger.error(e)
-        raise e
-
-    return stdout.decode().strip()
+    return result.stdout.strip()
 
 
 def _total_time_in_seconds(time_string: str) -> int:

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -299,7 +299,11 @@ async def sacctmgr_modify_resource(
 
 
 def return_formated_squeue_out() -> str:
-    """Call squeue via Popen and return the output."""
+    """
+    Call squeue via Popen and return the formatted output.
+    
+    Return the squeue output in the form "<job_id>|<run_time>|<state>".
+    """
 
     result = subprocess.run(
         [SQUEUE_PATH, "--noheader", "--format='%A|%M|%T'"],

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -323,19 +323,17 @@ def _total_time_in_seconds(time_string: str) -> int:
 
     days = 0
     hours = 0
-    if "-" in time_string:
-        days, time_string = time_string.split("-")
+    splitted_time = [int(value) for value in re.split("-|:", time_string)]
+    splitted_time_len = len(splitted_time)
 
-    measure_of_time = time_string.count(":")
-
-    if measure_of_time == 2:
-        hours, minutes, seconds = time_string.split(":")
+    if splitted_time_len == 3:
+        days, hours, minutes, seconds = splitted_time
+    elif splitted_time_len == 2:
+        hours, minutes, seconds = splitted_time
     else:
-        minutes, seconds = time_string.split(":")
+        minutes, seconds = splitted_time
 
-    return (
-        int(days) * DAY + int(hours) * HOUR + int(minutes) * MINUTE + int(seconds)
-    )
+    return days * DAY + hours * HOUR + minutes * MINUTE + seconds
 
 
 def squeue_parser(squeue_formatted_output) -> List[Dict]:

--- a/src/licensemanager2/workload_managers/slurm/cmd_utils.py
+++ b/src/licensemanager2/workload_managers/slurm/cmd_utils.py
@@ -315,7 +315,13 @@ def return_formated_squeue_out() -> str:
 
 
 def _total_time_in_seconds(time_string: str) -> int:
-    """Return the sum of the hours minutes and seconds (in seconds)."""
+    """
+    Return the runtime in seconds for a job.
+    
+    This function takes a slurm time string ("<days>-<hours>:<minutes>:<seconds>") as input, parses
+    and converts each of the units in the time string to seconds and returns a computed value, the sum of the days,
+    hours, minutes and seconds (in seconds).
+    """
     MINUTE = 60
     HOUR = 60 * MINUTE
     DAY = 24 * HOUR

--- a/src/licensemanager2/workload_managers/slurm/common.py
+++ b/src/licensemanager2/workload_managers/slurm/common.py
@@ -14,6 +14,7 @@ LM2_AGENT_HEADERS = {
 
 SCONTROL_PATH = "/usr/bin/scontrol"
 SACCTMGR_PATH = "/usr/bin/sacctmgr"
+SQUEUE_PATH = "/usr/bin/squeue"
 CMD_TIMEOUT = 5
 ENCODING = "UTF8"
 


### PR DESCRIPTION
#### What
These changes introduce the squeue_parser() function and associated code including; `_total_time_in_seconds()` and
`return_parsed_squeue_output()` as well as a test that makes assertions on 3 different cases; 1) the case of days in the time string, 2) the case of no days, but hours and 3) the case of only minutes and seconds.

#### Why
Part of the the booking cleanup work, implementing a way to get a list of running jobs on the cluster using squeue.

`Task`: https://omnivector-solutions.monday.com/boards/1204470680/pulses/1456711228

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).