### PR TITLE
don't start the agent if the backend version doesn't match

### DIFF
--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -9,7 +9,16 @@ from pydantic import BaseModel, ValidationError
 from lm_agent.forward import async_client
 from lm_agent.logs import logger
 
+
 GET_CONFIG_URL_PATH = "/api/v1/config/all"
+
+
+class LicenseManagerBackendConnectionError(Exception):
+    """Exception for backend connection issues."""
+
+
+class LicenseManagerBackendVersionError(Exception):
+    """Exception for backend/agent version mismatches."""
 
 
 class BackendConfigurationRow(BaseModel):

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -3,6 +3,7 @@ Provide utilities that communicate with the backend.
 """
 from typing import List
 
+from fastapi import status
 from httpx import ConnectError
 from pydantic import BaseModel, ValidationError
 
@@ -18,6 +19,16 @@ class LicenseManagerBackendConnectionError(Exception):
 
 class LicenseManagerBackendVersionError(Exception):
     """Exception for backend/agent version mismatches."""
+
+
+async def get_license_manager_backend_version():
+    """Return the license-manager-backend version."""
+    resp = await async_client().get("/version")
+    # Check that we have a valid response.
+    if resp.status_code != status.HTTP_200_OK:
+        logger.error("license-manager-backend version could not be obtained.")
+        raise LicenseManagerBackendConnectionError()
+    return resp.json()["version"]
 
 
 class BackendConfigurationRow(BaseModel):

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, ValidationError
 from lm_agent.forward import async_client
 from lm_agent.logs import logger
 
-
 GET_CONFIG_URL_PATH = "/api/v1/config/all"
 
 

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -21,7 +21,7 @@ class LicenseManagerBackendVersionError(Exception):
     """Exception for backend/agent version mismatches."""
 
 
-async def get_license_manager_backend_version():
+async def get_license_manager_backend_version() -> str:
     """Return the license-manager-backend version."""
     resp = await async_client().get("/version")
     # Check that we have a valid response.

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -4,23 +4,22 @@ License-manager agent, command line entrypoint
 Run with e.g. `uvicorn lm_agent.main:app`
 """
 import logging
-import pkg_resources
 import typing
 from itertools import cycle
 
+import pkg_resources
 from fastapi import FastAPI, HTTPException
 from fastapi_utils.tasks import repeat_every
 
 from lm_agent.api import api_v1
 from lm_agent.backend_utils import (
-    LicenseManagerBackendVersionError,
     LicenseManagerBackendConnectionError,
+    LicenseManagerBackendVersionError,
 )
 from lm_agent.config import settings
 from lm_agent.forward import async_client
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import reconcile
-
 
 app = FastAPI()
 # app.add_middleware(
@@ -71,7 +70,7 @@ def backend_version_check():
 
     # Check the version of the backend matches the version of the agent.
     backend_version = resp.json()["version"]
-    agent_version = pkg_resources.get_distribution('license-manager-agent').version
+    agent_version = pkg_resources.get_distribution("license-manager-agent").version
     if backend_version != agent_version:
         logger.error(f"license-manager-backend incompatible version: {backend_version}.")
         raise LicenseManagerBackendVersionError()

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -87,7 +87,7 @@ async def backend_version_check():
 
     # Check the version of the backend matches the version of the agent.
     BACKEND_VERSION = resp.json()["version"]
-    if BACKEND_VERSION != AGENT_VERSION:
+    if BACKEND_VERSION.split(".")[0] != AGENT_VERSION.split(".")[0]:
         logger.error(f"license-manager-backend incompatible version: {BACKEND_VERSION}.")
         raise LicenseManagerBackendVersionError()
     logger.info(f"license-manager-backend successfully connected. Version: {BACKEND_VERSION}.")

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -45,17 +45,6 @@ async def root():
     return dict(message="OK")
 
 
-@app.get("/debug")
-async def debug():
-    """
-    Expose version information for the license-manager-{agent,backend}.
-    """
-    return dict(
-        agent_version=AGENT_VERSION,
-        backend_version=await get_license_manager_backend_version(),
-    )
-
-
 @app.get("/health")
 async def health():
     """
@@ -75,12 +64,15 @@ async def reconcile_endpoint():
 @app.on_event("startup")
 async def backend_version_check():
     """Check that the license-manager-backend version matches our own."""
-    # Check the version of the backend matches the version of the agent.
+
+    # Get the backend_version and check that the major version matches our own.
     backend_version = await get_license_manager_backend_version()
+    logger.info(f"Agent Version: {AGENT_VERSION}")
+    logger.info(f"Backend Version: {backend_version}")
     if backend_version.split(".")[0] != AGENT_VERSION.split(".")[0]:
         logger.error(f"license-manager-backend incompatible version: {backend_version}.")
         raise LicenseManagerBackendVersionError()
-    logger.info(f"license-manager-backend successfully connected. Version: {backend_version}.")
+    logger.info(f"license-manager-backend successfully connected.")
 
 
 @app.on_event("startup")

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -21,7 +21,6 @@ from lm_agent.forward import async_client
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import reconcile
 
-
 AGENT_VERSION = pkg_resources.get_distribution("license-manager-agent").version
 BACKEND_VERSION = str()
 

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -13,8 +13,8 @@ from fastapi_utils.tasks import repeat_every
 
 from lm_agent.api import api_v1
 from lm_agent.backend_utils import (
-    LicenseManagerBackendConnectionError,
     LicenseManagerBackendVersionError,
+    get_license_manager_backend_version,
 )
 from lm_agent.config import settings
 from lm_agent.forward import async_client
@@ -22,7 +22,6 @@ from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import reconcile
 
 AGENT_VERSION = pkg_resources.get_distribution("license-manager-agent").version
-BACKEND_VERSION = str()
 
 
 app = FastAPI()
@@ -53,7 +52,7 @@ async def debug():
     """
     return dict(
         agent_version=AGENT_VERSION,
-        backend_version=BACKEND_VERSION,
+        backend_version=await get_license_manager_backend_version(),
     )
 
 
@@ -76,20 +75,12 @@ async def reconcile_endpoint():
 @app.on_event("startup")
 async def backend_version_check():
     """Check that the license-manager-backend version matches our own."""
-    # Get the license-manager-backend version.
-    global BACKEND_VERSION
-    resp = await async_client().get("/version")
-    # Check that we have a valid response.
-    if resp.status_code != status.HTTP_200_OK:
-        logger.error("license-manager-backend version could not be obtained.")
-        raise LicenseManagerBackendConnectionError()
-
     # Check the version of the backend matches the version of the agent.
-    BACKEND_VERSION = resp.json()["version"]
-    if BACKEND_VERSION.split(".")[0] != AGENT_VERSION.split(".")[0]:
-        logger.error(f"license-manager-backend incompatible version: {BACKEND_VERSION}.")
+    backend_version = await get_license_manager_backend_version()
+    if backend_version.split(".")[0] != AGENT_VERSION.split(".")[0]:
+        logger.error(f"license-manager-backend incompatible version: {backend_version}.")
         raise LicenseManagerBackendVersionError()
-    logger.info(f"license-manager-backend successfully connected. Version: {BACKEND_VERSION}.")
+    logger.info(f"license-manager-backend successfully connected. Version: {backend_version}.")
 
 
 @app.on_event("startup")

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -48,7 +48,7 @@ async def root():
 
 
 @app.get("/debug")
-async def version():
+async def debug():
     """
     Expose version information for the license-manager-{agent,backend}.
     """

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -59,7 +59,7 @@ async def reconcile_endpoint():
 
 
 @app.on_event("startup")
-def backend_version_check():
+async def backend_version_check():
     """Check that the license-manager-backend version matches our own."""
     # Get the license-manager-backend version.
     resp = await async_client().get("/version")

--- a/agent/mypy.ini
+++ b/agent/mypy.ini
@@ -19,3 +19,6 @@ ignore_missing_imports = True
 
 [mypy-typer.*]
 ignore_missing_imports = True
+
+[mypy-pkg_resources.*]
+ignore_missing_imports = True

--- a/agent/tests/test_main.py
+++ b/agent/tests/test_main.py
@@ -1,10 +1,28 @@
 import logging
+from unittest import mock
 from unittest.mock import patch
 
 from fastapi import HTTPException, status
-from pytest import mark
+from pytest import mark, raises
 
-from lm_agent import main
+from lm_agent import backend_utils, main
+
+
+@mark.asyncio
+@mock.patch("lm_agent.main.get_license_manager_backend_version")
+async def test_backend_version_check__on_non_matching_agent_backend_major_versions(
+    mock_license_manager_backend_version: mock.AsyncMock,
+):
+    """
+    Test that the agent starts when the major version returned by the backend matches our own.
+    """
+    mock_license_manager_backend_version.return_value = "2.5.4"
+    p0 = patch.object(main, "AGENT_VERSION", "1.5")
+    p1 = patch.object(main.settings, "LOG_LEVEL", "INFO")
+
+    with p0, p1:
+        with raises(backend_utils.LicenseManagerBackendVersionError):
+            await main.backend_version_check()
 
 
 @mark.asyncio

--- a/backend/lm_backend/main.py
+++ b/backend/lm_backend/main.py
@@ -4,10 +4,10 @@ Run with e.g. `uvicorn lm_backend.main:app` OR
 set `licensemanager2.backend.main.handler` as the ASGI handler
 """
 import logging
-import pkg_resources
 import sys
 from typing import Any, Optional
 
+import pkg_resources
 import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -62,7 +62,7 @@ async def version():
     """
     Return the license-manager-backend version.""
     """
-    version = pkg_resources.get_distribution('license-manager-backend').version
+    version = pkg_resources.get_distribution("license-manager-backend").version
     return dict(message="OK", version=version)
 
 

--- a/backend/lm_backend/main.py
+++ b/backend/lm_backend/main.py
@@ -4,6 +4,7 @@ Run with e.g. `uvicorn lm_backend.main:app` OR
 set `licensemanager2.backend.main.handler` as the ASGI handler
 """
 import logging
+import pkg_resources
 import sys
 from typing import Any, Optional
 
@@ -54,6 +55,15 @@ async def health():
     Healthcheck, for health monitors in the deployed environment
     """
     return dict(message="OK")
+
+
+@app.get("/version")
+async def version():
+    """
+    Return the license-manager-backend version.""
+    """
+    version = pkg_resources.get_distribution('license-manager-backend').version
+    return dict(message="OK", version=version)
 
 
 @app.on_event("startup")

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -19,3 +19,6 @@ ignore_missing_imports = True
 
 [mypy-typer.*]
 ignore_missing_imports = True
+
+[mypy-pkgresources.*]
+ignore_missing_imports = True

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -20,5 +20,5 @@ ignore_missing_imports = True
 [mypy-typer.*]
 ignore_missing_imports = True
 
-[mypy-pkgresources.*]
+[mypy-pkg_resources.*]
 ignore_missing_imports = True

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -932,14 +932,6 @@ ipython-genutils = "*"
 test = ["pytest"]
 
 [[package]]
-name = "types-setuptools"
-version = "57.0.2"
-description = "Typing stubs for setuptools"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -982,7 +974,7 @@ dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e5ed39370ac5a76fbb37b8b4cc8095efeef7b9dffa933eaad648669f50c3e4c6"
+content-hash = "d15efb16e9593b9d5423631c95c9ba9f1af6df7113bfdd7823a6e78e80a0eb54"
 
 [metadata.files]
 aiosqlite = [
@@ -1557,10 +1549,6 @@ tomli = [
 traitlets = [
     {file = "traitlets-5.0.5-py3-none-any.whl", hash = "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"},
     {file = "traitlets-5.0.5.tar.gz", hash = "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396"},
-]
-types-setuptools = [
-    {file = "types-setuptools-57.0.2.tar.gz", hash = "sha256:4ead432cc394b8de5ee94a312494f3c730d21dbfef37f300a6ac5e742271d735"},
-    {file = "types_setuptools-57.0.2-py3-none-any.whl", hash = "sha256:62c8dc465f29eeaad6b9025645138738d3df1cafc70cb0b14aea700946f2cbb7"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -932,6 +932,14 @@ ipython-genutils = "*"
 test = ["pytest"]
 
 [[package]]
+name = "types-setuptools"
+version = "57.0.2"
+description = "Typing stubs for setuptools"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -974,7 +982,7 @@ dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d15efb16e9593b9d5423631c95c9ba9f1af6df7113bfdd7823a6e78e80a0eb54"
+content-hash = "e5ed39370ac5a76fbb37b8b4cc8095efeef7b9dffa933eaad648669f50c3e4c6"
 
 [metadata.files]
 aiosqlite = [
@@ -1219,12 +1227,22 @@ mangum = [
     {file = "mangum-0.12.2.tar.gz", hash = "sha256:f49a3b56daffe776b0325734ff2afcb0f87f8f9d7eb3f1364ca50f600be52092"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1233,14 +1251,21 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1250,6 +1275,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1529,6 +1557,10 @@ tomli = [
 traitlets = [
     {file = "traitlets-5.0.5-py3-none-any.whl", hash = "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"},
     {file = "traitlets-5.0.5.tar.gz", hash = "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396"},
+]
+types-setuptools = [
+    {file = "types-setuptools-57.0.2.tar.gz", hash = "sha256:4ead432cc394b8de5ee94a312494f3c730d21dbfef37f300a6ac5e742271d735"},
+    {file = "types_setuptools-57.0.2-py3-none-any.whl", hash = "sha256:62c8dc465f29eeaad6b9025645138738d3df1cafc70cb0b14aea700946f2cbb7"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ black = "^21.7b0"
 alembic = "^1.6.5"
 mypy = "^0.910"
 sqlalchemy-stubs = "^0.4"
+types-setuptools = "^57.0.2"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,7 +35,6 @@ black = "^21.7b0"
 alembic = "^1.6.5"
 mypy = "^0.910"
 sqlalchemy-stubs = "^0.4"
-types-setuptools = "^57.0.2"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -26,6 +26,16 @@ async def test_root(backend_client):
     # TODO: If root is ever made to return anything meaningful, we should test that here
 
 
+@mark.asyncio
+async def test_health(backend_client):
+    """
+    Does a healthcheck endpoint exist?
+    """
+    resp = await backend_client.get("/version")
+    assert resp.status_code == 200
+    assert resp.json()["version"] != None
+
+
 def test_begin_logging():
     """
     Do I configure logging when the app starts up?

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -27,9 +27,9 @@ async def test_root(backend_client):
 
 
 @mark.asyncio
-async def test_health(backend_client):
+async def test_version(backend_client):
     """
-    Does a healthcheck endpoint exist?
+    Does a version endpoint exist?
     """
     resp = await backend_client.get("/version")
     assert resp.status_code == 200


### PR DESCRIPTION
#### What
Create a /version backend endpoint that exposes the version
of the license-manager-backend. Additionally add a startup
check in the license-manager-agent to ensure that it is
running the same code as the backend. Additionally, add a /debug
endpoint to the agent that exposes the version information of the
agent and the backend, to allow for simplified debugging.

#### Why
We need a way to guarantee that the license-manager-agent is talking to a compatible license-manager-backend and want to simplify the process of being able to introspect what versions are running/configured.

Fixes: #45
