### PR TITLE
add a way to ensure that the agent is compatible with the backend

### DIFF
--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -3,6 +3,7 @@ Provide utilities that communicate with the backend.
 """
 from typing import List
 
+from fastapi import status
 from httpx import ConnectError
 from pydantic import BaseModel, ValidationError
 
@@ -10,6 +11,24 @@ from lm_agent.forward import async_client
 from lm_agent.logs import logger
 
 GET_CONFIG_URL_PATH = "/api/v1/config/all"
+
+
+class LicenseManagerBackendConnectionError(Exception):
+    """Exception for backend connection issues."""
+
+
+class LicenseManagerBackendVersionError(Exception):
+    """Exception for backend/agent version mismatches."""
+
+
+async def get_license_manager_backend_version() -> str:
+    """Return the license-manager-backend version."""
+    resp = await async_client().get("/version")
+    # Check that we have a valid response.
+    if resp.status_code != status.HTTP_200_OK:
+        logger.error("license-manager-backend version could not be obtained.")
+        raise LicenseManagerBackendConnectionError()
+    return resp.json()["version"]
 
 
 class BackendConfigurationRow(BaseModel):

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -5,13 +5,18 @@ Run with e.g. `uvicorn lm_agent.main:app`
 """
 import logging
 
+import pkg_resources
 from fastapi import FastAPI
 from fastapi_utils.tasks import repeat_every
 
 from lm_agent.api import api_v1
+from lm_agent.backend_utils import LicenseManagerBackendVersionError, get_license_manager_backend_version
 from lm_agent.config import settings
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import reconcile
+
+AGENT_VERSION = pkg_resources.get_distribution("license-manager-agent").version
+
 
 app = FastAPI()
 # app.add_middleware(
@@ -48,6 +53,20 @@ async def reconcile_endpoint():
     Force a reconciliation by making a get request to this endpoint.
     """
     await reconcile()
+
+
+@app.on_event("startup")
+async def backend_version_check():
+    """Check that the license-manager-backend version matches our own."""
+
+    # Get the backend_version and check that the major version matches our own.
+    backend_version = await get_license_manager_backend_version()
+    logger.info(f"Agent Version: {AGENT_VERSION}")
+    logger.info(f"Backend Version: {backend_version}")
+    if backend_version.split(".")[0] != AGENT_VERSION.split(".")[0]:
+        logger.error(f"license-manager-backend incompatible version: {backend_version}.")
+        raise LicenseManagerBackendVersionError()
+    logger.info(f"license-manager-backend successfully connected.")
 
 
 @app.on_event("startup")

--- a/agent/lm_agent/main.py
+++ b/agent/lm_agent/main.py
@@ -66,7 +66,7 @@ async def backend_version_check():
     if backend_version.split(".")[0] != AGENT_VERSION.split(".")[0]:
         logger.error(f"license-manager-backend incompatible version: {backend_version}.")
         raise LicenseManagerBackendVersionError()
-    logger.info(f"license-manager-backend successfully connected.")
+    logger.info("license-manager-backend successfully connected.")
 
 
 @app.on_event("startup")

--- a/agent/mypy.ini
+++ b/agent/mypy.ini
@@ -19,3 +19,6 @@ ignore_missing_imports = True
 
 [mypy-typer.*]
 ignore_missing_imports = True
+
+[mypy-pkg_resources.*]
+ignore_missing_imports = True

--- a/agent/tests/test_main.py
+++ b/agent/tests/test_main.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from fastapi import HTTPException, status
-from pytest import mark
+from pytest import mark, raises
 
 from lm_agent import backend_utils, main
 

--- a/agent/tests/test_main.py
+++ b/agent/tests/test_main.py
@@ -1,10 +1,28 @@
 import logging
+from unittest import mock
 from unittest.mock import patch
 
 from fastapi import HTTPException, status
 from pytest import mark
 
-from lm_agent import main
+from lm_agent import backend_utils, main
+
+
+@mark.asyncio
+@mock.patch("lm_agent.main.get_license_manager_backend_version")
+async def test_backend_version_check__on_non_matching_agent_backend_major_versions(
+    mock_license_manager_backend_version: mock.AsyncMock,
+):
+    """
+    Test that the agent starts when the major version returned by the backend matches our own.
+    """
+    mock_license_manager_backend_version.return_value = "2.5.4"
+    p0 = patch.object(main, "AGENT_VERSION", "1.5")
+    p1 = patch.object(main.settings, "LOG_LEVEL", "INFO")
+
+    with p0, p1:
+        with raises(backend_utils.LicenseManagerBackendVersionError):
+            await main.backend_version_check()
 
 
 @mark.asyncio

--- a/backend/lm_backend/main.py
+++ b/backend/lm_backend/main.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from typing import Any, Optional
 
+import pkg_resources
 import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -54,6 +55,15 @@ async def health():
     Healthcheck, for health monitors in the deployed environment
     """
     return dict(message="OK")
+
+
+@app.get("/version")
+async def version():
+    """
+    Return the license-manager-backend version.""
+    """
+    version = pkg_resources.get_distribution("license-manager-backend").version
+    return dict(message="OK", version=version)
 
 
 @app.on_event("startup")

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -19,3 +19,6 @@ ignore_missing_imports = True
 
 [mypy-typer.*]
 ignore_missing_imports = True
+
+[mypy-pkg_resources.*]
+ignore_missing_imports = True

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -8,6 +8,16 @@ from lm_backend import main
 
 
 @mark.asyncio
+async def test_version(backend_client):
+    """
+    Does a version endpoint exist?
+    """
+    resp = await backend_client.get("/version")
+    assert resp.status_code == 200
+    assert resp.json()["version"] != None
+
+
+@mark.asyncio
 async def test_health(backend_client):
     """
     Does a healthcheck endpoint exist?


### PR DESCRIPTION
#### What
Add an endpoint in the license-manager-backend that exposes
the version. Additionally add a startup check in the agent that
checks for consist major versions between the configured backend
and the running agent.

#### Why
Need a way to provide a guarantee that the running agent will work with the backend before executing agent code.

Fixes: #45 

`Task`: https://omnivector-solutions.monday.com/boards/1204470680/pulses/1575098866

