### PR TITLE
Parser now returns lead_host, user_name and booked

### DIFF
--- a/agent/lm_agent/parsing/flexlm.py
+++ b/agent/lm_agent/parsing/flexlm.py
@@ -48,6 +48,7 @@ def parse(s: str) -> dict:
     """
     Parse lines of the license output with regular expressions
     """
+    parsed_data: dict = {"uses": [], "total": None}
     for line in s.splitlines():
         parsed = RX.match(line)
         if parsed is None:
@@ -55,10 +56,18 @@ def parse(s: str) -> dict:
 
         if parsed.group("total"):
             d = parsed.groupdict()
-            return {
+            parsed_data["total"] = {
                 "total": int(d["total"]),
                 "used": int(d["used"]),
                 "feature": d["feature"],
             }
-
-    return {}
+        if parsed.group("user"):
+            d = parsed.groupdict()
+            parsed_data["uses"].append(
+                {
+                    "user_name": d["user"],
+                    "lead_host": d["user_host"],
+                    "booked": int(d["tokens"]),
+                }
+            )
+    return parsed_data

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -35,6 +35,7 @@ class LicenseReportItem(BaseModel):
     product_feature: str = Field(..., regex=PRODUCT_FEATURE_RX)
     used: int
     total: int
+    used_licenses: typing.List
 
     @classmethod
     def from_stdout(cls, product, parse_fn, tool_name, stdout):
@@ -45,9 +46,10 @@ class LicenseReportItem(BaseModel):
         parsed = parse_fn(stdout)
         return cls(
             tool_name=tool_name,
-            product_feature=f"{product}.{parsed['feature']}",
-            used=parsed["used"],
-            total=parsed["total"],
+            product_feature=f"{product}.{parsed['total']['feature']}",
+            used=parsed["total"]["used"],
+            total=parsed["total"]["total"],
+            used_licenses=parsed["uses"],
         )
 
 

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -2,9 +2,9 @@
 Configuration of pytest for agent tests
 """
 from pathlib import Path
+from textwrap import dedent
 from unittest.mock import patch
 
-import pkg_resources
 import respx
 from httpx import ASGITransport, AsyncClient
 from pytest import fixture
@@ -51,3 +51,43 @@ def respx_mock():
     """
     with respx.mock as mock:
         yield mock
+
+
+@fixture
+def lm_output_bad():
+    """
+    Some unparseable lmstat output
+    """
+    return dedent(
+        """\
+    lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
+    Flexible License Manager status on Wed 03/31/2021 09:12
+
+    Error getting status: Cannot connect to license server (-15,570:111 "Connection refused")
+    """
+    )
+
+
+@fixture
+def lm_output():
+    """
+    Some lmstat output to parse
+    """
+    return dedent(
+        """\
+        lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
+        ...
+
+        Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 93 licenses in use)
+
+        ...
+
+
+        """
+        "           jbemfv myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
+        "start Thu 10/29 8:09, 29 licenses\n"
+        "           cdxfdn myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
+        "start Thu 10/29 8:09, 27 licenses\n"
+        "           jbemfv myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
+        "start Thu 10/29 8:09, 37 licenses\n"
+    )

--- a/agent/tests/parsing/test_flexlm.py
+++ b/agent/tests/parsing/test_flexlm.py
@@ -1,58 +1,26 @@
 """
 Test the flexlm parser
 """
-from textwrap import dedent
-
-from pytest import fixture, mark
+from pytest import mark
 
 from lm_agent.parsing.flexlm import parse
-
-
-@fixture
-def lm_output_bad():
-    """
-    Some unparseable lmstat output
-    """
-    return dedent(
-        """\
-    lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
-    Flexible License Manager status on Wed 03/31/2021 09:12
-
-    Error getting status: Cannot connect to license server (-15,570:111 "Connection refused")
-    """
-    )
-
-
-@fixture
-def lm_output():
-    """
-    Some lmstat output to parse
-    """
-    return dedent(
-        """\
-        lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
-        ...
-
-        Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 93 licenses in use)
-
-        ...
-
-
-        """
-        "           jbemfv myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
-        "start Thu 10/29 8:09, 29 licenses\n"
-        "           cdxfdn myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
-        "start Thu 10/29 8:09, 27 licenses\n"
-        "           jbemfv myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
-        "start Thu 10/29 8:09, 37 licenses\n"
-    )
 
 
 @mark.parametrize(
     "fixture,result",
     [
-        ("lm_output", {"feature": "TESTFEATURE", "total": 1000, "used": 93}),
-        ("lm_output_bad", {}),
+        (
+            "lm_output",
+            {
+                "total": {"feature": "TESTFEATURE", "total": 1000, "used": 93},
+                "uses": [
+                    {"booked": 29, "lead_host": "myserver.example.com", "user_name": "jbemfv"},
+                    {"booked": 27, "lead_host": "myserver.example.com", "user_name": "cdxfdn"},
+                    {"booked": 37, "lead_host": "myserver.example.com", "user_name": "jbemfv"},
+                ],
+            },
+        ),
+        ("lm_output_bad", {"total": None, "uses": []}),
     ],
 )
 def test_parse(request, fixture, result):

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -45,22 +45,26 @@ def tool_opts() -> tokenstat.ToolOptions:
     )
 
 
-def test_lri_from_stdout():
+def test_lri_from_stdout(lm_output):
     """
     Do I parse the stdout string from flexlm to produce structured data?
     """
-    stdout = "Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 502 licenses in use)"
     lri = tokenstat.LicenseReportItem.from_stdout(
         product="TESTPRODUCT",
         parse_fn=flexlm.parse,
         tool_name="flexlm",
-        stdout=stdout,
+        stdout=lm_output,
     )
     assert lri == tokenstat.LicenseReportItem(
         tool_name="flexlm",
         product_feature="TESTPRODUCT.TESTFEATURE",
-        used=502,
+        used=93,
         total=1000,
+        used_licenses=[
+            {"booked": 29, "user_name": "jbemfv", "lead_host": "myserver.example.com"},
+            {"booked": 27, "user_name": "cdxfdn", "lead_host": "myserver.example.com"},
+            {"booked": 37, "user_name": "jbemfv", "lead_host": "myserver.example.com"},
+        ],
     )
 
 
@@ -89,7 +93,36 @@ async def test_attempt_tool_checks(
         ["flexlm:127.0.0.1:2345"],
     )
     assert ret == tokenstat.LicenseReportItem(
-        tool_name="flexlm", product_feature="TESTPRODUCT.TESTFEATURE", used=502, total=1000
+        tool_name="flexlm",
+        product_feature="TESTPRODUCT.TESTFEATURE",
+        used=502,
+        total=1000,
+        used_licenses=[
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 29},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 27},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 23},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 9},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 8},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 15},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 43},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 11},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 13},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 23},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 28},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 11},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 17},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 38},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 25},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 35},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 38},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 4},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 9},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 11},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 19},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 15},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 14},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 37},
+        ],
     )
 
     # bad tool
@@ -121,6 +154,32 @@ async def test_report(
         "product_feature": "testproduct1.TESTFEATURE",
         "used": 502,
         "total": 1000,
+        "used_licenses": [
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 29},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 27},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 23},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 9},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 8},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 15},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 43},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 11},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 13},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 23},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 28},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 11},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 17},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 38},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 25},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 35},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 38},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 4},
+            {"user_name": "jxezha", "lead_host": "myserver.example.com", "booked": 9},
+            {"user_name": "cdxfdn", "lead_host": "myserver.example.com", "booked": 11},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 19},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 15},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 14},
+            {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 37},
+        ],
     }
     with p0, p1:
         assert [license_report_item] == await tokenstat.report()


### PR DESCRIPTION
#### What
Flexlm parser now returns the lead_host, user_name and quantity booked for each use of the licenses.

#### Why
These information are needed by the in use cleanup.

`Task`: https://omnivector-solutions.monday.com/boards/1204470680/pulses/1579578433