### PR TITLE
Fix regex for postgresql and add .env

### DIFF
--- a/backend/lm_backend/config.py
+++ b/backend/lm_backend/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
 
     # database to connect
     DATABASE_URL: str = Field(
-        "sqlite:///./sqlite.db?check_same_thread=true", regex=r"^(sqlite|postgres)://.+$"
+        "sqlite:///./sqlite.db?check_same_thread=true", regex=r"^(sqlite|postgresql)://.+$"
     )
 
     # log level (everything except sql tracing)
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_prefix = "LM2_"
+        env_file = ".env"
 
 
 settings = Settings()


### PR DESCRIPTION
#### What
Add .env in config and fix regex for DATABASE_URL in the backend.

#### Why
To be able to use a `.env`file to set the DATABASE_URL and have a working regex for postgres databases.