### PR TITLE
Use cluster_name in booking table

### DIFF
--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -58,6 +58,7 @@ class LicenseBookingRequest(BaseModel):
     bookings: Union[List, List[LicenseBooking]]
     user_name: str
     lead_host: str
+    cluster_name: str
 
 
 def _match_requested_license(requested_license: str) -> Union[dict, None]:
@@ -130,6 +131,7 @@ async def make_booking_request(lbr: LicenseBookingRequest) -> bool:
                 "features": features,
                 "user_name": lbr.user_name,
                 "lead_host": lbr.lead_host,
+                "cluster_name": lbr.cluster_name,
             },
         )
 

--- a/agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
+++ b/agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
@@ -33,6 +33,7 @@ async def prolog():
     job_id = job_context.get("job_id", "")
     user_name = job_context.get("user_name")
     lead_host = job_context.get("lead_host")
+    cluster_name = job_context.get("cluster_name")
 
     logger.info(f"Prolog started for job id: {job_id}")
 
@@ -66,7 +67,11 @@ async def prolog():
     # track. These tracked licenses are what we will check feature token
     # availability for.
     tracked_license_booking_request = LicenseBookingRequest(
-        job_id=job_id, bookings=[], user_name=user_name, lead_host=lead_host
+        job_id=job_id,
+        bookings=[],
+        user_name=user_name,
+        lead_host=lead_host,
+        cluster_name=cluster_name,
     )
     for booking in required_licenses:
         if booking.product_feature in tracked_licenses:

--- a/agent/tests/workload_managers/slurm/test_slurmctld_prolog.py
+++ b/agent/tests/workload_managers/slurm/test_slurmctld_prolog.py
@@ -89,7 +89,12 @@ async def test_main(
     get_job_context_mock,
     sys_mock,
 ):
-    get_job_context_mock.return_value = {"job_id": "1", "user_name": "user1", "lead_host": "host1"}
+    get_job_context_mock.return_value = {
+        "job_id": "1",
+        "user_name": "user1",
+        "lead_host": "host1",
+        "cluster_name": "cluster1",
+    }
     bookings_mock = mock.MagicMock()
     bookings_mock.product_feature = "test.feature"
     bookings_mock.license_server_type = "flexlm"

--- a/backend/lm_backend/api_schemas.py
+++ b/backend/lm_backend/api_schemas.py
@@ -46,6 +46,7 @@ class Booking(BaseModel):
     features: List[BookingFeature]
     lead_host: str
     user_name: str
+    cluster_name: str
 
     class Config:
         orm_mode = True
@@ -63,6 +64,7 @@ class BookingRow(BaseModel):
     config_id: int
     lead_host: str
     user_name: str
+    cluster_name: str
 
     class Config:
         orm_mode = True

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -42,6 +42,7 @@ def some_booking_rows():
             config_id=1,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
         ),
         BookingRow(
             id=2,
@@ -51,6 +52,7 @@ def some_booking_rows():
             config_id=1,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
         ),
         BookingRow(
             id=3,
@@ -60,5 +62,6 @@ def some_booking_rows():
             config_id=2,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
         ),
     ]

--- a/backend/tests/api/test_booking.py
+++ b/backend/tests/api/test_booking.py
@@ -6,7 +6,7 @@ from pytest import mark
 
 from lm_backend import table_schemas
 from lm_backend.api import booking
-from lm_backend.api_schemas import Booking, BookingFeature
+from lm_backend.api_schemas import Booking, BookingFeature, BookingRow
 from lm_backend.storage import database
 
 
@@ -36,6 +36,49 @@ async def test_get_bookings_job(
             config_id=2,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
+        ),
+    ]
+
+
+@mark.asyncio
+@database.transaction(force_rollback=True)
+async def test_get_bookings_for_cluster_name(
+    backend_client: AsyncClient,
+    some_licenses,
+    some_booking_rows,
+    some_config_rows,
+    insert_objects,
+):
+    """
+    Do I fetch a booking using the cluster_name?
+    """
+    await insert_objects(some_licenses, table_schemas.license_table)
+    await insert_objects(some_config_rows, table_schemas.config_table)
+    await insert_objects(some_booking_rows, table_schemas.booking_table)
+    booking = BookingRow(
+        id=4,
+        job_id="99",
+        product_feature="hello.world",
+        booked=1,
+        lead_host="host10",
+        user_name="user10",
+        cluster_name="cluster2",
+        config_id=2,
+    )
+    await insert_objects([booking], table_schemas.booking_table)
+    resp = await backend_client.get("/api/v1/booking/all?cluster_name=cluster2")
+    assert resp.status_code == 200
+    assert resp.json() == [
+        dict(
+            id=4,
+            job_id="99",
+            product_feature="hello.world",
+            booked=1,
+            config_id=2,
+            lead_host="host10",
+            user_name="user10",
+            cluster_name="cluster2",
         ),
     ]
 
@@ -78,6 +121,7 @@ async def test_bookings_all(
             config_id=1,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
         ),
         dict(
             id=2,
@@ -87,6 +131,7 @@ async def test_bookings_all(
             config_id=1,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
         ),
         dict(
             id=3,
@@ -96,6 +141,7 @@ async def test_bookings_all(
             config_id=2,
             lead_host="host1",
             user_name="user1",
+            cluster_name="cluster1",
         ),
     ]
 
@@ -107,7 +153,9 @@ async def test_booking_create(backend_client, some_config_rows, some_licenses, i
     await insert_objects(some_licenses, table_schemas.license_table)
     await insert_objects(some_config_rows, table_schemas.config_table)
     features = BookingFeature(booked=10, product_feature="hello.world")
-    booking = Booking(job_id=1, features=[features], lead_host="host1", user_name="user1")
+    booking = Booking(
+        job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
+    )
     resp = await backend_client.put("/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_200_OK
@@ -124,7 +172,9 @@ async def test_booking_create_negative_booked_error(
     await insert_objects(some_licenses, table_schemas.license_table)
     await insert_objects(some_config_rows, table_schemas.config_table)
     features = BookingFeature(booked=-1, product_feature="hello.world")
-    booking = Booking(job_id=1, features=[features], lead_host="host1", user_name="user1")
+    booking = Booking(
+        job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
+    )
     resp = await backend_client.put("/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -145,7 +195,9 @@ async def test_booking_create_booked_greater_than_total(
     await insert_objects(some_licenses, table_schemas.license_table)
     await insert_objects(some_config_rows, table_schemas.config_table)
     features = BookingFeature(booked=1000, product_feature="hello.world")
-    booking = Booking(job_id=1, features=[features], lead_host="host1", user_name="user1")
+    booking = Booking(
+        job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
+    )
     resp = await backend_client.put("/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -184,7 +236,9 @@ async def test_is_booking_available_not_available(
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
     features = BookingFeature(booked=100, product_feature="hello.world")
-    booking_row = Booking(job_id="new", features=[features], lead_host="host1", user_name="user2")
+    booking_row = Booking(
+        job_id="new", features=[features], lead_host="host1", user_name="user2", cluster_name="cluster1"
+    )
 
     assert await booking._is_booking_available(booking_row) is False
 
@@ -199,6 +253,8 @@ async def test_is_booking_available(
     await insert_objects(some_licenses, table_schemas.license_table)
     await insert_objects(some_config_rows, table_schemas.config_table)
     features = BookingFeature(booked=81, product_feature="hello.world")
-    booking_row = Booking(job_id="new", features=[features], lead_host="host1", user_name="user2")
+    booking_row = Booking(
+        job_id="new", features=[features], lead_host="host1", user_name="user2", cluster_name="cluster1"
+    )
 
     assert await booking._is_booking_available(booking_row) is True


### PR DESCRIPTION
#### What
- Send information about `cluster_name` to the backend
- Make changes to backend to be able to query the bookings given the `cluster_name`

#### Why
To be able to correctly remove the bookings, we'll need to filter by `cluster_name`.