### PR TITLE
Change RLM parsing to use product.feature instead of product_feature

### DIFF
--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -65,6 +65,17 @@ def _filter_current_feature(parsed_list, feature):
             return feature_item
 
 
+def _filter_used_features(parsed_list, feature):
+    used_licenses = []
+    for feature_booked in parsed_list:
+        if feature_booked["feature"].count("_") == 0:
+            if feature_booked["feature"] == feature:
+                used_licenses.append(feature_booked)
+        elif "".join(feature_booked["feature"].split(_)[1:]) == feature:
+            used_licenses.append(feature_booked)
+    return used_licenses
+
+
 def _cleanup_features(features_list):
     """
     Remove the feature key for each entry in the parsed["uses"], since we already handled it.
@@ -93,7 +104,8 @@ class RLMReportItem(BaseModel):
         if not feature:
             feature = product
         current_feature_item = _filter_current_feature(parsed["total"], feature)
-        used_licenses = _cleanup_features(parsed["uses"])
+        feature_booked_licenses = _filter_used_features(parsed["used"], feature)
+        used_licenses = _cleanup_features(feature_booked_licenses)
         return cls(
             tool_name=tool_name,
             product_feature=f"{product}.{feature}",

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -104,7 +104,7 @@ class RLMReportItem(BaseModel):
         if not feature:
             feature = product
         current_feature_item = _filter_current_feature(parsed["total"], feature)
-        feature_booked_licenses = _filter_used_features(parsed["used"], feature)
+        feature_booked_licenses = _filter_used_features(parsed["uses"], feature)
         used_licenses = _cleanup_features(feature_booked_licenses)
         return cls(
             tool_name=tool_name,

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -71,7 +71,7 @@ def _filter_used_features(parsed_list, feature):
         if feature_booked["feature"].count("_") == 0:
             if feature_booked["feature"] == feature:
                 used_licenses.append(feature_booked)
-        elif "".join(feature_booked["feature"].split(_)[1:]) == feature:
+        elif "".join(feature_booked["feature"].split("_")[1:]) == feature:
             used_licenses.append(feature_booked)
     return used_licenses
 

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -28,8 +28,8 @@ def one_configuration_row():
 def one_configuration_row_rlm():
     return [
         BackendConfigurationRow(
-            product="converge_super",
-            features={"converge_super": 10},
+            product="converge",
+            features={"super": 10},
             license_servers=["rlm:127.0.0.1:2345"],
             license_server_type="rlm",
             grace_time=10000,
@@ -50,7 +50,7 @@ def license_server_features_rlm():
     """
     The license server type, product and features.
     """
-    return [{"features": ["converge_super"], "license_server_type": "rlm", "product": "converge_super"}]
+    return [{"features": ["super"], "license_server_type": "rlm", "product": "converge"}]
 
 
 @fixture
@@ -248,7 +248,7 @@ async def test_report_rlm(
     reconcile_list = await tokenstat.report()
     assert reconcile_list == [
         {
-            "product_feature": "converge_super",
+            "product_feature": "converge.super",
             "used": 93,
             "total": 1000,
             "used_licenses": [
@@ -256,19 +256,16 @@ async def test_report_rlm(
                     "user_name": "jbemfv",
                     "lead_host": "myserver.example.com",
                     "booked": 29,
-                    "feature": "converge_super",
                 },
                 {
                     "user_name": "cdxfdn",
                     "lead_host": "myserver.example.com",
                     "booked": 27,
-                    "feature": "converge_super",
                 },
                 {
                     "user_name": "jbemfv",
                     "lead_host": "myserver.example.com",
                     "booked": 37,
-                    "feature": "converge_super",
                 },
             ],
         },

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -259,7 +259,7 @@ async def test_report(
                     "total": 1000,
                     "used_licenses": [],
                 },
-            ]
+            ],
         ),
     ],
 )

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -220,6 +220,49 @@ async def test_report(
 
 
 @mark.asyncio
+@mark.parametrize(
+    "output,reconciliation",
+    [
+        (
+            "rlm_output",
+            [
+                {
+                    "product_feature": "converge.super",
+                    "used": 93,
+                    "total": 1000,
+                    "used_licenses": [
+                        {
+                            "user_name": "jbemfv",
+                            "lead_host": "myserver.example.com",
+                            "booked": 29,
+                        },
+                        {
+                            "user_name": "cdxfdn",
+                            "lead_host": "myserver.example.com",
+                            "booked": 27,
+                        },
+                        {
+                            "user_name": "jbemfv",
+                            "lead_host": "myserver.example.com",
+                            "booked": 37,
+                        },
+                    ],
+                },
+            ],
+        ),
+        (
+            "rlm_output_no_licenses",
+            [
+                {
+                    "product_feature": "converge.super",
+                    "used": 0,
+                    "total": 1000,
+                    "used_licenses": [],
+                },
+            ]
+        ),
+    ],
+)
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 @mock.patch("lm_agent.tokenstat.asyncio.create_subprocess_shell")
 @mock.patch("lm_agent.tokenstat.asyncio.wait_for")
@@ -229,9 +272,11 @@ async def test_report_rlm(
     wait_for_mock: mock.AsyncMock,
     create_subprocess_mock: mock.AsyncMock,
     get_config_from_backend_mock: mock.MagicMock,
+    output,
+    reconciliation,
     tool_opts_rlm: tokenstat.ToolOptions,
     one_configuration_row_rlm,
-    rlm_output,
+    request,
 ):
     """
     Do I collect the requested structured data from running all these dang tools?
@@ -241,32 +286,11 @@ async def test_report_rlm(
     create_subprocess_mock.return_value = proc_mock
     get_config_from_backend_mock.return_value = one_configuration_row_rlm
     tools_mock.tools = {"rlm": tool_opts_rlm}
+    output = request.getfixturevalue(output)
+
     wait_for_mock.return_value = (
-        bytes(rlm_output, encoding="UTF8"),
+        bytes(output, encoding="UTF8"),
         None,
     )
     reconcile_list = await tokenstat.report()
-    assert reconcile_list == [
-        {
-            "product_feature": "converge.super",
-            "used": 93,
-            "total": 1000,
-            "used_licenses": [
-                {
-                    "user_name": "jbemfv",
-                    "lead_host": "myserver.example.com",
-                    "booked": 29,
-                },
-                {
-                    "user_name": "cdxfdn",
-                    "lead_host": "myserver.example.com",
-                    "booked": 27,
-                },
-                {
-                    "user_name": "jbemfv",
-                    "lead_host": "myserver.example.com",
-                    "booked": 37,
-                },
-            ],
-        },
-    ]
+    assert reconcile_list == reconciliation

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -294,3 +294,26 @@ async def test_report_rlm(
     )
     reconcile_list = await tokenstat.report()
     assert reconcile_list == reconciliation
+
+
+@mark.asyncio
+@mock.patch("lm_agent.tokenstat.get_config_from_backend")
+@mock.patch("lm_agent.tokenstat.asyncio.create_subprocess_shell")
+@mock.patch("lm_agent.tokenstat.ToolOptionsCollection")
+async def test_report_rlm_empty_backend(
+    tools_mock: mock.MagicMock,
+    create_subprocess_mock: mock.AsyncMock,
+    get_config_from_backend_mock: mock.MagicMock,
+    tool_opts_rlm: tokenstat.ToolOptions,
+):
+    """
+    Do I collect the requested structured data when the backend is empty?
+    """
+    proc_mock = mock.MagicMock()
+    proc_mock.returncode = 0
+    create_subprocess_mock.return_value = proc_mock
+    get_config_from_backend_mock.return_value = []
+    tools_mock.tools = {"rlm": tool_opts_rlm}
+
+    reconcile_list = await tokenstat.report()
+    assert reconcile_list == []


### PR DESCRIPTION
#### What
Change the designation of product and feature to use `.` instead of `_`as separator.

#### Why
To keep the same nomenclature across different license servers, such as flexlm.

`Task`: https://app.clickup.com/t/18022949/LM-148