### PR TITLE
Check which configs apply for the cluster

### DIFF
--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -215,7 +215,7 @@ def get_all_product_features_from_cluster(show_lic_output) -> typing.List:
     """
     Returns a list of all product.feature in the cluster
     """
-    PRODUCT_FEATURE = "LicenseName=(?P<product>[a-zA-Z0-9]+)[_\-.](?P<feature>\w+)"
+    PRODUCT_FEATURE = r"LicenseName=(?P<product>[a-zA-Z0-9]+)[_\-.](?P<feature>\w+)"
     RX_PRODUCT_FEATURE = re.compile(PRODUCT_FEATURE)
 
     parsed_features = []

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -215,12 +215,12 @@ def get_all_product_features_from_cluster(show_lic_output) -> typing.List:
     """
     Returns a list of all product.feature in the cluster
     """
-    PRODUCT_FEATURE = "LicenseName=(?P<product>[a-zA-Z]+)[_\-.](?P<feature>\w+)"
+    PRODUCT_FEATURE = "LicenseName=(?P<product>[a-zA-Z0-9]+)[_\-.](?P<feature>\w+)"
     RX_PRODUCT_FEATURE = re.compile(PRODUCT_FEATURE)
 
     parsed_features = []
-    breakpoint()  # is broken here
-    for line in show_lic_output:
+    output = show_lic_output.split("\n")
+    for line in output:
         parsed_line = RX_PRODUCT_FEATURE.match(line)
         if parsed_line:
             parsed_data = parsed_line.groupdict()
@@ -235,7 +235,7 @@ def filter_entries_from_backend(entries, my_features):
     """
     Returns a list entries from the backend that match the features on the cluster
     """
-    filtered_entries = {}
+    filtered_entries = []
 
     for entry in entries:
         for feature in entry.features.keys():

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -233,7 +233,7 @@ def get_all_product_features_from_cluster(show_lic_output: str) -> typing.List[s
 
 def get_local_license_configurations(
     license_configurations: typing.List[BackendConfigurationRow], local_licenses: typing.List[str]
-):
+) -> typing.List[BackendConfigurationRow]:
     """
     Return the license configurations from the backend that are configured on the cluster.
     """

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -211,7 +211,7 @@ async def attempt_tool_checks(
         return lri
 
 
-def get_all_product_features_from_cluster(show_lic_output):
+def get_all_product_features_from_cluster(show_lic_output) -> typing.List:
     """
     Returns a list of all product.feature in the cluster
     """
@@ -219,7 +219,7 @@ def get_all_product_features_from_cluster(show_lic_output):
     RX_PRODUCT_FEATURE = re.compile(PRODUCT_FEATURE)
 
     parsed_features = []
-
+    breakpoint()  # is broken here
     for line in show_lic_output:
         parsed_line = RX_PRODUCT_FEATURE.match(line)
         if parsed_line:

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -39,8 +39,7 @@ def one_configuration_row_rlm():
 
 @fixture
 def scontrol_show_lic_output():
-    return
-    """
+    return """
 LicenseName=testproduct1.feature1@nashlic
     Total=10 Used=0 Free=10 Reserved=0 Remote=yes
     """
@@ -181,7 +180,9 @@ async def test_attempt_tool_checks(
 
 @mark.asyncio
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
+@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
 async def test_report(
+    show_lic_mock,
     get_config_from_backend_mock: mock.MagicMock,
     tool_opts: tokenstat.ToolOptions,
     one_configuration_row,
@@ -191,9 +192,9 @@ async def test_report(
     Do I collect the requested structured data from running all these dang tools?
     """
     get_config_from_backend_mock.return_value = one_configuration_row
+    show_lic_mock.return_value = scontrol_show_lic_output
     # Patch the objects needed to generate a report.
     p0 = patch.object(cmd_utils, "get_tokens_for_license", 0)
-    p1 = patch.object(cmd_utils, "scontrol_show_lic", scontrol_show_lic_output)
     p2 = patch.dict(tokenstat.ToolOptionsCollection.tools, {"flexlm": tool_opts})
     license_report_item = {
         "product_feature": "testproduct1.TESTFEATURE",
@@ -226,7 +227,7 @@ async def test_report(
             {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 37},
         ],
     }
-    with p0, p1, p2:
+    with p0, p2:
         assert [license_report_item] == await tokenstat.report()
 
 

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from textwrap import dedent
+from typing import List
 from unittest import mock
 from unittest.mock import patch
 
@@ -348,3 +350,33 @@ async def test_report_rlm_empty_backend(
 
     reconcile_list = await tokenstat.report()
     assert reconcile_list == []
+
+
+@mark.parametrize(
+    "show_lic_output,features_from_cluster",
+    [
+        (
+            dedent(
+                """
+                LicenseName=testproduct1.feature1@flexlm
+                    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+                """
+            ),
+            ["testproduct1.feature1"],
+        ),
+        (
+            dedent(
+                """
+                LicenseName=converge_super@rlm
+                    Total=9 Used=0 Free=9 Reserved=0 Remote=yes
+                LicenseName=converge_tecplot@rlm
+                    Total=45 Used=0 Free=45 Reserved=0 Remote=yes
+                """
+            ),
+            ["converge.super", "converge.tecplot"],
+        ),
+        ("", []),
+    ],
+)
+def test_get_product_features_from_cluster(show_lic_output: str, features_from_cluster: List[str]):
+    assert features_from_cluster == tokenstat.get_all_product_features_from_cluster(show_lic_output)

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -182,7 +182,7 @@ async def test_attempt_tool_checks(
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 @mock.patch("lm_agent.tokenstat.scontrol_show_lic")
 async def test_report(
-    show_lic_mock,
+    show_lic_mock: mock.MagicMock,
     get_config_from_backend_mock: mock.MagicMock,
     tool_opts: tokenstat.ToolOptions,
     one_configuration_row,
@@ -193,9 +193,10 @@ async def test_report(
     """
     get_config_from_backend_mock.return_value = one_configuration_row
     show_lic_mock.return_value = scontrol_show_lic_output
+
     # Patch the objects needed to generate a report.
     p0 = patch.object(cmd_utils, "get_tokens_for_license", 0)
-    p2 = patch.dict(tokenstat.ToolOptionsCollection.tools, {"flexlm": tool_opts})
+    p1 = patch.dict(tokenstat.ToolOptionsCollection.tools, {"flexlm": tool_opts})
     license_report_item = {
         "product_feature": "testproduct1.TESTFEATURE",
         "used": 502,
@@ -227,7 +228,7 @@ async def test_report(
             {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 37},
         ],
     }
-    with p0, p2:
+    with p0, p1:
         assert [license_report_item] == await tokenstat.report()
 
 

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -46,6 +46,16 @@ LicenseName=testproduct1.feature1@nashlic
 
 
 @fixture
+def scontrol_show_lic_output_rlm():
+    return """
+LicenseName=converge.super@nashlic
+    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+    """
+
+
+
+
+@fixture
 def license_server_features():
     """
     The license server type, product and features.
@@ -276,6 +286,7 @@ async def test_report(
         ),
     ],
 )
+@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 @mock.patch("lm_agent.tokenstat.asyncio.create_subprocess_shell")
 @mock.patch("lm_agent.tokenstat.asyncio.wait_for")
@@ -285,10 +296,12 @@ async def test_report_rlm(
     wait_for_mock: mock.AsyncMock,
     create_subprocess_mock: mock.AsyncMock,
     get_config_from_backend_mock: mock.MagicMock,
+    show_lic_mock: mock.MagicMock,
     output,
     reconciliation,
     tool_opts_rlm: tokenstat.ToolOptions,
     one_configuration_row_rlm,
+    scontrol_show_lic_output_rlm,
     request,
 ):
     """
@@ -298,6 +311,8 @@ async def test_report_rlm(
     proc_mock.returncode = 0
     create_subprocess_mock.return_value = proc_mock
     get_config_from_backend_mock.return_value = one_configuration_row_rlm
+    show_lic_mock.return_value = scontrol_show_lic_output_rlm
+
     tools_mock.tools = {"rlm": tool_opts_rlm}
     output = request.getfixturevalue(output)
 
@@ -310,6 +325,7 @@ async def test_report_rlm(
 
 
 @mark.asyncio
+@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 @mock.patch("lm_agent.tokenstat.asyncio.create_subprocess_shell")
 @mock.patch("lm_agent.tokenstat.ToolOptionsCollection")
@@ -317,7 +333,9 @@ async def test_report_rlm_empty_backend(
     tools_mock: mock.MagicMock,
     create_subprocess_mock: mock.AsyncMock,
     get_config_from_backend_mock: mock.MagicMock,
+    show_lic_mock: mock.MagicMock,
     tool_opts_rlm: tokenstat.ToolOptions,
+    scontrol_show_lic_output_rlm,
 ):
     """
     Do I collect the requested structured data when the backend is empty?
@@ -326,6 +344,8 @@ async def test_report_rlm_empty_backend(
     proc_mock.returncode = 0
     create_subprocess_mock.return_value = proc_mock
     get_config_from_backend_mock.return_value = []
+    show_lic_mock.return_value = scontrol_show_lic_output_rlm
+
     tools_mock.tools = {"rlm": tool_opts_rlm}
 
     reconcile_list = await tokenstat.report()

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -53,8 +53,6 @@ LicenseName=converge.super@nashlic
     """
 
 
-
-
 @fixture
 def license_server_features():
     """

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -41,18 +41,22 @@ def one_configuration_row_rlm():
 
 @fixture
 def scontrol_show_lic_output():
-    return """
-LicenseName=testproduct1.feature1@flexlm
-    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
-    """
+    return dedent(
+        """
+        LicenseName=testproduct1.feature1@flexlm
+            Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+        """
+    )
 
 
 @fixture
 def scontrol_show_lic_output_rlm():
-    return """
-LicenseName=converge.super@rlm
-    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
-    """
+    return dedent(
+        """
+        LicenseName=converge.super@rlm
+            Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+        """
+    )
 
 
 @fixture

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -38,6 +38,15 @@ def one_configuration_row_rlm():
 
 
 @fixture
+def scontrol_show_lic_output():
+    return
+    """
+LicenseName=testproduct1.feature1@nashlic
+    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+    """
+
+
+@fixture
 def license_server_features():
     """
     The license server type, product and features.
@@ -176,6 +185,7 @@ async def test_report(
     get_config_from_backend_mock: mock.MagicMock,
     tool_opts: tokenstat.ToolOptions,
     one_configuration_row,
+    scontrol_show_lic_output,
 ):
     """
     Do I collect the requested structured data from running all these dang tools?
@@ -183,7 +193,8 @@ async def test_report(
     get_config_from_backend_mock.return_value = one_configuration_row
     # Patch the objects needed to generate a report.
     p0 = patch.object(cmd_utils, "get_tokens_for_license", 0)
-    p1 = patch.dict(tokenstat.ToolOptionsCollection.tools, {"flexlm": tool_opts})
+    p1 = patch.object(cmd_utils, "scontrol_show_lic", scontrol_show_lic_output)
+    p2 = patch.dict(tokenstat.ToolOptionsCollection.tools, {"flexlm": tool_opts})
     license_report_item = {
         "product_feature": "testproduct1.TESTFEATURE",
         "used": 502,
@@ -215,7 +226,7 @@ async def test_report(
             {"user_name": "jbemfv", "lead_host": "myserver.example.com", "booked": 37},
         ],
     }
-    with p0, p1:
+    with p0, p1, p2:
         assert [license_report_item] == await tokenstat.report()
 
 

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -384,3 +384,28 @@ async def test_report_rlm_empty_backend(
 )
 def test_get_product_features_from_cluster(show_lic_output: str, features_from_cluster: List[str]):
     assert features_from_cluster == tokenstat.get_all_product_features_from_cluster(show_lic_output)
+
+
+def test_get_local_license_configurations():
+    configuration_super = BackendConfigurationRow(
+        product="converge",
+        features={"super": 10},
+        license_servers=["rlm:127.0.0.1:2345"],
+        license_server_type="rlm",
+        grace_time=10000,
+    )
+
+    configuration_polygonica = BackendConfigurationRow(
+        product="converge",
+        features={"polygonica": 10},
+        license_servers=["rlm:127.0.0.1:2345"],
+        license_server_type="rlm",
+        grace_time=10000,
+    )
+
+    license_configurations = [configuration_super, configuration_polygonica]
+    local_licenses = ["converge.super"]
+
+    assert tokenstat.get_local_license_configurations(license_configurations, local_licenses) == [
+        configuration_super
+    ]

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -40,7 +40,7 @@ def one_configuration_row_rlm():
 @fixture
 def scontrol_show_lic_output():
     return """
-LicenseName=testproduct1.feature1@nashlic
+LicenseName=testproduct1.feature1@flexlm
     Total=10 Used=0 Free=10 Reserved=0 Remote=yes
     """
 
@@ -48,7 +48,7 @@ LicenseName=testproduct1.feature1@nashlic
 @fixture
 def scontrol_show_lic_output_rlm():
     return """
-LicenseName=converge.super@nashlic
+LicenseName=converge.super@rlm
     Total=10 Used=0 Free=10 Reserved=0 Remote=yes
     """
 


### PR DESCRIPTION
#### What
Filter the backend configuration entries before reconciliation by checking which licenses are on the cluster.

#### Why
We were using all the configuration entries in the backend to check the licenses, so if a cluster didn't have them, it would crash. To prevent this, we are filtering the backend configs to check only those that are in the cluster. For this we're using the `scontrol show lic` command to get the cluster's licenses and parsing the output to use as a filter before reconciliation.

`Task`: https://app.clickup.com/t/18022949/LM-139