### PR TITLE
Fix regex and database URL default value

### DIFF
--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -215,7 +215,7 @@ def get_all_product_features_from_cluster(show_lic_output: str) -> typing.List[s
     """
     Returns a list of all product.feature in the cluster
     """
-    PRODUCT_FEATURE = r"LicenseName=(?P<product>[a-zA-Z0-9]+)[_\-.](?P<feature>\w+)"
+    PRODUCT_FEATURE = r"LicenseName=(?P<product>[a-zA-Z0-9_]+)[_\-.](?P<feature>\w+)"
     RX_PRODUCT_FEATURE = re.compile(PRODUCT_FEATURE)
 
     parsed_features = []

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.1.0-dev1"
+version = "2.1.0-dev2"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -371,6 +371,15 @@ async def test_report_rlm_empty_backend(
         (
             dedent(
                 """
+                LicenseName=product_name.feature_name@flexlm
+                    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+                """
+            ),
+            ["product_name.feature_name"],
+        ),
+        (
+            dedent(
+                """
                 LicenseName=converge_super@rlm
                     Total=9 Used=0 Free=9 Reserved=0 Remote=yes
                 LicenseName=converge_tecplot@rlm

--- a/backend/lm_backend/config.py
+++ b/backend/lm_backend/config.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseSettings, Field
+from pydantic import BaseSettings
 
 
 class LogLevelEnum(str, Enum):

--- a/backend/lm_backend/config.py
+++ b/backend/lm_backend/config.py
@@ -32,9 +32,7 @@ class Settings(BaseSettings):
     ALLOW_ORIGINS_REGEX: str = r"https://.*\.omnivector\.solutions"
 
     # database to connect
-    DATABASE_URL: str = Field(
-        "sqlite:///./sqlite.db?check_same_thread=true", regex=r"^(sqlite|postgresql|postgres)://.+$"
-    )
+    DATABASE_URL: str
 
     # log level (everything except sql tracing)
     LOG_LEVEL: LogLevelEnum = LogLevelEnum.INFO


### PR DESCRIPTION
#### What
Fix the regex for parsing product and features from cluster.
Also fix database default URL and bump lm-agent version.

#### Why
The regex was not parsing correctly the features from the cluster.
The default value was causing the project to use a sqlite database instead of the postgres defined in the docker-compose.