### PR TITLE
(backend) Mount main app as a subapp

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
 * Added ``config`` table and ``config`` endpoints in backend
 * Parse job run-time through squeue and corrected time parsing logic
 * Added docstrings throughout codebase
+* Changed backend URL prefix
 
 1.0.0 -- 2021-06-03
 -------------------

--- a/agent/bin/lmconfigure.py
+++ b/agent/bin/lmconfigure.py
@@ -20,7 +20,7 @@ def get_all():
     Get all configurations from the backend.
     """
     resp = requests.get(
-        f"{SETTINGS.BACKEND_BASE_URL}/api/v1/config/all",
+        f"{SETTINGS.BACKEND_BASE_URL}/lm/api/v1/config/all",
         headers=LM2_AGENT_HEADERS,
     )
     if resp.status_code == 200:
@@ -38,7 +38,7 @@ def get(id: int):
     Return a single configuration from the backend given a configuration id.
     """
     resp = requests.get(
-        f"{SETTINGS.BACKEND_BASE_URL}/api/v1/config/{id}",
+        f"{SETTINGS.BACKEND_BASE_URL}/lm/api/v1/config/{id}",
         headers=LM2_AGENT_HEADERS,
     )
     if resp.status_code == 200:
@@ -62,7 +62,7 @@ def add(
     Add a configuration to the database.
     """
     resp = requests.post(
-        f"{SETTINGS.BACKEND_BASE_URL}/api/v1/config/",
+        f"{SETTINGS.BACKEND_BASE_URL}/lm/api/v1/config/",
         headers=LM2_AGENT_HEADERS,
         json={
             "product": product,
@@ -107,7 +107,7 @@ def update(
         ctxt['grace_time'] = int(grace_time)
 
     resp = requests.put(
-        f"{SETTINGS.BACKEND_BASE_URL}/api/v1/config/{id}",
+        f"{SETTINGS.BACKEND_BASE_URL}/lm/api/v1/config/{id}",
         headers=LM2_AGENT_HEADERS,
         json=ctxt
     )
@@ -126,7 +126,7 @@ def delete(id: int):
         typer.echo("Please supply an ID")
         return
     resp = requests.delete(
-        f"{SETTINGS.BACKEND_BASE_URL}/api/v1/config/{id}",
+        f"{SETTINGS.BACKEND_BASE_URL}/lm/api/v1/config/{id}",
         headers=LM2_AGENT_HEADERS,
         data={'id': id}
     )

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ValidationError
 from lm_agent.forward import async_client
 from lm_agent.logs import logger
 
-GET_CONFIG_URL_PATH = "/api/v1/config/all"
+GET_CONFIG_URL_PATH = "/lm/api/v1/config/all"
 
 
 class LicenseManagerBackendConnectionError(Exception):
@@ -72,9 +72,9 @@ async def get_bookings_from_backend(cluster_name: Optional[str] = None) -> List[
     bookings: List = []
     try:
         if cluster_name:
-            resp = await client.get(f"/api/v1/booking/all?cluster_name={cluster_name}")
+            resp = await client.get(f"/lm/api/v1/booking/all?cluster_name={cluster_name}")
         else:
-            resp = await client.get("/api/v1/booking/all")
+            resp = await client.get("/lm/api/v1/booking/all")
     except ConnectError as e:
         logger.error(f"Connection failed to backend: {e}")
         return bookings
@@ -88,7 +88,7 @@ async def get_bookings_from_backend(cluster_name: Optional[str] = None) -> List[
 
 async def get_config_id_from_backend(product_feature: str) -> int:
     """Given the product_feature return return the config id."""
-    path = "/api/v1/config/"
+    path = "/lm/api/v1/config/"
     resp = await async_client().get(path, params={"product_feature": product_feature})
     return resp.json()
 

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -24,14 +24,14 @@ from lm_agent.workload_managers.slurm.cmd_utils import (
     squeue_parser,
 )
 
-RECONCILE_URL_PATH = "/api/v1/license/reconcile"
+RECONCILE_URL_PATH = "/lm/api/v1/license/reconcile"
 
 
 async def remove_booked_for_job_id(job_id: str):
     """
-    Send DELETE to /api/v1/booking/book/{job_id}.
+    Send DELETE to /lm/api/v1/booking/book/{job_id}.
     """
-    response = await async_client().delete(f"/api/v1/booking/book/{job_id}")
+    response = await async_client().delete(f"/lm/api/v1/booking/book/{job_id}")
     if response.status_code != 200:
         logger.error(f"{job_id} could not be deleted.")
         logger.debug(f"response from delete: {response.__dict__}")
@@ -39,9 +39,9 @@ async def remove_booked_for_job_id(job_id: str):
 
 async def get_all_grace_times() -> Dict[int, int]:
     """
-    Send GET to /api/v1/config/all.
+    Send GET to /lm/api/v1/config/all.
     """
-    response = await async_client().get("/api/v1/config/all")
+    response = await async_client().get("/lm/api/v1/config/all")
     configs = response.json()
     grace_times = {config["id"]: config["grace_time"] for config in configs}
     return grace_times
@@ -51,7 +51,7 @@ async def get_booked_for_job_id(job_id: str) -> Dict:
     """
     Return the booking row for the given job_id.
     """
-    response = await async_client().get(f"/api/v1/booking/job/{job_id}")
+    response = await async_client().get(f"/lm/api/v1/booking/job/{job_id}")
     return response.json()
 
 
@@ -132,7 +132,7 @@ async def reconcile():
     """Generate the report and reconcile the license feature token usage."""
     await clean_booked_grace_time()
     r = await update_report()
-    response = await async_client().get("/api/v1/license/cluster_update")
+    response = await async_client().get("/lm/api/v1/license/cluster_update")
     configs = await get_config_from_backend()
     licenses_to_update = response.json()
     for license_data in licenses_to_update:

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -120,7 +120,7 @@ async def make_booking_request(lbr: LicenseBookingRequest) -> bool:
     logger.debug(f"lbr: {lbr}")
 
     resp = await async_client().put(
-        "/api/v1/booking/book",
+        "/lm/api/v1/booking/book",
         json={
             "job_id": lbr.job_id,
             "features": features,

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -36,7 +36,7 @@ async def test_get_config_from_backend__omits_invalid_config_rows(
     caplog,
 ):
     with respx.mock:
-        respx.get("http://backend/api/v1/config/all").mock(
+        respx.get("http://backend/lm/api/v1/config/all").mock(
             return_value=Response(
                 200,
                 json=[
@@ -71,7 +71,7 @@ async def test_get_config_from_backend__returns_empty_list_on_connect_error(
     caplog,
 ):
     with respx.mock:
-        respx.get("http://backend/api/v1/config/all").mock(
+        respx.get("http://backend/lm/api/v1/config/all").mock(
             side_effect=ConnectError("BOOM"),
         )
         configs = await get_config_from_backend()

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -148,7 +148,7 @@ async def test_get_all_grace_times(respx_mock):
     """
     Check the return value for the get_all_grace_times.
     """
-    respx_mock.get("/api/v1/config/all").mock(
+    respx_mock.get("/lm/api/v1/config/all").mock(
         return_value=Response(
             status_code=200,
             json=[
@@ -180,16 +180,16 @@ async def test_reconcile(clean_booked_grace_time_mock, report_mock, respx_mock):
     """
     Check if reconcile does a patch to /license/reconcile and await for clean_booked_grace_time.
     """
-    respx_mock.patch("/api/v1/license/reconcile").mock(
+    respx_mock.patch("/lm/api/v1/license/reconcile").mock(
         return_value=Response(
             status_code=200,
         )
     )
-    respx_mock.get("/api/v1/config/all").mock(return_value=Response(status_code=200, json={}))
-    respx_mock.get("/api/v1/config/?product_feature=product.feature").mock(
+    respx_mock.get("/lm/api/v1/config/all").mock(return_value=Response(status_code=200, json={}))
+    respx_mock.get("/lm/api/v1/config/?product_feature=product.feature").mock(
         return_value=Response(status_code=200, json={})
     )
-    respx_mock.get("/api/v1/license/cluster_update").mock(
+    respx_mock.get("/lm/api/v1/license/cluster_update").mock(
         return_value=Response(
             status_code=200,
             json=[
@@ -215,7 +215,7 @@ async def test_reconcile_patch_failed(clean_booked_grace_time_mock, report_mock,
     """
     Check that when patch to /license/reconcile response status_code is not 200, should raise exception.
     """
-    respx_mock.patch("/api/v1/license/reconcile").mock(
+    respx_mock.patch("/lm/api/v1/license/reconcile").mock(
         return_value=Response(
             status_code=400,
         )

--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -11,6 +11,8 @@ Unreleased
 * Added ``config`` table and ``config`` endpoints in backend
 * Parse job run-time through squeue and corrected time parsing logic
 * Added docstrings throughout codebase
+* Changed backend structure: the previously app is now mounted as a subapp
+* Removed unnecessary unit tests from the backend and refactored some from both backend and agent
 
 1.0.0 -- 2021-06-03
 -------------------

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -456,17 +456,6 @@ babel = ["babel"]
 lingua = ["lingua"]
 
 [[package]]
-name = "mangum"
-version = "0.12.2"
-description = "AWS Lambda & API Gateway support for ASGI"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = "*"
-
-[[package]]
 name = "markupsafe"
 version = "2.0.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1034,7 +1023,7 @@ dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.9"
-content-hash = "5f5c11cc4b20d6fd363abec702fd27082ea92a9597a1ca5cf34385af9d1a21bc"
+content-hash = "57216ad18e42cf3a234adac5a0e76ed834d47eeccffa46280f0554c994b738df"
 
 [metadata.files]
 aiosqlite = [
@@ -1297,16 +1286,15 @@ mako = [
     {file = "Mako-1.1.4-py2.py3-none-any.whl", hash = "sha256:aea166356da44b9b830c8023cd9b557fa856bd8b4035d6de771ca027dfc5cc6e"},
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
 ]
-mangum = [
-    {file = "mangum-0.12.2-py3-none-any.whl", hash = "sha256:eb7cb2cf0c06b537aee8ac39993771d0bf8aa86ba1b0a2173e4037aa58e5c35f"},
-    {file = "mangum-0.12.2.tar.gz", hash = "sha256:f49a3b56daffe776b0325734ff2afcb0f87f8f9d7eb3f1364ca50f600be52092"},
-]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1318,6 +1306,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1329,6 +1320,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1341,6 +1335,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1353,6 +1350,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,6 @@ SQLAlchemy = "1.3.23"
 jwt = {version = "^1.2.0", optional = true}
 databases = {extras = ["postgresql"], version = "^0.4.3"}
 SQLAlchemy-Utils = "^0.37.8"
-mangum = "^0.12.1"
 loguru = "^0.5.3"
 asyncpg = "^0.24.0"
 aws-psycopg2 = "^1.2.1"

--- a/backend/tests/api/test_booking.py
+++ b/backend/tests/api/test_booking.py
@@ -25,7 +25,7 @@ async def test_get_bookings_job(
     await insert_objects(some_licenses, table_schemas.license_table)
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
-    resp = await backend_client.get("/api/v1/booking/job/coolbeans")
+    resp = await backend_client.get("/lm/api/v1/booking/job/coolbeans")
     assert resp.status_code == 200
     assert resp.json() == [
         dict(
@@ -67,7 +67,7 @@ async def test_get_bookings_for_cluster_name(
         config_id=2,
     )
     await insert_objects([booking], table_schemas.booking_table)
-    resp = await backend_client.get("/api/v1/booking/all?cluster_name=cluster2")
+    resp = await backend_client.get("/lm/api/v1/booking/all?cluster_name=cluster2")
     assert resp.status_code == 200
     assert resp.json() == [
         dict(
@@ -110,7 +110,7 @@ async def test_bookings_all(
     await insert_objects(some_licenses, table_schemas.license_table)
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
-    resp = await backend_client.get("/api/v1/booking/all")
+    resp = await backend_client.get("/lm/api/v1/booking/all")
     assert resp.status_code == 200
     assert resp.json() == [
         dict(
@@ -156,7 +156,7 @@ async def test_booking_create(backend_client, some_config_rows, some_licenses, i
     booking = Booking(
         job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
     )
-    resp = await backend_client.put("/api/v1/booking/book", json=booking.dict())
+    resp = await backend_client.put("/lm/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_200_OK
 
@@ -175,7 +175,7 @@ async def test_booking_create_negative_booked_error(
     booking = Booking(
         job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
     )
-    resp = await backend_client.put("/api/v1/booking/book", json=booking.dict())
+    resp = await backend_client.put("/lm/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -198,7 +198,7 @@ async def test_booking_create_booked_greater_than_total(
     booking = Booking(
         job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
     )
-    resp = await backend_client.put("/api/v1/booking/book", json=booking.dict())
+    resp = await backend_client.put("/lm/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert "not enough" in resp.json()["detail"]
@@ -220,7 +220,7 @@ async def test_booking_delete(
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
 
-    resp = await backend_client.delete("/api/v1/booking/book/helloworld")
+    resp = await backend_client.delete("/lm/api/v1/booking/book/helloworld")
     assert resp.status_code == status.HTTP_200_OK
 
 

--- a/backend/tests/api/test_config.py
+++ b/backend/tests/api/test_config.py
@@ -120,7 +120,7 @@ async def test_get_all_configurations(
     Test fetching all configuration rows in the db.
     """
     await insert_objects(some_configuration_rows, table_schemas.config_table)
-    resp = await backend_client.get("/api/v1/config/all")
+    resp = await backend_client.get("/lm/api/v1/config/all")
     assert resp.status_code == 200
     assert resp.json() == [ConfigurationItem.parse_obj(x) for x in some_configuration_items]
 
@@ -138,7 +138,7 @@ async def test_get_configuration(
     """
 
     await insert_objects(one_configuration_row, table_schemas.config_table)
-    resp = await backend_client.get("/api/v1/config/100")
+    resp = await backend_client.get("/lm/api/v1/config/100")
     assert resp.status_code == 200
     assert resp.json() == ConfigurationItem.parse_obj(one_configuration_item[0])
 
@@ -157,7 +157,7 @@ async def test_add_configuration(backend_client: AsyncClient):
         "grace_time": "10000",
     }
 
-    response = await backend_client.post("/api/v1/config", json=data)
+    response = await backend_client.post("/lm/api/v1/config", json=data)
     assert response.status_code == 200
 
 
@@ -180,7 +180,7 @@ async def test_update_configuration(
         "license_server_type": "servertype100",
         "grace_time": "10000",
     }
-    resp = await backend_client.put("/api/v1/config/100", json=data)
+    resp = await backend_client.put("/lm/api/v1/config/100", json=data)
     assert resp.status_code == 200
 
 
@@ -198,7 +198,7 @@ async def test_update_nonexistant_configuration(backend_client: AsyncClient):
         "license_server_type": "servertype100",
         "grace_time": "10000",
     }
-    resp = await backend_client.put("/api/v1/config/100000", json=data)
+    resp = await backend_client.put("/lm/api/v1/config/100000", json=data)
     assert resp.status_code == 200
 
 
@@ -210,7 +210,7 @@ async def test_delete_configuration(backend_client: AsyncClient, one_configurati
     """
 
     await insert_objects(one_configuration_row, table_schemas.config_table)
-    resp = await backend_client.delete("/api/v1/config/100")
+    resp = await backend_client.delete("/lm/api/v1/config/100")
     assert resp.status_code == 200
     assert resp.json()["message"] == "Deleted 100 from the configuration table."
 
@@ -225,5 +225,5 @@ async def test_delete_nonexistant__configuration(
     """
 
     await insert_objects(one_configuration_row, table_schemas.config_table)
-    resp = await backend_client.delete("/api/v1/config/99999999")
+    resp = await backend_client.delete("/lm/api/v1/config/99999999")
     assert resp.status_code == 404

--- a/backend/tests/api/test_init.py
+++ b/backend/tests/api/test_init.py
@@ -18,7 +18,7 @@ async def test_reconcile_reset(backend_client: AsyncClient, some_licenses, inser
     assert count[0][0] == 3
 
     with patch("lm_backend.debug.settings.DEBUG", True):
-        resp = await backend_client.put("/api/v1/reset", headers={"X-Reset": "please"})
+        resp = await backend_client.put("/lm/api/v1/reset", headers={"X-Reset": "please"})
     assert resp.status_code == 200
 
     count = await database.fetch_all("SELECT COUNT(*) FROM license")

--- a/backend/tests/api/test_license.py
+++ b/backend/tests/api/test_license.py
@@ -73,7 +73,7 @@ async def test_licenses_product(backend_client: AsyncClient, some_licenses, inse
     Do I fetch and order the licenses in the db?
     """
     await insert_objects(some_licenses, license_table)
-    resp = await backend_client.get("/api/v1/license/use/hello")
+    resp = await backend_client.get("/lm/api/v1/license/use/hello")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
         dict(
@@ -93,7 +93,7 @@ async def test_licenses_product_feature(backend_client: AsyncClient, some_licens
     Do I fetch and order the licenses in the db?
     """
     await insert_objects(some_licenses, license_table)
-    resp = await backend_client.get("/api/v1/license/use/cool/beans")
+    resp = await backend_client.get("/lm/api/v1/license/use/cool/beans")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
         dict(
@@ -112,7 +112,7 @@ async def test_licenses_all(backend_client: AsyncClient, some_licenses, insert_o
     Do I fetch and order the licenses in the db?
     """
     await insert_objects(some_licenses, license_table)
-    resp = await backend_client.get("/api/v1/license/all")
+    resp = await backend_client.get("/lm/api/v1/license/all")
     assert resp.status_code == 200
     assert resp.json() == [
         dict(product_feature="cool.beans", total=11, used=11, available=0),
@@ -229,7 +229,7 @@ async def test_reconcile_changes_clean_up_in_use_bookings(
     )
 
     response = await backend_client.patch(
-        "/api/v1/license/reconcile", json=[license_reconcile_request.dict()]
+        "/lm/api/v1/license/reconcile", json=[license_reconcile_request.dict()]
     )
     assert response.status_code == status.HTTP_200_OK
 


### PR DESCRIPTION
#### What
This PR changes the app structure for the backend app. The idea is to mount the previous app as a subapp and add the `/lm` route prefix.

#### Why
This is needed to better integrate the LM backend to the Armada's k8s application.

`Task`: https://app.clickup.com/t/18022949/LM-87

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
