### PR TITLE
Fix path to /version endpoint

### DIFF
--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -22,7 +22,7 @@ class LicenseManagerBackendVersionError(Exception):
 
 async def get_license_manager_backend_version() -> str:
     """Return the license-manager-backend version."""
-    resp = await async_client().get("/version")
+    resp = await async_client().get("/lm/version")
     # Check that we have a valid response.
     if resp.status_code != 200:
         logger.error("license-manager-backend version could not be obtained.")

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.1.0-dev2"
+version = "2.1.0-dev3"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -13,7 +13,7 @@ from lm_agent.backend_utils import (
 async def test_get_license_manager_backend_version__returns_version_on_two_hundred():
     test_backend_version = "2.5.4"
     with respx.mock:
-        respx.get("http://backend/version").mock(
+        respx.get("http://backend/lm/version").mock(
             return_value=Response(
                 200,
                 json=dict(version=test_backend_version),
@@ -26,7 +26,7 @@ async def test_get_license_manager_backend_version__returns_version_on_two_hundr
 @mark.asyncio
 async def test_get_license_manager_backend_version__raises_exception_on_non_two_hundred():
     with respx.mock:
-        respx.get("http://backend/version").mock(return_value=Response(500))
+        respx.get("http://backend/lm/version").mock(return_value=Response(500))
         with raises(LicenseManagerBackendConnectionError):
             await get_license_manager_backend_version()
 


### PR DESCRIPTION
#### What
Fix path to the /version endpoint, adding the /lm prefix.

#### Why
The lm-agent was not starting because it couldn't get the backend version from the endpoint.