### PR TITLE
Add release info for lm-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ docker-compose up --build
 uvicorn licensemanager2.agent.main:app --port 8010
 ```
 
+## Release (agent)
+To make a new release of the License Manager Agent:
+
+1. Bump the version in the `pyproject.toml` file
+2. Update the CHANGELOG file, moving the changes under the Unreleased section to the new version section.
+3. Use Poetry to publish the new version to Pypicloud (the credentials can be found on `1Password`)
+```
+poetry publish --build --repository pypicloud --username <username> --password <password>
+```
+
 ## Database Migrations
 The license manager project uses alembic to manage the database and perform migrations. 
 The migrations are kept in this project in the `alembic/versions` directory, and the config file is in the root of the project, `alembic.ini`. 

--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ uvicorn licensemanager2.agent.main:app --port 8010
 ## Release (agent)
 To make a new release of the License Manager Agent:
 
-1. Bump the version in the `pyproject.toml` file
-2. Update the CHANGELOG file, moving the changes under the Unreleased section to the new version section.
+1. Bump the version in the `pyproject.toml` file.
+2. Update the `CHANGELOG` file, moving the changes under the Unreleased section to the new version section. Always keep an `Unreleased` section at the top.
+3. Create a new commit with the title `Release x.y.z`.
 3. Use Poetry to publish the new version to Pypicloud (the credentials can be found on `1Password`)
-```
+```bash
 poetry publish --build --repository pypicloud --username <username> --password <password>
 ```
 

--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,9 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+
+2.1.0.dev3 - 2021-12-01
+-----------------------
 * Added RLM parser
 * Converted agent to a CLI application (from FastAPI with internal scheduler)
 * Update booking-accounting logic to requeue jobs if there are not enough licenses


### PR DESCRIPTION
#### What
Add release information for License Manager Agent.
Also add version 2.1.0.dev3 to CHANGELOG.

#### Why
We need to document the release process for the agent.

`Task`: https://app.clickup.com/t/18022949/LM-150

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
