### PR TITLE
Get license's server type from backend config row

### DIFF
--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -140,13 +140,15 @@ async def reconcile():
         bookings_sum = license_data["bookings_sum"]
         license_total = license_data["license_total"]
         license_used = license_data["license_used"]
-        slurm_used = await get_tokens_for_license(product_feature + "@flexlm", "Used")
         config_id = await get_config_id_from_backend(product_feature)
         minimum_value = 0
+        server_type = ""
         for config in configs:
             if config.id == config_id:
                 minimum_value = config.features[product_feature.split(".")[1]]
+                server_type = config.license_server_type
                 break
+        slurm_used = await get_tokens_for_license(product_feature + "@" + server_type, "Used")
         if slurm_used is None:
             slurm_used = 0
         new_quantity = license_total - license_used - bookings_sum + slurm_used


### PR DESCRIPTION
#### What
Get the license's server type from the backend config row.

#### Why
The server type was hardcoded in the code, causing the `slurm_used` value to be None when the license was from a different server type.