### PR TITLE
Fix rlmstat command

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -19,6 +19,7 @@ Unreleased
 * Parse job run-time through squeue and corrected time parsing logic
 * Added docstrings throughout codebase
 * Changed backend URL prefix
+* Fix rlmutil command path
 
 1.0.0 -- 2021-06-03
 -------------------

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -158,8 +158,8 @@ class ToolOptionsCollection:
         ),
         "rlm": ToolOptions(
             name="rlm",
-            path=Path(f"{settings.BIN_PATH}/rlmstat"),
-            args="{exe} -c {port}@{host} -a -p",
+            path=Path(f"{settings.BIN_PATH}/rlmutil"),
+            args="{exe} rlmstat -c {port}@{host} -a -p",
             parse_fn=rlm.parse,
         ),
         # "other_tool": ToolOptions(...)


### PR DESCRIPTION
#### What
Change the args for invoking `rlmstat`. 

#### Why
The binary for RLM is actually `rlmutil`, `rlmstat` is one of the tools available.

**Obs:** http://www.reprisesoftware.com/RLM_License_Administration.pdf (page 43 describes the usage of `rlmstat`)
