### PR TITLE
remove the 'LM2_' prefix from the Settings class

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to license-manager-backend
 Unreleased
 ----------
 
+2.1.3 - 2021-12-15
+------------------
+* Removed the "LM2_" prefix from the Settings class
+
 2.1.2 - 2021-12-10
 ------------------
 * Changed the CORS policy to allow origins from everywhere

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -22,11 +22,11 @@ services:
     volumes:
       - ./lm_backend:/app/lm_backend
     environment:
-      LM2_DATABASE_URL: ${LM2_DATABASE_URL:-postgres://postgres:123@postgres-back:5432/postgres}
-      LM2_ARMASEC_DOMAIN: ${LM2_ARMASEC_DOMAIN}
-      LM2_ARMASEC_AUDIENCE: ${LM2_ARMASEC_AUDIENCE}
-      LM2_ARMASEC_DEBUG: ${LM2_ARMASEC_DEBUG}
-      LM2_LOG_LEVEL: ${LM2_LOG_LEVEL}
+      DATABASE_URL: ${DATABASE_URL:-postgres://postgres:123@postgres-back:5432/postgres}
+      ARMASEC_DOMAIN: ${ARMASEC_DOMAIN}
+      ARMASEC_AUDIENCE: ${ARMASEC_AUDIENCE}
+      ARMASEC_DEBUG: ${ARMASEC_DEBUG}
+      LOG_LEVEL: ${LOG_LEVEL}
     ports:
       - "7000:8000"
     command: uvicorn lm_backend.main:app --reload --workers 1 --host 0.0.0.0 --port 8000

--- a/backend/lm_backend/config.py
+++ b/backend/lm_backend/config.py
@@ -15,9 +15,6 @@ class LogLevelEnum(str, Enum):
 class Settings(BaseSettings):
     """
     App config.
-
-    If you are setting these in the environment, you must prefix "LM2_", e.g.
-    LM2_ASGI_ROOT_PATH=/staging
     """
 
     # debug mode turns on certain dangerous operations
@@ -43,7 +40,6 @@ class Settings(BaseSettings):
     ARMASEC_DEBUG: bool = Field(False)
 
     class Config:
-        env_prefix = "LM2_"
         env_file = ".env"
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "2.1.2"
+version = "2.1.3"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"
@@ -45,12 +45,12 @@ minversion = "6.0"
 addopts = "--random-order --cov=lm_backend --cov-report=term-missing --cov-fail-under=85"
 testpaths = ["tests"]
 env = [
-    "LM2_DATABASE_URL = sqlite:///sqlite-testing.db",
-    "LM2_LOG_LEVEL_SQL = ERROR",
+    "DATABASE_URL = sqlite:///sqlite-testing.db",
+    "LOG_LEVEL_SQL = ERROR",
 
     # This setting must align with the rs256_domain fixture from armasec's pytest extension
-    "LM2_ARMASEC_DOMAIN = armasec.dev",
-    "LM2_ARMASEC_DEBUG = True",
+    "ARMASEC_DOMAIN = armasec.dev",
+    "ARMASEC_DEBUG = True",
 ]
 
 [tool.black]


### PR DESCRIPTION
#### What
Simply as it is, this PR removes the env prefix from the Settings class for the backend. Note nothing changed in the agent. Why? Because the backend is supposed to run in a container while the agent is not supposed to always run in isolation mode.

#### Why
Needed to remove unnecessary complexity =.

`Task`: https://app.clickup.com/t/18022949/LM-165

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
