### PR TITLE
Raise clear exception when report is empty

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 * Remove lmstat binary
+* Raise exception for empty reports on reconcilitation
 
 2.1.0 - 2021-12-09
 ------------------

--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,7 +7,7 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 * Remove lmstat binary
-* Raise exception for empty reports on reconcilitation
+* Raise exception for empty reports on reconciliation
 
 2.1.0 - 2021-12-09
 ------------------

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -20,6 +20,10 @@ class LicenseManagerBackendVersionError(Exception):
     """Exception for backend/agent version mismatches."""
 
 
+class LicenseManagerEmptyReportError(Exception):
+    """Exception for empty report when no licenses added in backend"""
+
+
 async def get_license_manager_backend_version() -> str:
     """Return the license-manager-backend version."""
     resp = await async_client().get("/lm/version")

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -9,6 +9,7 @@ from httpx import ConnectError
 
 from lm_agent.backend_utils import (
     LicenseManagerBackendConnectionError,
+    LicenseManagerEmptyReportError,
     get_bookings_from_backend,
     get_config_from_backend,
     get_config_id_from_backend,
@@ -173,7 +174,7 @@ async def update_report():
             "No license data could be collected, check that tools are installed "
             "correctly and the right hosts/ports are configured in settings"
         )
-        raise LicenseManagerBackendConnectionError()
+        raise LicenseManagerEmptyReportError()
     client = async_client()
     try:
         r = await client.patch(RECONCILE_URL_PATH, json=rep)

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 from httpx import Response
 
-from lm_agent.backend_utils import LicenseManagerBackendConnectionError
+from lm_agent.backend_utils import LicenseManagerBackendConnectionError, LicenseManagerEmptyReportError
 from lm_agent.reconciliation import (
     clean_booked_grace_time,
     clean_bookings,
@@ -168,7 +168,7 @@ async def test_reconcile_report_empty(report_mock: mock.AsyncMock):
     Check the correct behavior when the report is empty in reconcile.
     """
     report_mock.return_value = []
-    with pytest.raises(LicenseManagerBackendConnectionError):
+    with pytest.raises(LicenseManagerEmptyReportError):
         await update_report()
 
 


### PR DESCRIPTION
#### What
Change the exception raised when the report is empty in reconciliation.

#### Why
The exception that was being used before is misleading, because it implies that the empty report is related to backend connection issues, when in fact it happens when there aren't licenses in the backend.