### PR TITLE
Fix regex expression for token matching

### DIFF
--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -59,12 +59,17 @@ class LicenseBookingRequest(BaseModel):
 
 
 def _match_requested_license(requested_license: str) -> Union[dict, None]:
-    license_regex = re.compile(r"(?P<product>\w+)\.(?P<feature>\w+)@(?P<server_type>\w+):(?P<tokens>\d+)")
+    license_regex = re.compile(r"(?P<product>\w+)\.(?P<feature>\w+)@(?P<server_type>\w+)?(:(?P<tokens>\d+))?")
+    
     matches = license_regex.match(requested_license)
 
     if not matches:
         return None
+
     groups = matches.groupdict()
+    if not groups["tokens"]:
+        groups["tokens"] = 1
+
     return {
         "product_feature": groups["product"] + "." + groups["feature"],
         "server_type": groups["server_type"],

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -68,7 +68,7 @@ def _match_requested_license(requested_license: str) -> Union[dict, None]:
 
     groups = matches.groupdict()
     if not groups["tokens"]:
-        groups["tokens"] = 1
+        groups["tokens"] = "1"
 
     return {
         "product_feature": groups["product"] + "." + groups["feature"],

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -60,7 +60,7 @@ class LicenseBookingRequest(BaseModel):
 
 def _match_requested_license(requested_license: str) -> Union[dict, None]:
     license_regex = re.compile(r"(?P<product>\w+)\.(?P<feature>\w+)@(?P<server_type>\w+)?(:(?P<tokens>\d+))?")
-    
+
     matches = license_regex.match(requested_license)
 
     if not matches:

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -59,7 +59,7 @@ class LicenseBookingRequest(BaseModel):
 
 
 def _match_requested_license(requested_license: str) -> Union[dict, None]:
-    license_regex = re.compile(r"(?P<product>\w+)\.(?P<feature>\w+)@(?P<server_type>\w+)?(:(?P<tokens>\d+))?")
+    license_regex = re.compile(r"(?P<product>\w+)\.(?P<feature>\w+)@(?P<server_type>\w+)(:(?P<tokens>\d+))?")
 
     matches = license_regex.match(requested_license)
 

--- a/agent/tests/workload_managers/slurm/test_cmd_utils.py
+++ b/agent/tests/workload_managers/slurm/test_cmd_utils.py
@@ -31,6 +31,7 @@ def test_squeue_parser_returns_correct_output_format():
     )
     assert squeue_parsed == squeue_parsed_output
 
+
 @mark.parametrize(
     "license,output",
     [
@@ -40,7 +41,7 @@ def test_squeue_parser_returns_correct_output_format():
                 "product_feature": "product.feature",
                 "server_type": "flexlm",
                 "tokens": 123,
-            }
+            },
         ),
         (
             "product.feature@rlm",
@@ -48,9 +49,9 @@ def test_squeue_parser_returns_correct_output_format():
                 "product_feature": "product.feature",
                 "server_type": "rlm",
                 "tokens": 1,
-            }
-        )
-    ]
+            },
+        ),
+    ],
 )
 def test_match_requested_license(license, output):
     requested_license = license

--- a/agent/tests/workload_managers/slurm/test_cmd_utils.py
+++ b/agent/tests/workload_managers/slurm/test_cmd_utils.py
@@ -31,17 +31,33 @@ def test_squeue_parser_returns_correct_output_format():
     )
     assert squeue_parsed == squeue_parsed_output
 
-
-def test_match_requested_license():
-    requested_license = "product.feature@flexlm:123"
+@mark.parametrize(
+    "license,output",
+    [
+        (
+            "product.feature@flexlm:123",
+            {
+                "product_feature": "product.feature",
+                "server_type": "flexlm",
+                "tokens": 123,
+            }
+        ),
+        (
+            "product.feature@rlm",
+            {
+                "product_feature": "product.feature",
+                "server_type": "rlm",
+                "tokens": 1,
+            }
+        )
+    ]
+)
+def test_match_requested_license(license, output):
+    requested_license = license
 
     return_value = _match_requested_license(requested_license)
 
-    assert return_value == {
-        "product_feature": "product.feature",
-        "server_type": "flexlm",
-        "tokens": 123,
-    }
+    assert return_value == output
 
 
 @mark.parametrize(

--- a/agent/tests/workload_managers/slurm/test_cmd_utils.py
+++ b/agent/tests/workload_managers/slurm/test_cmd_utils.py
@@ -66,7 +66,6 @@ def test_match_requested_license(license, output):
         ("productfeature@flexlm:bla"),
         ("productfeature@flexlm:999"),
         ("product.featureflexlm:999"),
-        ("product.feature@flexlm999"),
         ("productfeatureflexlm999"),
         (""),
         ("product.feature:flexlm@999"),


### PR DESCRIPTION
#### What
Fix regex expression to assume the quantity of licenses needed for a job is 1 when no token quantity is provided.

#### Why
Slurm assumes the quantity is 1 when it's not provided, so we should also accept it.

`Task`: https://app.clickup.com/t/18022949/LM-175