### PR TITLE
Tucker/job 121  simplify permissions

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Simplified the permissions structure to a view/edit model for each data model
 
 2.1.5 -- 2022-01-13
 -------------------

--- a/backend/lm_backend/api/booking.py
+++ b/backend/lm_backend/api/booking.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.sql import delete, join, select
 
 from lm_backend.api.config import get_config_id_for_product_features
+from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import Booking, BookingRow, BookingRowDetail, LicenseUse, LicenseUseBooking
 from lm_backend.compat import INTEGRITY_CHECK_EXCEPTIONS
 from lm_backend.security import guard
@@ -19,7 +20,7 @@ router = APIRouter()
 @router.get(
     "/all",
     response_model=List[BookingRow],
-    dependencies=[Depends(guard.lockdown("license-manager:booking:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.BOOKING_VIEW))],
 )
 async def get_bookings_all(cluster_name: Optional[str] = Query(None)):
     """
@@ -35,7 +36,7 @@ async def get_bookings_all(cluster_name: Optional[str] = Query(None)):
 @router.get(
     "/{booking_id}",
     response_model=BookingRowDetail,
-    dependencies=[Depends(guard.lockdown("license-manager:booking:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.BOOKING_VIEW))],
 )
 async def get_booking(booking_id: int):
     """
@@ -62,7 +63,7 @@ async def get_booking(booking_id: int):
 @router.get(
     "/job/{job_id}",
     response_model=List[BookingRow],
-    dependencies=[Depends(guard.lockdown("license-manager:booking:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.BOOKING_VIEW))],
 )
 async def get_bookings_job(job_id: str):
     """
@@ -111,7 +112,7 @@ async def _is_booking_available(booking: Booking):
 @database.transaction()
 @router.put(
     "/book",
-    dependencies=[Depends(guard.lockdown("license-manager:booking:write"))],
+    dependencies=[Depends(guard.lockdown(Permissions.BOOKING_EDIT))],
 )
 async def create_booking(booking: Booking):
     """
@@ -169,7 +170,7 @@ async def create_booking(booking: Booking):
 @database.transaction()
 @router.delete(
     "/book/{job_id}",
-    dependencies=[Depends(guard.lockdown("license-manager:booking:write"))],
+    dependencies=[Depends(guard.lockdown(Permissions.BOOKING_EDIT))],
 )
 async def delete_booking(job_id: str):
     """

--- a/backend/lm_backend/api/config.py
+++ b/backend/lm_backend/api/config.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 
+from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import ConfigurationItem, ConfigurationRow
 from lm_backend.compat import INTEGRITY_CHECK_EXCEPTIONS
 from lm_backend.security import guard
@@ -15,7 +16,7 @@ router = APIRouter()
 @router.get(
     "/all",
     response_model=List[ConfigurationItem],
-    dependencies=[Depends(guard.lockdown("license-manager:config:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.CONFIG_VIEW))],
 )
 async def get_all_configurations():
     """
@@ -33,7 +34,7 @@ async def get_all_configurations():
 @router.get(
     "/{config_id}",
     response_model=ConfigurationItem,
-    dependencies=[Depends(guard.lockdown("license-manager:config:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.CONFIG_VIEW))],
 )
 async def get_configuration(config_id: int):
     """
@@ -71,7 +72,7 @@ async def get_config_id(product_feature: str):
 @database.transaction()
 @router.post(
     "/",
-    dependencies=[Depends(guard.lockdown("license-manager:config:write"))],
+    dependencies=[Depends(guard.lockdown(Permissions.CONFIG_EDIT))],
 )
 async def add_configuration(configuration: ConfigurationRow):
     """
@@ -95,7 +96,7 @@ async def add_configuration(configuration: ConfigurationRow):
 @database.transaction()
 @router.put(
     "/{config_id}",
-    dependencies=[Depends(guard.lockdown("license-manager:config:write"))],
+    dependencies=[Depends(guard.lockdown(Permissions.CONFIG_EDIT))],
 )
 async def update_configuration(
     config_id: int,
@@ -133,7 +134,7 @@ async def update_configuration(
 @database.transaction()
 @router.delete(
     "/{config_id}",
-    dependencies=[Depends(guard.lockdown("license-manager:config:write"))],
+    dependencies=[Depends(guard.lockdown(Permissions.CONFIG_EDIT))],
 )
 async def delete_configuration(config_id: int):
     """

--- a/backend/lm_backend/api/license.py
+++ b/backend/lm_backend/api/license.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Sequence, Tuple
 from fastapi import APIRouter, Depends
 from sqlalchemy.sql import select, update
 
+from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import (
     BookingRow,
     LicenseUse,
@@ -22,7 +23,7 @@ router = APIRouter()
 @router.get(
     "/all",
     response_model=List[LicenseUse],
-    dependencies=[Depends(guard.lockdown("license-manager:license:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.LICENSE_VIEW))],
 )
 async def licenses_all():
     """
@@ -36,7 +37,7 @@ async def licenses_all():
 @router.get(
     "/cluster_update",
     response_model=List[Dict],
-    dependencies=[Depends(guard.lockdown("license-manager:license:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.LICENSE_VIEW))],
 )
 async def licenses_and_bookings_to_update():
     """
@@ -72,7 +73,7 @@ async def licenses_and_bookings_to_update():
 @router.get(
     "/use/{product}",
     response_model=List[LicenseUse],
-    dependencies=[Depends(guard.lockdown("license-manager:license:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.LICENSE_VIEW))],
 )
 async def licenses_product(product: str):
     """
@@ -90,7 +91,7 @@ async def licenses_product(product: str):
 @router.get(
     "/use/{product}/{feature}",
     response_model=List[LicenseUse],
-    dependencies=[Depends(guard.lockdown("license-manager:license:read"))],
+    dependencies=[Depends(guard.lockdown(Permissions.LICENSE_VIEW))],
 )
 async def licenses_product_feature(product: str, feature: str):
     """
@@ -182,7 +183,7 @@ async def _clean_up_in_use_booking(
 @router.patch(
     "/reconcile",
     response_model=List[LicenseUse],
-    dependencies=[Depends(guard.lockdown("license-manager:license:write"))],
+    dependencies=[Depends(guard.lockdown(Permissions.LICENSE_EDIT))],
 )
 async def reconcile_changes(reconcile_request: List[LicenseUseReconcileRequest]):
     """

--- a/backend/lm_backend/api/permissions.py
+++ b/backend/lm_backend/api/permissions.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class Permissions(str, Enum):
+    """
+    Describe the permissions that may be used for protecting LM Backend routes.
+    """
+
+    BOOKING_VIEW = "license-manager:booking:view"
+    BOOKING_EDIT = "license-manager:booking:edit"
+    CONFIG_VIEW = "license-manager:config:view"
+    CONFIG_EDIT = "license-manager:config:edit"
+    LICENSE_VIEW = "license-manager:license:view"
+    LICENSE_EDIT = "license-manager:license:edit"

--- a/backend/tests/api/test_booking.py
+++ b/backend/tests/api/test_booking.py
@@ -7,6 +7,7 @@ from pytest import mark
 
 from lm_backend import table_schemas
 from lm_backend.api import booking
+from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import Booking, BookingFeature, BookingRow
 from lm_backend.storage import database
 
@@ -30,7 +31,7 @@ async def test_get_bookings__by_id(
     with time_frame() as window:
         await insert_objects(some_booking_rows, table_schemas.booking_table)
 
-    inject_security_header("owner1", "license-manager:booking:read")
+    inject_security_header("owner1", Permissions.BOOKING_VIEW)
     resp = await backend_client.get(f"/lm/api/v1/booking/{1}")
 
     assert resp.status_code == 200
@@ -69,7 +70,7 @@ async def test_get_bookings_job__success(
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
 
-    inject_security_header("owner1", "license-manager:booking:read")
+    inject_security_header("owner1", Permissions.BOOKING_VIEW)
     resp = await backend_client.get("/lm/api/v1/booking/job/coolbeans")
 
     assert resp.status_code == 200
@@ -142,7 +143,7 @@ async def test_get_bookings_for_cluster_name__success(
     )
     await insert_objects([booking], table_schemas.booking_table)
 
-    inject_security_header("owner1", "license-manager:booking:read")
+    inject_security_header("owner1", Permissions.BOOKING_VIEW)
     resp = await backend_client.get("/lm/api/v1/booking/all?cluster_name=cluster2")
 
     assert resp.status_code == 200
@@ -227,7 +228,7 @@ async def test_bookings_all(
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
 
-    inject_security_header("owner1", "license-manager:booking:read")
+    inject_security_header("owner1", Permissions.BOOKING_VIEW)
     resp = await backend_client.get("/lm/api/v1/booking/all")
 
     assert resp.status_code == 200
@@ -282,7 +283,7 @@ async def test_booking_create__success(
         job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
     )
 
-    inject_security_header("owner1", "license-manager:booking:write")
+    inject_security_header("owner1", Permissions.BOOKING_EDIT)
     resp = await backend_client.put("/lm/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_200_OK
@@ -337,7 +338,7 @@ async def test_booking_create_negative_booked_error(
         job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
     )
 
-    inject_security_header("owner1", "license-manager:booking:write")
+    inject_security_header("owner1", Permissions.BOOKING_EDIT)
     resp = await backend_client.put("/lm/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -362,7 +363,7 @@ async def test_booking_create_booked_greater_than_total(
     booking = Booking(
         job_id=1, features=[features], lead_host="host1", user_name="user1", cluster_name="cluster1"
     )
-    inject_security_header("owner1", "license-manager:booking:write")
+    inject_security_header("owner1", Permissions.BOOKING_EDIT)
     resp = await backend_client.put("/lm/api/v1/booking/book", json=booking.dict())
 
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -386,7 +387,7 @@ async def test_booking_delete__success(
     await insert_objects(some_config_rows, table_schemas.config_table)
     await insert_objects(some_booking_rows, table_schemas.booking_table)
 
-    inject_security_header("owner1", "license-manager:booking:write")
+    inject_security_header("owner1", Permissions.BOOKING_EDIT)
     resp = await backend_client.delete("/lm/api/v1/booking/book/helloworld")
     assert resp.status_code == status.HTTP_200_OK
 

--- a/backend/tests/api/test_config.py
+++ b/backend/tests/api/test_config.py
@@ -4,6 +4,7 @@ from httpx import AsyncClient
 from pytest import fixture, mark
 
 from lm_backend import table_schemas
+from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import ConfigurationItem, ConfigurationRow
 from lm_backend.storage import database
 
@@ -130,7 +131,7 @@ async def test_get_all_configurations__success(
     """
     await insert_objects(some_configuration_rows, table_schemas.config_table)
 
-    inject_security_header("owner1", "license-manager:config:read")
+    inject_security_header("owner1", Permissions.CONFIG_VIEW)
     resp = await backend_client.get("/lm/api/v1/config/all")
 
     assert resp.status_code == 200
@@ -176,7 +177,7 @@ async def test_get_configuration__success(
 
     await insert_objects(one_configuration_row, table_schemas.config_table)
 
-    inject_security_header("owner1", "license-manager:config:read")
+    inject_security_header("owner1", Permissions.CONFIG_VIEW)
     resp = await backend_client.get("/lm/api/v1/config/100")
 
     assert resp.status_code == 200
@@ -226,7 +227,7 @@ async def test_add_configuration__success(
         "grace_time": "10000",
     }
 
-    inject_security_header("owner1", "license-manager:config:write")
+    inject_security_header("owner1", Permissions.CONFIG_EDIT)
     response = await backend_client.post("/lm/api/v1/config", json=data)
     assert response.status_code == 200
 
@@ -288,7 +289,7 @@ async def test_update_configuration__success(
         "license_server_type": "servertype100",
         "grace_time": "10000",
     }
-    inject_security_header("owner1", "license-manager:config:write")
+    inject_security_header("owner1", Permissions.CONFIG_EDIT)
     resp = await backend_client.put("/lm/api/v1/config/100", json=data)
     assert resp.status_code == 200
 
@@ -342,7 +343,7 @@ async def test_update_nonexistant_configuration(
         "grace_time": "10000",
     }
 
-    inject_security_header("owner1", "license-manager:config:write")
+    inject_security_header("owner1", Permissions.CONFIG_EDIT)
     resp = await backend_client.put("/lm/api/v1/config/100000", json=data)
     assert resp.status_code == 200
 
@@ -361,7 +362,7 @@ async def test_delete_configuration__success(
 
     await insert_objects(one_configuration_row, table_schemas.config_table)
 
-    inject_security_header("owner1", "license-manager:config:write")
+    inject_security_header("owner1", Permissions.CONFIG_EDIT)
     resp = await backend_client.delete("/lm/api/v1/config/100")
     assert resp.status_code == 200
     assert resp.json()["message"] == "Deleted 100 from the configuration table."
@@ -404,6 +405,6 @@ async def test_delete_nonexistant__configuration(
     """
 
     await insert_objects(one_configuration_row, table_schemas.config_table)
-    inject_security_header("owner1", "license-manager:config:write")
+    inject_security_header("owner1", Permissions.CONFIG_EDIT)
     resp = await backend_client.delete("/lm/api/v1/config/99999999")
     assert resp.status_code == 404

--- a/backend/tests/api/test_license.py
+++ b/backend/tests/api/test_license.py
@@ -5,6 +5,7 @@ from httpx import AsyncClient
 from pytest import mark, raises
 
 from lm_backend.api import license
+from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import BookingRow, LicenseUseReconcile, LicenseUseReconcileRequest
 from lm_backend.storage import database
 from lm_backend.table_schemas import booking_table, config_table, license_table
@@ -79,7 +80,7 @@ async def test_licenses_product__success(
     """
     await insert_objects(some_licenses, license_table)
 
-    inject_security_header("owner1", "license-manager:license:read")
+    inject_security_header("owner1", Permissions.LICENSE_VIEW)
     resp = await backend_client.get("/lm/api/v1/license/use/hello")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
@@ -129,7 +130,7 @@ async def test_licenses_product_feature__success(
     """
     await insert_objects(some_licenses, license_table)
 
-    inject_security_header("owner1", "license-manager:license:read")
+    inject_security_header("owner1", Permissions.LICENSE_VIEW)
     resp = await backend_client.get("/lm/api/v1/license/use/cool/beans")
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
@@ -175,7 +176,7 @@ async def test_licenses_all__success(
     """
     await insert_objects(some_licenses, license_table)
 
-    inject_security_header("owner1", "license-manager:license:read")
+    inject_security_header("owner1", Permissions.LICENSE_VIEW)
     resp = await backend_client.get("/lm/api/v1/license/all")
     assert resp.status_code == 200
     assert resp.json() == [
@@ -318,7 +319,7 @@ async def test_reconcile_changes_clean_up_in_use_bookings__success(
         used=19, product_feature="hello.world", total=100, used_licenses=used_licenses
     )
 
-    inject_security_header("owner1", "license-manager:license:write")
+    inject_security_header("owner1", Permissions.LICENSE_EDIT)
     response = await backend_client.patch(
         "/lm/api/v1/license/reconcile", json=[license_reconcile_request.dict()]
     )


### PR DESCRIPTION
#### What
Instead of maintaining 4 (or 5) different permission types for all the license manager entities, we condensed it down to to two apiece: view or edit

#### Why
This will drastically reduce the number of permissions that we need to track in our apps and our OIDC provider. It's also most likely that permissions that fine-grained wouldn't even be used anyway.

`Task`: https://app.clickup.com/t/18022949/JOB-121

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
