### PR TITLE
Fix validation errors in Tokenstat

### DIFF
--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -66,11 +66,11 @@ class Settings(BaseSettings):
     # path to the license server features config file
     LICENSE_SERVER_FEATURES_CONFIG_PATH: Optional[str]
 
-    # path to the binary for lmstat (needed for FlexLM licenses)
-    LMUTIL_PATH: DirectoryPath = _DEFAULT_BIN_PATH
+    # path to the binary for lmutil (needed for FlexLM licenses)
+    LMUTIL_PATH: Path = _DEFAULT_BIN_PATH
 
-    # path to the binary for rlmstat (needed for RLM licenses)
-    RLMUTIL_PATH: DirectoryPath = _DEFAULT_BIN_PATH
+    # path to the binary for tlmutil (needed for RLM licenses)
+    RLMUTIL_PATH: Path = _DEFAULT_BIN_PATH
 
     # debug mode turns on certain dangerous operations
     DEBUG: bool = False

--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -4,7 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseSettings, DirectoryPath, Field
+from pydantic import BaseSettings, Field
 from pydantic.error_wrappers import ValidationError
 
 logger = logging.getLogger("lm_agent.config")

--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
     # path to the binary for lmutil (needed for FlexLM licenses)
     LMUTIL_PATH: Path = _DEFAULT_BIN_PATH
 
-    # path to the binary for tlmutil (needed for RLM licenses)
+    # path to the binary for rlmutil (needed for RLM licenses)
     RLMUTIL_PATH: Path = _DEFAULT_BIN_PATH
 
     # debug mode turns on certain dangerous operations

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -98,10 +98,10 @@ class FlexLMLicenseServer(LicenseServerInterface):
 
         # raise exception if parser didn't output license information
         if (
-            not parsed_output.get("total")
-            or not parsed_output.get("uses")
-            or not parsed_output.get("total", {}).get("used")
-            or not parsed_output.get("total", {}).get("total")
+            parsed_output.get("total") is None
+            or parsed_output.get("uses") is None
+            or parsed_output.get("total", {}).get("used") is None
+            or parsed_output.get("total", {}).get("total") is None
         ):
             raise LicenseManagerBadServerOutput()
 
@@ -167,7 +167,7 @@ class RLMLicenseServer(LicenseServerInterface):
         used_licenses = self._filter_used_features(parsed_output["uses"], product_feature.split(".")[1])
 
         # raise exception if parser didn't output license information
-        if not current_feature_item or used_licenses is None:
+        if current_feature_item is None or used_licenses is None:
             raise LicenseManagerBadServerOutput()
 
         report_item = LicenseReportItem(

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -83,6 +83,24 @@ def lm_output():
 
 
 @fixture
+def lm_output_no_licenses():
+    """
+    Some lmstat output with no licenses in use to parse
+    """
+    return dedent(
+        """
+        lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
+        ...
+
+        Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 0 licenses in use)
+
+        ...
+
+        """
+    )
+
+
+@fixture
 def rlm_output():
     return """Setting license file path to 10@licserv.server.com
 rlmutil v12.2

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -43,7 +43,7 @@ def respx_mock():
 
 
 @fixture
-def lm_output_bad():
+def lmstat_output_bad():
     """
     Some unparseable lmstat output
     """
@@ -58,7 +58,7 @@ def lm_output_bad():
 
 
 @fixture
-def lm_output():
+def lmstat_output():
     """
     Some lmstat output to parse
     """
@@ -83,7 +83,7 @@ def lm_output():
 
 
 @fixture
-def lm_output_no_licenses():
+def lmstat_output_no_licenses():
     """
     Some lmstat output with no licenses in use to parse
     """

--- a/agent/tests/parsing/test_flexlm.py
+++ b/agent/tests/parsing/test_flexlm.py
@@ -10,7 +10,7 @@ from lm_agent.parsing.flexlm import parse
     "fixture,result",
     [
         (
-            "lm_output",
+            "lmstat_output",
             {
                 "total": {"feature": "TESTFEATURE", "total": 1000, "used": 93},
                 "uses": [
@@ -20,7 +20,7 @@ from lm_agent.parsing.flexlm import parse
                 ],
             },
         ),
-        ("lm_output_bad", {"total": None, "uses": []}),
+        ("lmstat_output_bad", {"total": None, "uses": []}),
     ],
 )
 def test_parse(request, fixture, result):

--- a/agent/tests/parsing/test_rlm.py
+++ b/agent/tests/parsing/test_rlm.py
@@ -41,7 +41,7 @@ from lm_agent.parsing.rlm import _get_start_offset, parse
                 ],
             },
         ),
-        ("lm_output_bad", {"total": [], "uses": []}),
+        ("lmstat_output_bad", {"total": [], "uses": []}),
         (
             "rlm_output_no_licenses",
             {
@@ -65,7 +65,7 @@ def test_parse(request, fixture, result):
     assert parse(text) == result
 
 
-@mark.parametrize("fixture,result", [("rlm_output", 41), ("lm_output_bad", 0)])
+@mark.parametrize("fixture,result", [("rlm_output", 41), ("lmstat_output_bad", 0)])
 def test_get_start_offset(request, fixture, result):
     """
     Test the function that returns the offset for the RLM parser

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -85,7 +85,7 @@ async def test_flexlm_get_output_from_server(
     create_subprocess_mock: mock.MagicMock,
     wait_for_mock: mock.MagicMock,
     flexlm_server,
-    lm_output,
+    lmstat_output,
 ):
     """
     Do the license server interface return the output from the license server?
@@ -95,12 +95,12 @@ async def test_flexlm_get_output_from_server(
 
     create_subprocess_mock.return_value = proc_mock
     wait_for_mock.return_value = (
-        bytes(lm_output, encoding="UTF8"),
+        bytes(lmstat_output, encoding="UTF8"),
         None,
     )
 
     output = await flexlm_server.get_output_from_server("testproduct.testfeature")
-    assert output == lm_output
+    assert output == lmstat_output
 
 
 @mark.asyncio
@@ -130,11 +130,13 @@ async def test_rlm_get_output_from_server(
 
 @mark.asyncio
 @mock.patch("lm_agent.tokenstat.FlexLMLicenseServer.get_output_from_server")
-async def test_flexlm_get_report_item(get_output_from_server_mock: mock.MagicMock, flexlm_server, lm_output):
+async def test_flexlm_get_report_item(
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output
+):
     """
     Do the FlexLM server interface generate a report item for the product?
     """
-    get_output_from_server_mock.return_value = lm_output
+    get_output_from_server_mock.return_value = lmstat_output
 
     assert await flexlm_server.get_report_item("testproduct.testfeature") == tokenstat.LicenseReportItem(
         product_feature="testproduct.testfeature",
@@ -171,9 +173,9 @@ async def test_rlm_get_report_item(get_output_from_server_mock: mock.MagicMock, 
 @mark.asyncio
 @mock.patch("lm_agent.tokenstat.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item_with_bad_output(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server, lm_output_bad
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output_bad
 ):
-    get_output_from_server_mock.return_value = lm_output_bad
+    get_output_from_server_mock.return_value = lmstat_output_bad
 
     with raises(LicenseManagerBadServerOutput):
         await flexlm_server.get_report_item("testproduct.testfeature")
@@ -197,9 +199,9 @@ async def test_rlm_get_report_item_with_no_used_licenses(
 @mark.asyncio
 @mock.patch("lm_agent.tokenstat.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item_with_no_used_licenses(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server, lm_output_no_licenses
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output_no_licenses
 ):
-    get_output_from_server_mock.return_value = lm_output_no_licenses
+    get_output_from_server_mock.return_value = lmstat_output_no_licenses
 
     assert await flexlm_server.get_report_item("testproduct.testfeature") == tokenstat.LicenseReportItem(
         product_feature="testproduct.testfeature",
@@ -214,7 +216,7 @@ async def test_flexlm_get_report_item_with_no_used_licenses(
     "output,reconciliation",
     [
         (
-            "lm_output",
+            "lmstat_output",
             [
                 {
                     "product_feature": "testproduct.testfeature",

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -193,6 +193,20 @@ async def test_rlm_get_report_item_with_no_used_licenses(
         used_licenses=[],
     )
 
+@mark.asyncio
+@mock.patch("lm_agent.tokenstat.FlexLMLicenseServer.get_output_from_server")
+async def test_flexlm_get_report_item_with_no_used_licenses(
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lm_output_no_licenses
+):
+    get_output_from_server_mock.return_value = lm_output_no_licenses
+
+    assert await flexlm_server.get_report_item("testproduct.testfeature") == tokenstat.LicenseReportItem(
+        product_feature="testproduct.testfeature",
+        used=0,
+        total=1000,
+        used_licenses=[],
+    )
+
 
 @mark.asyncio
 @mark.parametrize(

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -193,6 +193,7 @@ async def test_rlm_get_report_item_with_no_used_licenses(
         used_licenses=[],
     )
 
+
 @mark.asyncio
 @mock.patch("lm_agent.tokenstat.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item_with_no_used_licenses(


### PR DESCRIPTION
#### What
Fix validation for server output, adding unit test for the case when `0` licenses are in use.
Also fix type of the env var for the binaries path.

#### Why
After testing the `tokenstat` refactor, I caught some validations erros, such as: when the feature in the `flexlm` output is not in use `(total == 0)`, it was not passing the validation.