### PR TITLE
Tucker/prepare for 2.2 release

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,11 +6,14 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+
+2.2.0 - 2022-02-02
+------------------
+* Refactored tokenstat module
 * Remove lmstat binary
 * Get license server type from backend configuration row
 * Fix rlmutil command path
 * Added auth via Auth0 and removed static token logic
-* Refactored tokenstat module
 
 2.1.1 - 2022-01-10
 ------------------

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.1.0-dev3"
+version = "2.2.0"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,9 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+
+2.2.0 -- 2022-02-02
+-------------------
 * Simplified the permissions structure to a view/edit model for each data model
 
 2.1.5 -- 2022-01-13

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "2.1.5"
+version = "2.2.0"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Preparations for 2.2.0 release

#### Why
Needed to bump versions and update CHAGELOG

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
