### PR TITLE
Fix cache token permission error

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 
+2.2.3 - 2022-02-09
+* Fixed permission error when accessing cached token 
+
 2.2.2 - 2022-02-03
 ------------------
 * Bump to sync with lm-backend version

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -22,7 +22,11 @@ def _load_token_from_cache() -> typing.Union[str, None]:
     * The token is expired (or will expire within 10 seconds)
     """
     token_path = settings.CACHE_DIR / "auth-token"
-    if not token_path.exists():
+
+    try:
+        if not token_path.exists():
+            return None
+    except Exception:
         return None
 
     try:


### PR DESCRIPTION
#### What
Fix permission error when accesssing cached token dir.

#### Why
It was making the prolog to fail.