### PR TITLE
Remove License Server Interfaces from tokenstat module

### DIFF
--- a/agent/lm_agent/server_interfaces/flexlm.py
+++ b/agent/lm_agent/server_interfaces/flexlm.py
@@ -1,3 +1,4 @@
+"""FlexLM license server interface."""
 import typing
 
 from lm_agent.config import settings

--- a/agent/lm_agent/server_interfaces/flexlm.py
+++ b/agent/lm_agent/server_interfaces/flexlm.py
@@ -33,7 +33,7 @@ class FlexLMLicenseServer(LicenseServerInterface):
 
         # run each command in the list, one at a time, until one succeds
         for cmd in commands_to_run:
-            feature = product_feature.split(".")[1]
+            (_, feature) = product_feature.split(".")
             feature_cmd = f"{cmd} {feature}"
             output = await run_command(feature_cmd)
 

--- a/agent/lm_agent/server_interfaces/flexlm.py
+++ b/agent/lm_agent/server_interfaces/flexlm.py
@@ -51,11 +51,12 @@ class FlexLMLicenseServer(LicenseServerInterface):
         parsed_output = self.parser(server_output)
 
         # raise exception if parser didn't output license information
-        if (
-            parsed_output.get("total") is None
-            or parsed_output.get("uses") is None
-            or parsed_output.get("total", {}).get("used") is None
-            or parsed_output.get("total", {}).get("total") is None
+        if parsed_output.get("total") is None or any(
+            [
+                parsed_output.get("total", {}).get("used") is None,
+                parsed_output.get("total", {}).get("total") is None,
+                parsed_output.get("uses") is None,
+            ]
         ):
             raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
 

--- a/agent/lm_agent/server_interfaces/flexlm.py
+++ b/agent/lm_agent/server_interfaces/flexlm.py
@@ -1,0 +1,68 @@
+import typing
+
+from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.parsing import flexlm
+from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
+from lm_agent.server_interfaces.utils import run_command
+
+
+class FlexLMLicenseServer(LicenseServerInterface):
+    """Extract license information from FlexLM license server."""
+
+    def __init__(self, license_servers: typing.List[str]):
+        self.license_servers = license_servers
+        self.parser = flexlm.parse
+
+    def get_commands_list(self):
+        """Generate a list of commands with the available license server hosts."""
+
+        host_ports = [(server.split(":")[1:]) for server in self.license_servers]
+        commands_to_run = []
+        for host, port in host_ports:
+            command_line = f"{settings.LMUTIL_PATH} lmstat -c {port}@{host} -f"
+            commands_to_run.append(command_line)
+        return commands_to_run
+
+    async def get_output_from_server(self, product_feature: str):
+        """Override abstract method to get output from FlexLM license server."""
+
+        # get the list of commands for each license server host
+        commands_to_run = self.get_commands_list()
+
+        # run each command in the list, one at a time, until one succeds
+        for cmd in commands_to_run:
+            feature = product_feature.split(".")[1]
+            feature_cmd = f"{cmd} {feature}"
+            output = await run_command(feature_cmd)
+
+            # try the next server if the previous didn't return the expected data
+            if output is None:
+                continue
+            return output
+
+        raise RuntimeError("None of the checks for FlexLM succeeded!")
+
+    async def get_report_item(self, product_feature: str):
+        """Override abstract method to parse FlexLM license server output into License Report Item."""
+
+        server_output = await self.get_output_from_server(product_feature)
+        parsed_output = self.parser(server_output)
+
+        # raise exception if parser didn't output license information
+        if (
+            parsed_output.get("total") is None
+            or parsed_output.get("uses") is None
+            or parsed_output.get("total", {}).get("used") is None
+            or parsed_output.get("total", {}).get("total") is None
+        ):
+            raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
+
+        report_item = LicenseReportItem(
+            product_feature=product_feature,
+            used=parsed_output["total"]["used"],
+            total=parsed_output["total"]["total"],
+            used_licenses=parsed_output["uses"],
+        )
+
+        return report_item

--- a/agent/lm_agent/server_interfaces/license_server_interface.py
+++ b/agent/lm_agent/server_interfaces/license_server_interface.py
@@ -8,15 +8,15 @@ from lm_agent.config import PRODUCT_FEATURE_RX
 
 class LicenseServerInterface(metaclass=abc.ABCMeta):
     """
-    Abstract class for License Server interface.
+    Abstract base class for License Server interface.
 
     The logic for obtaining the data output from the License Server should be encapsulated in
-    the get_output_from_server method.
+    the ``get_output_from_server`` method.
 
-    After obtaining the output, the parsing and manipulation of the data should be implement in
-    the get_report_item method.
+    After obtaining the output, the parsing and manipulation of the data should be implemented in
+    the ``get_report_item`` method.
 
-    It is expected the license information to be parsed into an LicenseReportItem.
+    The license information should be parsed into a ``LicenseReportItem``.
     """
 
     @classmethod

--- a/agent/lm_agent/server_interfaces/license_server_interface.py
+++ b/agent/lm_agent/server_interfaces/license_server_interface.py
@@ -21,13 +21,12 @@ class LicenseServerInterface(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        return (
-            hasattr(subclass, "get_output_from_server")
-            and callable(subclass.get_output_from_server)
-            and hasattr(subclass, "get_report_item")
-            and callable(subclass.get_report_item)
-            or NotImplemented
-        )
+        return all([
+            hasattr(subclass, "get_output_from_server"),
+            callable(subclass.get_output_from_server),
+            hasattr(subclass, "get_report_item"),
+            callable(subclass.get_report_item),
+        ]) or NotImplemented
 
     @abc.abstractclassmethod
     def get_output_from_server(self, product_feature: str):

--- a/agent/lm_agent/server_interfaces/license_server_interface.py
+++ b/agent/lm_agent/server_interfaces/license_server_interface.py
@@ -21,12 +21,17 @@ class LicenseServerInterface(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        return all([
-            hasattr(subclass, "get_output_from_server"),
-            callable(subclass.get_output_from_server),
-            hasattr(subclass, "get_report_item"),
-            callable(subclass.get_report_item),
-        ]) or NotImplemented
+        return (
+            all(
+                [
+                    hasattr(subclass, "get_output_from_server"),
+                    callable(subclass.get_output_from_server),
+                    hasattr(subclass, "get_report_item"),
+                    callable(subclass.get_report_item),
+                ]
+            )
+            or NotImplemented
+        )
 
     @abc.abstractclassmethod
     def get_output_from_server(self, product_feature: str):

--- a/agent/lm_agent/server_interfaces/license_server_interface.py
+++ b/agent/lm_agent/server_interfaces/license_server_interface.py
@@ -1,0 +1,49 @@
+import abc
+import typing
+
+from pydantic import BaseModel, Field
+
+from lm_agent.config import PRODUCT_FEATURE_RX
+
+
+class LicenseServerInterface(metaclass=abc.ABCMeta):
+    """
+    Abstract class for License Server interface.
+
+    The logic for obtaining the data output from the License Server should be encapsulated in
+    the get_output_from_server method.
+
+    After obtaining the output, the parsing and manipulation of the data should be implement in
+    the get_report_item method.
+
+    It is expected the license information to be parsed into an LicenseReportItem.
+    """
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        return (
+            hasattr(subclass, "get_output_from_server")
+            and callable(subclass.get_output_from_server)
+            and hasattr(subclass, "get_report_item")
+            and callable(subclass.get_report_item)
+            or NotImplemented
+        )
+
+    @abc.abstractclassmethod
+    def get_output_from_server(self, product_feature: str):
+        """Return output from license server for the indicated features."""
+
+    @abc.abstractclassmethod
+    def get_report_item(self, product_feature: str):
+        """Parse license server output into a report item for the indicated feature."""
+
+
+class LicenseReportItem(BaseModel):
+    """
+    An item in a LicenseReport, a count of tokens for one product/feature.
+    """
+
+    product_feature: str = Field(..., regex=PRODUCT_FEATURE_RX)
+    used: int
+    total: int
+    used_licenses: typing.List

--- a/agent/lm_agent/server_interfaces/license_server_interface.py
+++ b/agent/lm_agent/server_interfaces/license_server_interface.py
@@ -1,3 +1,4 @@
+"""Module for license server interface abstract base class."""
 import abc
 import typing
 

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -73,8 +73,7 @@ class RLMLicenseServer(LicenseServerInterface):
             if feature_item["feature"].count("_") == 0:  # `converge`
                 if feature_item["feature"] == feature:
                     return feature_item
-            elif "".join(feature_item["feature"].split("_")[1:]) == feature:
-                # `converge_super` | `converge_gui_polygonica` | `converge_...`
+            elif "_".join(feature_item["feature"].split("_")[1:]) == feature:
                 return feature_item
 
     def _filter_used_features(self, parsed_list, feature):
@@ -86,7 +85,7 @@ class RLMLicenseServer(LicenseServerInterface):
             if feature_booked["feature"].count("_") == 0:
                 if feature_booked["feature"] == feature:
                     used_licenses.append(feature_booked)
-            elif "".join(feature_booked["feature"].split("_")[1:]) == feature:
+            elif "_".join(feature_booked["feature"].split("_")[1:]) == feature:
                 used_licenses.append(feature_booked)
 
         for license in used_licenses:

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -1,0 +1,96 @@
+import typing
+
+from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.parsing import rlm
+from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
+from lm_agent.server_interfaces.utils import run_command
+
+
+class RLMLicenseServer(LicenseServerInterface):
+    """Extract license information from RLM license server."""
+
+    def __init__(self, license_servers: typing.List[str]):
+        self.license_servers = license_servers
+        self.parser = rlm.parse
+
+    def get_commands_list(self):
+        """Generate a list of commands with the available license server hosts."""
+
+        host_ports = [(server.split(":")[1:]) for server in self.license_servers]
+        commands_to_run = []
+        for host, port in host_ports:
+            command_line = f"{settings.RLMUTIL_PATH} rlmstat -c {port}@{host} -a -p"
+            commands_to_run.append(command_line)
+        return commands_to_run
+
+    async def get_output_from_server(self):
+        """Override abstract method to get output from RLM license server."""
+
+        # get the list of commands for each license server host
+        commands_to_run = self.get_commands_list()
+
+        # run each command in the list, one at a time, until one succeds
+        for cmd in commands_to_run:
+            output = await run_command(cmd)
+
+            # try the next server if the previous didn't return the expected data
+            if output is None:
+                continue
+            return output
+
+        raise RuntimeError("None of the checks for RLM succeeded!")
+
+    async def get_report_item(self, product_feature: str):
+        """Override abstract method to parse RLM license server output into License Report Item."""
+
+        server_output = await self.get_output_from_server()
+        parsed_output = self.parser(server_output)
+
+        current_feature_item = self._filter_current_feature(
+            parsed_output["total"], product_feature.split(".")[1]
+        )
+        used_licenses = self._filter_used_features(parsed_output["uses"], product_feature.split(".")[1])
+
+        # raise exception if parser didn't output license information
+        if current_feature_item is None or used_licenses is None:
+            raise LicenseManagerBadServerOutput()
+
+        report_item = LicenseReportItem(
+            product_feature=product_feature,
+            used=current_feature_item["used"],
+            total=current_feature_item["total"],
+            used_licenses=used_licenses,
+        )
+
+        return report_item
+
+    def _filter_current_feature(self, parsed_list, feature):
+        """
+        Get the current feature from the parsed list.
+        """
+        for feature_item in parsed_list:
+            if feature_item["feature"].count("_") == 0:  # `converge`
+                if feature_item["feature"] == feature:
+                    return feature_item
+            elif "".join(feature_item["feature"].split("_")[1:]) == feature:
+                # `converge_super` | `converge_gui_polygonica` | `converge_...`
+                return feature_item
+
+    def _filter_used_features(self, parsed_list, feature):
+        """
+        Get the used information for the specified feature.
+        """
+        used_licenses = []
+        for feature_booked in parsed_list:
+            if feature_booked["feature"].count("_") == 0:
+                if feature_booked["feature"] == feature:
+                    used_licenses.append(feature_booked)
+            elif "".join(feature_booked["feature"].split("_")[1:]) == feature:
+                used_licenses.append(feature_booked)
+
+        for license in used_licenses:
+            # remove the feature key, since we already handled it.
+            del license["feature"]
+
+        return used_licenses

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -1,3 +1,4 @@
+"""RLM license server interface."""
 import typing
 
 from lm_agent.config import settings
@@ -67,10 +68,23 @@ class RLMLicenseServer(LicenseServerInterface):
 
     def _filter_current_feature(self, parsed_list, feature):
         """
-        Get the current feature from the parsed list.
+        The output from the RLM server returns information about all the licenses
+        in the server. This function filters the output to return only the information
+        about the feature we want.
+
+        Also, the output from the RLM server returns only a ``feature`` identifier,
+        which can be the ``product`` and the ``feature`` concatenated.
+        To extract the ``feature``, we check if it has more than one word concatenated with ``_``.
+        If so, we consider the first word as the ``product`` and the rest as the ``feature``.
+        If it's only one word, we consider it as both the ``product`` and the ``feature``.
+
+        Example:
+        "converge" -> "converge.converge"
+        "converge_super" -> "converge.super"
+        "converge_gui_polygonica" -> "converge.gui_polygonica"
         """
         for feature_item in parsed_list:
-            if feature_item["feature"].count("_") == 0:  # `converge`
+            if feature_item["feature"].count("_") == 0:
                 if feature_item["feature"] == feature:
                     return feature_item
             elif "_".join(feature_item["feature"].split("_")[1:]) == feature:
@@ -78,7 +92,20 @@ class RLMLicenseServer(LicenseServerInterface):
 
     def _filter_used_features(self, parsed_list, feature):
         """
-        Get the used information for the specified feature.
+        The output from the RLM server returns information about all the licenses
+        that are in use. This function filters the output to return only the information
+        about the usage of the feature we want.
+
+        Also, the output from the RLM server returns only a ``feature`` identifier,
+        which can be the ``product`` and the ``feature`` concatenated.
+        To extract the ``feature``, we check if it has more than one word concatenated with ``_``.
+        If so, we consider the first word as the ``product`` and the rest as the ``feature``.
+        If it's only one word, we consider it as both the ``product`` and the ``feature``.
+
+        Example:
+        "converge" -> "converge.converge"
+        "converge_super" -> "converge.super"
+        "converge_gui_polygonica" -> "converge.gui_polygonica"
         """
         used_licenses = []
         for feature_booked in parsed_list:

--- a/agent/lm_agent/server_interfaces/utils.py
+++ b/agent/lm_agent/server_interfaces/utils.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from lm_agent.config import ENCODING, TOOL_TIMEOUT
+from lm_agent.logs import logger
+
+
+async def run_command(command_line: str):
+    """Run a command using a subprocess shell."""
+
+    proc = await asyncio.create_subprocess_shell(
+        command_line, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
+    )
+
+    # block until the command succeeds
+    stdout, _ = await asyncio.wait_for(proc.communicate(), TOOL_TIMEOUT)
+    output = str(stdout, encoding=ENCODING)
+
+    if proc.returncode != 0:
+        logger.error(f"Error: {output} | Return Code: {proc.returncode}")
+        return None
+    return output

--- a/agent/lm_agent/server_interfaces/utils.py
+++ b/agent/lm_agent/server_interfaces/utils.py
@@ -1,3 +1,4 @@
+"""Provide utilities to be used by some of the license server interfaces."""
 import asyncio
 
 from lm_agent.config import ENCODING, TOOL_TIMEOUT

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -1,224 +1,16 @@
 """
 Invoke license stat tools to build a view of license token counts.
 """
-import abc
-import asyncio
 import re
 import typing
 
-from pydantic import BaseModel, Field
-
 from lm_agent.backend_utils import BackendConfigurationRow, get_config_from_backend
-from lm_agent.config import ENCODING, PRODUCT_FEATURE_RX, TOOL_TIMEOUT, settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput, LicenseManagerNonSupportedServerTypeError
 from lm_agent.logs import logger
-from lm_agent.parsing import flexlm, rlm
+from lm_agent.server_interfaces.flexlm import FlexLMLicenseServer
+from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
+from lm_agent.server_interfaces.rlm import RLMLicenseServer
 from lm_agent.workload_managers.slurm.cmd_utils import scontrol_show_lic
-
-
-class LicenseServerInterface(metaclass=abc.ABCMeta):
-    """
-    Abstract class for License Server interface.
-
-    The logic for obtaining the data output from the License Server should be encapsulated in
-    the get_output_from_server method.
-
-    After obtaining the output, the parsing and manipulation of the data should be implement in
-    the get_report_item method.
-
-    It is expected the license information to be parsed into an LicenseReportItem.
-    """
-
-    @classmethod
-    def __subclasshook__(cls, subclass):
-        return (
-            hasattr(subclass, "get_output_from_server")
-            and callable(subclass.get_output_from_server)
-            and hasattr(subclass, "get_report_item")
-            and callable(subclass.get_report_item)
-            or NotImplemented
-        )
-
-    @abc.abstractclassmethod
-    def get_output_from_server(self, product_feature: str):
-        """Return output from license server for the indicated features."""
-
-    @abc.abstractclassmethod
-    def get_report_item(self, product_feature: str):
-        """Parse license server output into a report item for the indicated feature."""
-
-
-class FlexLMLicenseServer(LicenseServerInterface):
-    """Extract license information from FlexLM license server."""
-
-    def __init__(self, license_servers: typing.List[str]):
-        self.license_servers = license_servers
-        self.parser = flexlm.parse
-
-    def get_commands_list(self):
-        """Generate a list of commands with the available license server hosts."""
-
-        host_ports = [(server.split(":")[1:]) for server in self.license_servers]
-        commands_to_run = []
-        for host, port in host_ports:
-            command_line = f"{settings.LMUTIL_PATH} lmstat -c {port}@{host} -f"
-            commands_to_run.append(command_line)
-        return commands_to_run
-
-    async def get_output_from_server(self, product_feature: str):
-        """Override abstract method to get output from FlexLM license server."""
-
-        # get the list of commands for each license server host
-        commands_to_run = self.get_commands_list()
-
-        # run each command in the list, one at a time, until one succeds
-        for cmd in commands_to_run:
-            feature = product_feature.split(".")[1]
-            feature_cmd = f"{cmd} {feature}"
-            proc = await asyncio.create_subprocess_shell(
-                feature_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
-            )
-
-            # block until a check at this host:port succeeds or fails
-            stdout, _ = await asyncio.wait_for(proc.communicate(), TOOL_TIMEOUT)
-            output = str(stdout, encoding=ENCODING)
-
-            if proc.returncode != 0:
-                logger.error(f"Error: {output} | Return Code: {proc.returncode}")
-                continue
-            return output
-
-        raise RuntimeError("None of the checks for FlexLM succeeded!")
-
-    async def get_report_item(self, product_feature: str):
-        """Override abstract method to parse FlexLM license server output into License Report Item."""
-
-        server_output = await self.get_output_from_server(product_feature)
-        parsed_output = self.parser(server_output)
-
-        # raise exception if parser didn't output license information
-        if (
-            parsed_output.get("total") is None
-            or parsed_output.get("uses") is None
-            or parsed_output.get("total", {}).get("used") is None
-            or parsed_output.get("total", {}).get("total") is None
-        ):
-            raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
-
-        report_item = LicenseReportItem(
-            product_feature=product_feature,
-            used=parsed_output["total"]["used"],
-            total=parsed_output["total"]["total"],
-            used_licenses=parsed_output["uses"],
-        )
-
-        return report_item
-
-
-class RLMLicenseServer(LicenseServerInterface):
-    """Extract license information from RLM license server."""
-
-    def __init__(self, license_servers: typing.List[str]):
-        self.license_servers = license_servers
-        self.parser = rlm.parse
-
-    def get_commands_list(self):
-        """Generate a list of commands with the available license server hosts."""
-
-        host_ports = [(server.split(":")[1:]) for server in self.license_servers]
-        commands_to_run = []
-        for host, port in host_ports:
-            command_line = f"{settings.RLMUTIL_PATH} rlmstat -c {port}@{host} -a -p"
-            commands_to_run.append(command_line)
-        return commands_to_run
-
-    async def get_output_from_server(self):
-        """Override abstract method to get output from RLM license server."""
-
-        # get the list of commands for each license server host
-        commands_to_run = self.get_commands_list()
-
-        # run each command in the list, one at a time, until one succeds
-        for cmd in commands_to_run:
-            proc = await asyncio.create_subprocess_shell(
-                cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
-            )
-
-            # block until a check at this host:port succeeds or fails
-            stdout, _ = await asyncio.wait_for(proc.communicate(), TOOL_TIMEOUT)
-            output = str(stdout, encoding=ENCODING)
-
-            if proc.returncode != 0:
-                logger.error(f"Error: {output} | Return Code: {proc.returncode}")
-                continue
-            return output
-
-        raise RuntimeError("None of the checks for RLM succeeded!")
-
-    async def get_report_item(self, product_feature: str):
-        """Override abstract method to parse RLM license server output into License Report Item."""
-
-        server_output = await self.get_output_from_server()
-        parsed_output = self.parser(server_output)
-
-        current_feature_item = self._filter_current_feature(
-            parsed_output["total"], product_feature.split(".")[1]
-        )
-        used_licenses = self._filter_used_features(parsed_output["uses"], product_feature.split(".")[1])
-
-        # raise exception if parser didn't output license information
-        if current_feature_item is None or used_licenses is None:
-            raise LicenseManagerBadServerOutput()
-
-        report_item = LicenseReportItem(
-            product_feature=product_feature,
-            used=current_feature_item["used"],
-            total=current_feature_item["total"],
-            used_licenses=used_licenses,
-        )
-
-        return report_item
-
-    def _filter_current_feature(self, parsed_list, feature):
-        """
-        Get the current feature from the parsed list.
-        """
-        for feature_item in parsed_list:
-            if feature_item["feature"].count("_") == 0:  # `converge`
-                if feature_item["feature"] == feature:
-                    return feature_item
-            elif "".join(feature_item["feature"].split("_")[1:]) == feature:
-                # `converge_super` | `converge_gui_polygonica` | `converge_...`
-                return feature_item
-
-    def _filter_used_features(self, parsed_list, feature):
-        """
-        Get the used information for the specified feature.
-        """
-        used_licenses = []
-        for feature_booked in parsed_list:
-            if feature_booked["feature"].count("_") == 0:
-                if feature_booked["feature"] == feature:
-                    used_licenses.append(feature_booked)
-            elif "".join(feature_booked["feature"].split("_")[1:]) == feature:
-                used_licenses.append(feature_booked)
-
-        for license in used_licenses:
-            # remove the feature key, since we already handled it.
-            del license["feature"]
-
-        return used_licenses
-
-
-class LicenseReportItem(BaseModel):
-    """
-    An item in a LicenseReport, a count of tokens for one product/feature.
-    """
-
-    product_feature: str = Field(..., regex=PRODUCT_FEATURE_RX)
-    used: int
-    total: int
-    used_licenses: typing.List
 
 
 def get_all_product_features_from_cluster(show_lic_output: str) -> typing.List[str]:
@@ -275,6 +67,12 @@ async def report() -> typing.List[dict]:
     local_licenses = get_all_product_features_from_cluster(await scontrol_show_lic())
     filtered_entries = get_local_license_configurations(license_configurations, local_licenses)
 
+    logger.debug("#### Getting reconciliation report ####")
+    logger.debug("### Licenses in the backend: ")
+    logger.debug(license_configurations)
+    logger.debug("### Licenses in the cluster: ")
+    logger.debug(filtered_entries)
+
     license_server_interface: LicenseServerInterface
 
     server_type_map = dict(
@@ -288,6 +86,9 @@ async def report() -> typing.List[dict]:
             product_feature = f"{entry.product}.{feature}"
             product_features_to_check.append(product_feature)
 
+        logger.debug("### Features to check: ")
+        logger.debug(product_features_to_check)
+
         server_type = server_type_map.get(entry.license_server_type)
 
         if server_type is None:
@@ -296,9 +97,15 @@ async def report() -> typing.List[dict]:
         license_server_interface = server_type(entry.license_servers)
 
         for product_feature in product_features_to_check:
-            report_item = await license_server_interface.get_report_item(product_feature)
-            report_items.append(report_item)
+            try:
+                report_item = await license_server_interface.get_report_item(product_feature)
+                report_items.append(report_item)
+            except LicenseManagerBadServerOutput:
+                logger.error(f"#### Report for feature {product_feature} failed! ####")
+                continue
 
     reconciliation = [item.dict() for item in report_items]
+    logger.debug("#### Reconciliation items:")
+    logger.debug(reconciliation)
 
     return reconciliation

--- a/agent/tests/server_interfaces/test_flexlm.py
+++ b/agent/tests/server_interfaces/test_flexlm.py
@@ -1,0 +1,97 @@
+from unittest import mock
+
+from pytest import fixture, mark, raises
+
+from lm_agent.backend_utils import BackendConfigurationRow
+from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.server_interfaces.flexlm import FlexLMLicenseServer
+from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
+
+
+@fixture
+def one_configuration_row_flexlm():
+    return BackendConfigurationRow(
+        product="testproduct",
+        features={"testfeature": 10},
+        license_servers=["flexlm:127.0.0.1:2345"],
+        license_server_type="flexlm",
+        grace_time=10000,
+    )
+
+
+@fixture
+def flexlm_server(one_configuration_row_flexlm):
+    return FlexLMLicenseServer(one_configuration_row_flexlm.license_servers)
+
+
+def test_get_flexlm_commands_list(flexlm_server):
+    """
+    Do the commands for invoking the license server have the correct data?
+    """
+    commands_list = flexlm_server.get_commands_list()
+    assert commands_list == [f"{settings.LMUTIL_PATH} lmstat -c 2345@127.0.0.1 -f"]
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.flexlm.run_command")
+async def test_flexlm_get_output_from_server(
+    run_command_mock: mock.MagicMock,
+    flexlm_server,
+    lmstat_output,
+):
+    """
+    Do the license server interface return the output from the license server?
+    """
+    run_command_mock.return_value = lmstat_output
+
+    output = await flexlm_server.get_output_from_server("testproduct.testfeature")
+    assert output == lmstat_output
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
+async def test_flexlm_get_report_item(
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output
+):
+    """
+    Do the FlexLM server interface generate a report item for the product?
+    """
+    get_output_from_server_mock.return_value = lmstat_output
+
+    assert await flexlm_server.get_report_item("testproduct.testfeature") == LicenseReportItem(
+        product_feature="testproduct.testfeature",
+        used=93,
+        total=1000,
+        used_licenses=[
+            {"booked": 29, "user_name": "jbemfv", "lead_host": "myserver.example.com"},
+            {"booked": 27, "user_name": "cdxfdn", "lead_host": "myserver.example.com"},
+            {"booked": 37, "user_name": "jbemfv", "lead_host": "myserver.example.com"},
+        ],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
+async def test_flexlm_get_report_item_with_bad_output(
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output_bad
+):
+    get_output_from_server_mock.return_value = lmstat_output_bad
+
+    with raises(LicenseManagerBadServerOutput):
+        await flexlm_server.get_report_item("testproduct.testfeature")
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
+async def test_flexlm_get_report_item_with_no_used_licenses(
+    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output_no_licenses
+):
+    get_output_from_server_mock.return_value = lmstat_output_no_licenses
+
+    assert await flexlm_server.get_report_item("testproduct.testfeature") == LicenseReportItem(
+        product_feature="testproduct.testfeature",
+        used=0,
+        total=1000,
+        used_licenses=[],
+    )

--- a/agent/tests/server_interfaces/test_flexlm.py
+++ b/agent/tests/server_interfaces/test_flexlm.py
@@ -1,3 +1,5 @@
+"""Test the FlexLM license server interface."""
+
 from unittest import mock
 
 from pytest import fixture, mark, raises

--- a/agent/tests/server_interfaces/test_rlm.py
+++ b/agent/tests/server_interfaces/test_rlm.py
@@ -1,0 +1,83 @@
+from unittest import mock
+
+from pytest import fixture, mark
+
+from lm_agent.backend_utils import BackendConfigurationRow
+from lm_agent.config import settings
+from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
+from lm_agent.server_interfaces.rlm import RLMLicenseServer
+
+
+@fixture
+def one_configuration_row_rlm():
+    return BackendConfigurationRow(
+        product="converge",
+        features={"super": 10},
+        license_servers=["rlm:127.0.0.1:2345"],
+        license_server_type="rlm",
+        grace_time=10000,
+    )
+
+
+@fixture
+def rlm_server(one_configuration_row_rlm):
+    return RLMLicenseServer(one_configuration_row_rlm.license_servers)
+
+
+def test_get_rlm_commands_list(rlm_server):
+    """
+    Do the commands for invoking the license server have the correct data?
+    """
+    commands_list = rlm_server.get_commands_list()
+    assert commands_list == [f"{settings.RLMUTIL_PATH} rlmstat -c 2345@127.0.0.1 -a -p"]
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.rlm.run_command")
+async def test_rlm_get_output_from_server(
+    run_command_mock: mock.MagicMock,
+    rlm_server,
+    rlm_output,
+):
+    """
+    Do the license server interface return the output from the license server?
+    """
+    run_command_mock.return_value = rlm_output
+
+    output = await rlm_server.get_output_from_server()
+    assert output == rlm_output
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
+async def test_rlm_get_report_item(get_output_from_server_mock: mock.MagicMock, rlm_server, rlm_output):
+    """
+    Do the RLM server interface generate a report item for the product?
+    """
+    get_output_from_server_mock.return_value = rlm_output
+
+    assert await rlm_server.get_report_item("converge.super") == LicenseReportItem(
+        product_feature="converge.super",
+        used=93,
+        total=1000,
+        used_licenses=[
+            {"booked": 29, "user_name": "jbemfv", "lead_host": "myserver.example.com"},
+            {"booked": 27, "user_name": "cdxfdn", "lead_host": "myserver.example.com"},
+            {"booked": 37, "user_name": "jbemfv", "lead_host": "myserver.example.com"},
+        ],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
+async def test_rlm_get_report_item_with_no_used_licenses(
+    get_output_from_server_mock: mock.MagicMock, rlm_server, rlm_output_no_licenses
+):
+    get_output_from_server_mock.return_value = rlm_output_no_licenses
+
+    assert await rlm_server.get_report_item("converge.super") == LicenseReportItem(
+        product_feature="converge.super",
+        used=0,
+        total=1000,
+        used_licenses=[],
+    )

--- a/agent/tests/server_interfaces/test_rlm.py
+++ b/agent/tests/server_interfaces/test_rlm.py
@@ -1,3 +1,4 @@
+"""Test the RLM license server interface."""
 from unittest import mock
 
 from pytest import fixture, mark


### PR DESCRIPTION
#### What
Remove License Server Interfaces from tokenstat, creating modules for each one.
Also add debugging logs to tokenstat.

#### Why
All the license servers were cluttered in tokenstat, making it difficult to add a new interface.