### PR TITLE
Add type hint, docstring and more tests for the server interfaces

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Add LS-Dyna license server support
 
 2.2.3 - 2022-02-09
 * Fixed permission error when accessing cached token 

--- a/agent/lm_agent/server_interfaces/lsdyna.py
+++ b/agent/lm_agent/server_interfaces/lsdyna.py
@@ -53,7 +53,7 @@ class LSDynaLicenseServer(LicenseServerInterface):
 
         # raise exception if parser didn't output license information
         if current_feature_item is None:
-            raise LicenseManagerBadServerOutput()
+            raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
 
         report_item = LicenseReportItem(
             product_feature=product_feature,

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -55,7 +55,7 @@ class RLMLicenseServer(LicenseServerInterface):
 
         # raise exception if parser didn't output license information
         if current_feature_item is None or used_licenses is None:
-            raise LicenseManagerBadServerOutput()
+            raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
 
         report_item = LicenseReportItem(
             product_feature=product_feature,

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -133,6 +133,26 @@ def lmstat_output_no_licenses():
 
 
 @fixture
+def rlm_output_bad():
+    """
+    Some unparseable lmstat output
+    """
+    return dedent(
+        """\
+        rlmutil v12.2
+        Copyright (C) 2006-2017, Reprise Software, Inc. All rights reserved.
+
+
+        Error connecting to "rlm" server
+
+        Connection attempted to host: "" on port 5053
+
+        No error
+        """
+    )
+
+
+@fixture
 def rlm_output():
     """
     Some rlm output to parse

--- a/agent/tests/server_interfaces/test_flexlm.py
+++ b/agent/tests/server_interfaces/test_flexlm.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from pytest import fixture, mark, raises
 
+from lm_agent.backend_utils import BackendConfigurationRow
 from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.server_interfaces.flexlm import FlexLMLicenseServer
@@ -11,11 +12,11 @@ from lm_agent.server_interfaces.license_server_interface import LicenseReportIte
 
 
 @fixture
-def flexlm_server(one_configuration_row_flexlm):
+def flexlm_server(one_configuration_row_flexlm: BackendConfigurationRow) -> FlexLMLicenseServer:
     return FlexLMLicenseServer(one_configuration_row_flexlm.license_servers)
 
 
-def test_get_flexlm_commands_list(flexlm_server):
+def test_get_flexlm_commands_list(flexlm_server: FlexLMLicenseServer):
     """
     Do the commands for invoking the license server have the correct data?
     """
@@ -27,8 +28,8 @@ def test_get_flexlm_commands_list(flexlm_server):
 @mock.patch("lm_agent.server_interfaces.flexlm.run_command")
 async def test_flexlm_get_output_from_server(
     run_command_mock: mock.MagicMock,
-    flexlm_server,
-    lmstat_output,
+    flexlm_server: FlexLMLicenseServer,
+    lmstat_output: str,
 ):
     """
     Do the license server interface return the output from the license server?
@@ -42,7 +43,7 @@ async def test_flexlm_get_output_from_server(
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output
+    get_output_from_server_mock: mock.MagicMock, flexlm_server: FlexLMLicenseServer, lmstat_output: str
 ):
     """
     Do the FlexLM server interface generate a report item for the product?
@@ -64,8 +65,11 @@ async def test_flexlm_get_report_item(
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item_with_bad_output(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output_bad
+    get_output_from_server_mock: mock.MagicMock, flexlm_server: FlexLMLicenseServer, lmstat_output_bad: str
 ):
+    """
+    Do the FlexLM server interface raise an exception when the server returns an unparseable output?
+    """
     get_output_from_server_mock.return_value = lmstat_output_bad
 
     with raises(LicenseManagerBadServerOutput):
@@ -75,8 +79,13 @@ async def test_flexlm_get_report_item_with_bad_output(
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item_with_no_used_licenses(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server, lmstat_output_no_licenses
+    get_output_from_server_mock: mock.MagicMock,
+    flexlm_server: FlexLMLicenseServer,
+    lmstat_output_no_licenses: str,
 ):
+    """
+    Do the FlexLM server interface generate a report item when no licenses are in use?
+    """
     get_output_from_server_mock.return_value = lmstat_output_no_licenses
 
     assert await flexlm_server.get_report_item("testproduct.testfeature") == LicenseReportItem(

--- a/agent/tests/server_interfaces/test_lsdyna.py
+++ b/agent/tests/server_interfaces/test_lsdyna.py
@@ -64,6 +64,20 @@ async def test_lsdyna_get_report_item(
 
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.lsdyna.LSDynaLicenseServer.get_output_from_server")
+async def test_lsdyna_get_report_item_with_bad_output(
+    get_output_from_server_mock: mock.MagicMock, lsdyna_server: LSDynaLicenseServer, lsdyna_output_bad: str
+):
+    """
+    Do the LS-Dyna server interface raise an exception when the server returns an unparseable output?
+    """
+    get_output_from_server_mock.return_value = lsdyna_output_bad
+
+    with raises(LicenseManagerBadServerOutput):
+        await lsdyna_server.get_report_item("mppdyna.mppdyna")
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.lsdyna.LSDynaLicenseServer.get_output_from_server")
 async def test_lsdyna_get_report_item_with_no_used_licenses(
     get_output_from_server_mock: mock.MagicMock,
     lsdyna_server: LSDynaLicenseServer,

--- a/agent/tests/server_interfaces/test_lsdyna.py
+++ b/agent/tests/server_interfaces/test_lsdyna.py
@@ -1,15 +1,17 @@
 """Test the LS-Dyna license server interface."""
 from unittest import mock
 
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 
+from lm_agent.backend_utils import BackendConfigurationRow
 from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
 from lm_agent.server_interfaces.lsdyna import LSDynaLicenseServer
 
 
 @fixture
-def lsdyna_server(one_configuration_row_lsdyna: str) -> LSDynaLicenseServer:
+def lsdyna_server(one_configuration_row_lsdyna: BackendConfigurationRow) -> LSDynaLicenseServer:
     return LSDynaLicenseServer(one_configuration_row_lsdyna.license_servers)
 
 
@@ -83,6 +85,9 @@ async def test_lsdyna_get_report_item_with_no_used_licenses(
     lsdyna_server: LSDynaLicenseServer,
     lsdyna_output_no_licenses: str,
 ):
+    """
+    Do the LS-Dyna server interface generate a report item when no licenses are in use?
+    """
     get_output_from_server_mock.return_value = lsdyna_output_no_licenses
 
     assert await lsdyna_server.get_report_item("mppdyna.mppdyna") == LicenseReportItem(

--- a/agent/tests/server_interfaces/test_rlm.py
+++ b/agent/tests/server_interfaces/test_rlm.py
@@ -1,19 +1,21 @@
 """Test the RLM license server interface."""
 from unittest import mock
 
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 
+from lm_agent.backend_utils import BackendConfigurationRow
 from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
 from lm_agent.server_interfaces.rlm import RLMLicenseServer
 
 
 @fixture
-def rlm_server(one_configuration_row_rlm):
+def rlm_server(one_configuration_row_rlm: BackendConfigurationRow):
     return RLMLicenseServer(one_configuration_row_rlm.license_servers)
 
 
-def test_get_rlm_commands_list(rlm_server):
+def test_get_rlm_commands_list(rlm_server: RLMLicenseServer):
     """
     Do the commands for invoking the license server have the correct data?
     """
@@ -25,8 +27,8 @@ def test_get_rlm_commands_list(rlm_server):
 @mock.patch("lm_agent.server_interfaces.rlm.run_command")
 async def test_rlm_get_output_from_server(
     run_command_mock: mock.MagicMock,
-    rlm_server,
-    rlm_output,
+    rlm_server: RLMLicenseServer,
+    rlm_output: str,
 ):
     """
     Do the license server interface return the output from the license server?
@@ -39,7 +41,9 @@ async def test_rlm_get_output_from_server(
 
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
-async def test_rlm_get_report_item(get_output_from_server_mock: mock.MagicMock, rlm_server, rlm_output):
+async def test_rlm_get_report_item(
+    get_output_from_server_mock: mock.MagicMock, rlm_server: RLMLicenseServer, rlm_output: str
+):
     """
     Do the RLM server interface generate a report item for the product?
     """
@@ -74,8 +78,11 @@ async def test_rlm_get_report_item_with_bad_output(
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
 async def test_rlm_get_report_item_with_no_used_licenses(
-    get_output_from_server_mock: mock.MagicMock, rlm_server, rlm_output_no_licenses
+    get_output_from_server_mock: mock.MagicMock, rlm_server: RLMLicenseServer, rlm_output_no_licenses: str
 ):
+    """
+    Do the RLM server interface generate a report item when no licenses are in use?
+    """
     get_output_from_server_mock.return_value = rlm_output_no_licenses
 
     assert await rlm_server.get_report_item("converge.super") == LicenseReportItem(

--- a/agent/tests/server_interfaces/test_rlm.py
+++ b/agent/tests/server_interfaces/test_rlm.py
@@ -59,6 +59,20 @@ async def test_rlm_get_report_item(get_output_from_server_mock: mock.MagicMock, 
 
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
+async def test_rlm_get_report_item_with_bad_output(
+    get_output_from_server_mock: mock.MagicMock, rlm_server: RLMLicenseServer, lsdyna_output_bad: str
+):
+    """
+    Do the RLM server interface raise an exception when the server returns an unparseable output?
+    """
+    get_output_from_server_mock.return_value = lsdyna_output_bad
+
+    with raises(LicenseManagerBadServerOutput):
+        await rlm_server.get_report_item("converge.super")
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
 async def test_rlm_get_report_item_with_no_used_licenses(
     get_output_from_server_mock: mock.MagicMock, rlm_server, rlm_output_no_licenses
 ):


### PR DESCRIPTION
#### What
Add tests to ensure that an exception will be raised when the parser returns an unparseable output.
Also add type hint and dosctrings to all tests that were missing them.

#### Why
To make sure the tests are following our code standards.