### PR TITLE
LM-178 Fixed token caching mechanism to use home directory

### DIFF
--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -11,7 +11,6 @@ logger = logging.getLogger("lm_agent.config")
 
 
 DEFAULT_DOTENV_PATH = Path("/etc/default/license-manager-agent")
-DEFAULT_CACHE_DIR = Path("/run/license-manager-agent/")
 PRODUCT_FEATURE_RX = r"^.+?\..+$"
 ENCODING = "UTF8"
 TOOL_TIMEOUT = 6  # seconds
@@ -85,9 +84,6 @@ class Settings(BaseSettings):
     AUTH0_AUDIENCE: str
     AUTH0_CLIENT_ID: str
     AUTH0_CLIENT_SECRET: str
-
-    # Token cache directory
-    CACHE_DIR: Path = DEFAULT_CACHE_DIR
 
     class Config:
         env_prefix = "LM2_AGENT_"

--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -11,6 +11,7 @@ logger = logging.getLogger("lm_agent.config")
 
 
 DEFAULT_DOTENV_PATH = Path("/etc/default/license-manager-agent")
+DEFAULT_CACHE_DIR = Path.home() / Path(".cache/license-manager")
 PRODUCT_FEATURE_RX = r"^.+?\..+$"
 ENCODING = "UTF8"
 TOOL_TIMEOUT = 6  # seconds
@@ -84,6 +85,9 @@ class Settings(BaseSettings):
     AUTH0_AUDIENCE: str
     AUTH0_CLIENT_ID: str
     AUTH0_CLIENT_SECRET: str
+
+    # Token cache directory
+    CACHE_DIR: Path = DEFAULT_CACHE_DIR
 
     class Config:
         env_prefix = "LM2_AGENT_"

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -45,6 +45,7 @@ env = [
     "LM2_AGENT_BACKEND_BASE_URL = http://backend",
     "LM2_AGENT_LMUTIL_PATH = ./tests/mock_tools",
     "LM2_AGENT_RLMUTIL_PATH = ./tests/mock_tools",
+    "LM2_AGENT_LOG_LEVEL = DEBUG",
 ]
 
 [tool.black]

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -17,10 +17,9 @@ MOCK_BIN_PATH = Path(__file__).parent / "mock_tools"
 
 @fixture(autouse=True)
 def mock_cache_dir(tmp_path):
-    tmp_path.chmod(0o777)
-    _cache_dir = tmp_path / ".cache/license-manager"
+    _cache_dir = tmp_path / "license-manager-cache"
     assert not _cache_dir.exists()
-    with patch("lm_agent.backend_utils._get_cache_dir", return_value=_cache_dir):
+    with patch("lm_agent.config.settings.CACHE_DIR", new=_cache_dir):
         yield _cache_dir
 
 

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -17,8 +17,10 @@ MOCK_BIN_PATH = Path(__file__).parent / "mock_tools"
 
 @fixture(autouse=True)
 def mock_cache_dir(tmp_path):
+    tmp_path.chmod(0o777)
     _cache_dir = tmp_path / ".cache/license-manager"
-    with patch("lm_agent.backend_utils.settings.CACHE_DIR", new=_cache_dir):
+    assert not _cache_dir.exists()
+    with patch("lm_agent.backend_utils._get_cache_dir", return_value=_cache_dir):
         yield _cache_dir
 
 
@@ -310,7 +312,7 @@ def lsdyna_output_bad():
     return dedent(
         """\
 		Using default server 31010@localhost
-		*** ERROR failed to open server localhost			
+		*** ERROR failed to open server localhost
 		"""
     )
 


### PR DESCRIPTION
#### What
Adjusted token caching code to use the current user's home directory.

#### Why
The agent was having issues with root and the slurm user both trying to use the same token.

`Task`: https://app.clickup.com/t/18022949/LM-178

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
