### PR TITLE
Prepared release agent 2.2.4

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,9 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+
+2.2.4 -- 2022-03-03
+-------------------
 * Add LS-Dyna license server support
 
 2.2.3 - 2022-02-09

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.2.3"
+version = "2.2.4"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Release 2.2.4 version of the license-manager-agent.

#### Why
To update the version for the staging deploy.