### PR TITLE
Update parsers to output feature name in lowercase

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Fixed parsers to output feature name in lowercase
 
 2.2.4 -- 2022-03-03
 -------------------

--- a/agent/lm_agent/parsing/flexlm.py
+++ b/agent/lm_agent/parsing/flexlm.py
@@ -59,7 +59,7 @@ def parse(s: str) -> dict:
             parsed_data["total"] = {
                 "total": int(d["total"]),
                 "used": int(d["used"]),
-                "feature": d["feature"],
+                "feature": d["feature"].lower(),
             }
         if parsed.group("user"):
             d = parsed.groupdict()

--- a/agent/lm_agent/parsing/lmx.py
+++ b/agent/lm_agent/parsing/lmx.py
@@ -32,7 +32,7 @@ def parse_feature_line(line: str) -> Optional[str]:
         return None
     feature_data = parsed_feature.groupdict()
 
-    return feature_data["feature"]
+    return feature_data["feature"].lower()
 
 
 def parse_in_use_line(line: str) -> Optional[dict]:

--- a/agent/lm_agent/parsing/rlm.py
+++ b/agent/lm_agent/parsing/rlm.py
@@ -50,7 +50,7 @@ def parse(s: str) -> dict:
                     "user_name": total_data["user_name"],
                     "lead_host": total_data["lead_host"],
                     "booked": int(total_data["license_used_by_host"]),
-                    "feature": total_data["license_feature"],
+                    "feature": total_data["license_feature"].lower(),
                 }
             )
         elif parsed_data:
@@ -61,7 +61,7 @@ def parse(s: str) -> dict:
             data_data = parsed_data.groupdict()
             parsed_dict["total"].append(
                 {
-                    "feature": data_data["license_feature"],
+                    "feature": data_data["license_feature"].lower(),
                     "total": int(count_data["count"]),
                     "used": int(count_data["in_use"]),
                 }

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -78,8 +78,8 @@ def one_configuration_row_lsdyna():
 @fixture
 def one_configuration_row_lmx():
     return BackendConfigurationRow(
-        product="HyperWorks",
-        features={"HyperWorks": 1000000},
+        product="hyperworks",
+        features={"hyperworks": 1000000},
         license_servers=["lmx:127.0.0.1:2345"],
         license_server_type="lmx",
         grace_time=10000,

--- a/agent/tests/parsing/test_flexlm.py
+++ b/agent/tests/parsing/test_flexlm.py
@@ -12,7 +12,7 @@ from lm_agent.parsing.flexlm import parse
         (
             "lmstat_output",
             {
-                "total": {"feature": "TESTFEATURE", "total": 1000, "used": 93},
+                "total": {"feature": "testfeature", "total": 1000, "used": 93},
                 "uses": [
                     {"booked": 29, "lead_host": "myserver.example.com", "user_name": "jbemfv"},
                     {"booked": 27, "lead_host": "myserver.example.com", "user_name": "cdxfdn"},

--- a/agent/tests/parsing/test_lmx.py
+++ b/agent/tests/parsing/test_lmx.py
@@ -14,9 +14,9 @@ def test_parse_feature_line():
     - vendor
     From these, we only need to extract ``feature``.
     """
-    assert parse_feature_line("Feature: CatiaV5Reader Version: 21.0 Vendor: ALTAIR") == "CatiaV5Reader"
-    assert parse_feature_line("Feature: GlobalZoneEU Version: 21.0 Vendor: ALTAIR") == "GlobalZoneEU"
-    assert parse_feature_line("Feature: HWAIFPBS Version: 21.0 Vendor: ALTAIR") == "HWAIFPBS"
+    assert parse_feature_line("Feature: CatiaV5Reader Version: 21.0 Vendor: ALTAIR") == "catiav5reader"
+    assert parse_feature_line("Feature: GlobalZoneEU Version: 21.0 Vendor: ALTAIR") == "globalzoneeu"
+    assert parse_feature_line("Feature: HWAIFPBS Version: 21.0 Vendor: ALTAIR") == "hwaifpbs"
     assert parse_feature_line("not a feature line") is None
     assert parse_feature_line("Version: 21.0 Vendor: ALTAIR") is None
     assert parse_feature_line("") is None
@@ -75,8 +75,8 @@ def test_parse__correct_output(lmx_output):
     which contain licenses and usage information.
     """
     assert parse(lmx_output) == {
-        "CatiaV5Reader": {"total": 3, "used": 0, "uses": []},
-        "GlobalZoneEU": {
+        "catiav5reader": {"total": 3, "used": 0, "uses": []},
+        "globalzoneeu": {
             "total": 1000003,
             "used": 40000,
             "uses": [
@@ -84,10 +84,10 @@ def test_parse__correct_output(lmx_output):
                 {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 25000},
             ],
         },
-        "HWAIFPBS": {"total": 2147483647, "used": 0, "uses": []},
-        "HWAWPF": {"total": 2147483647, "used": 0, "uses": []},
-        "HWActivate": {"total": 2147483647, "used": 0, "uses": []},
-        "HWFlux2D": {
+        "hwaifpbs": {"total": 2147483647, "used": 0, "uses": []},
+        "hwawpf": {"total": 2147483647, "used": 0, "uses": []},
+        "hwactivate": {"total": 2147483647, "used": 0, "uses": []},
+        "hwflux2d": {
             "total": 2147483647,
             "used": 30000,
             "uses": [
@@ -95,7 +95,7 @@ def test_parse__correct_output(lmx_output):
                 {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
             ],
         },
-        "HyperWorks": {
+        "hyperworks": {
             "total": 1000000,
             "used": 25000,
             "uses": [
@@ -121,11 +121,11 @@ def test_parse__no_licenses_output(lmx_output_no_licenses):
     when none of the licenses are in use by users.
     """
     assert parse(lmx_output_no_licenses) == {
-        "CatiaV5Reader": {"total": 3, "used": 0, "uses": []},
-        "GlobalZoneEU": {"total": 1000003, "used": 0, "uses": []},
-        "HWAIFPBS": {"total": 2147483647, "used": 0, "uses": []},
-        "HWAWPF": {"total": 2147483647, "used": 0, "uses": []},
-        "HWActivate": {"total": 2147483647, "used": 0, "uses": []},
-        "HWFlux2D": {"total": 2147483647, "used": 0, "uses": []},
-        "HyperWorks": {"total": 1000000, "used": 0, "uses": []},
+        "catiav5reader": {"total": 3, "used": 0, "uses": []},
+        "globalzoneeu": {"total": 1000003, "used": 0, "uses": []},
+        "hwaifpbs": {"total": 2147483647, "used": 0, "uses": []},
+        "hwawpf": {"total": 2147483647, "used": 0, "uses": []},
+        "hwactivate": {"total": 2147483647, "used": 0, "uses": []},
+        "hwflux2d": {"total": 2147483647, "used": 0, "uses": []},
+        "hyperworks": {"total": 1000000, "used": 0, "uses": []},
     }

--- a/agent/tests/server_interfaces/test_lmx.py
+++ b/agent/tests/server_interfaces/test_lmx.py
@@ -49,8 +49,8 @@ async def test_lmx_get_report_item(
     """
     get_output_from_server_mock.return_value = lmx_output
 
-    assert await lmx_server.get_report_item("HyperWorks.HyperWorks") == LicenseReportItem(
-        product_feature="HyperWorks.HyperWorks",
+    assert await lmx_server.get_report_item("hyperworks.hyperworks") == LicenseReportItem(
+        product_feature="hyperworks.hyperworks",
         used=25000,
         total=1000000,
         used_licenses=[
@@ -70,7 +70,7 @@ async def test_lmx_get_report_item_with_bad_output(
     get_output_from_server_mock.return_value = lmx_output_bad
 
     with raises(LicenseManagerBadServerOutput):
-        await lmx_server.get_report_item("HyperWorks.HyperWorks")
+        await lmx_server.get_report_item("hyperworks.hyperworks")
 
 
 @mark.asyncio
@@ -85,8 +85,8 @@ async def test_lmx_get_report_item_with_no_used_licenses(
     """
     get_output_from_server_mock.return_value = lmx_output_no_licenses
 
-    assert await lmx_server.get_report_item("HyperWorks.HyperWorks") == LicenseReportItem(
-        product_feature="HyperWorks.HyperWorks",
+    assert await lmx_server.get_report_item("hyperworks.hyperworks") == LicenseReportItem(
+        product_feature="hyperworks.hyperworks",
         used=0,
         total=1000000,
         used_licenses=[],

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -42,7 +42,7 @@ def scontrol_show_lic_output_lsdyna():
 def scontrol_show_lic_output_lmx():
     return dedent(
         """
-        LicenseName=HyperWorks.HyperWorks@lmx
+        LicenseName=hyperworks.hyperworks@lmx
             Total=1000000 Used=0 Free=500 Reserved=0 Remote=yes
         """
     )
@@ -246,7 +246,7 @@ async def test_lsdyna_get_report(
             "lmx_output",
             [
                 {
-                    "product_feature": "HyperWorks.HyperWorks",
+                    "product_feature": "hyperworks.hyperworks",
                     "used": 25000,
                     "total": 1000000,
                     "used_licenses": [
@@ -259,7 +259,7 @@ async def test_lsdyna_get_report(
             "lmx_output_no_licenses",
             [
                 {
-                    "product_feature": "HyperWorks.HyperWorks",
+                    "product_feature": "hyperworks.hyperworks",
                     "used": 0,
                     "total": 1000000,
                     "used_licenses": [],


### PR DESCRIPTION
#### What
Update FlexLM, RLM and LM-X parsers to output the license feature's name in lowercase.

#### Why
Slurm licenses don't hold casing and capitalization, so we need to keep everything in lowercase.