### PR TITLE
Fix command to get feature from product_feature

### DIFF
--- a/agent/lm_agent/server_interfaces/lmx.py
+++ b/agent/lm_agent/server_interfaces/lmx.py
@@ -49,7 +49,9 @@ class LMXLicenseServer(LicenseServerInterface):
         server_output = await self.get_output_from_server()
         parsed_output = self.parser(server_output)
 
-        current_feature_item = parsed_output.get(product_feature.split(".")[0])
+        (_, feature) = product_feature.split(".")
+
+        current_feature_item = parsed_output.get(feature)
 
         # raise exception if parser didn't output license information
         if current_feature_item is None:

--- a/agent/lm_agent/server_interfaces/lsdyna.py
+++ b/agent/lm_agent/server_interfaces/lsdyna.py
@@ -49,7 +49,9 @@ class LSDynaLicenseServer(LicenseServerInterface):
         server_output = await self.get_output_from_server()
         parsed_output = self.parser(server_output)
 
-        current_feature_item = parsed_output.get(product_feature.split(".")[0])
+        (_, feature) = product_feature.split(".")
+
+        current_feature_item = parsed_output.get(feature)
 
         # raise exception if parser didn't output license information
         if current_feature_item is None:

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -48,10 +48,12 @@ class RLMLicenseServer(LicenseServerInterface):
         server_output = await self.get_output_from_server()
         parsed_output = self.parser(server_output)
 
+        (_, feature) = product_feature.split(".")
+        
         current_feature_item = self._filter_current_feature(
-            parsed_output["total"], product_feature.split(".")[1]
+            parsed_output["total"], feature
         )
-        used_licenses = self._filter_used_features(parsed_output["uses"], product_feature.split(".")[1])
+        used_licenses = self._filter_used_features(parsed_output["uses"], feature)
 
         # raise exception if parser didn't output license information
         if current_feature_item is None or used_licenses is None:


### PR DESCRIPTION
#### What
Change server interfaces to correctly get the `feature` from the `product_feature`.

#### Why
We should get the last part of the `product_feature`, in case the product is named differently than the feature.