### PR TITLE
Add flag to control if reconcile is triggered by prolog/epilog 

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 ----------
 * Fixed parsers to output feature name in lowercase
 * Change Prolog and Epilog scripts to get job's license from env var instead of scontrol
+* Add env var to flag if reconciliation should be triggered during Prolog and Epilog scripts execution
 
 2.2.4 -- 2022-03-03
 -------------------

--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -92,7 +92,7 @@ class Settings(BaseSettings):
     # Token cache directory
     CACHE_DIR: Path = DEFAULT_CACHE_DIR
 
-    # Set if reconcile will be triggered by Prolog/Epilog
+    # If set to `True`, reconcile will be triggered by Prolog/Epilog. Set to `False` to disable this.
     USE_RECONCILE_IN_PROLOG_EPILOG: bool = True
 
     class Config:

--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -92,6 +92,9 @@ class Settings(BaseSettings):
     # Token cache directory
     CACHE_DIR: Path = DEFAULT_CACHE_DIR
 
+    # Set if reconcile will be triggered by Prolog/Epilog
+    USE_RECONCILE_IN_PROLOG_EPILOG: bool = True
+
     class Config:
         env_prefix = "LM2_AGENT_"
         if DEFAULT_DOTENV_PATH.is_file():

--- a/agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
+++ b/agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
@@ -5,8 +5,8 @@ The EpilogSlurmctld executable.
 import asyncio
 import sys
 
-from lm_agent.config import settings
 from lm_agent.backend_utils import backend_client
+from lm_agent.config import settings
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import update_report
 from lm_agent.workload_managers.slurm.cmd_utils import get_required_licenses_for_job

--- a/agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
+++ b/agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
@@ -5,6 +5,7 @@ The EpilogSlurmctld executable.
 import asyncio
 import sys
 
+from lm_agent.config import settings
 from lm_agent.backend_utils import backend_client
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import update_report
@@ -30,12 +31,14 @@ async def epilog():
     job_id = job_context["job_id"]
     job_licenses = job_context["job_licenses"]
 
-    # force reconcile
-    try:
-        await update_report()
-    except Exception as e:
-        logger.error(f"Failed to call reconcile with {e}")
-        sys.exit(1)
+    # Check if reconciliation should be triggered.
+    if settings.USE_RECONCILE_IN_PROLOG_EPILOG:
+        # Force a reconciliation before we attempt to remove bookings.
+        try:
+            await update_report()
+        except Exception as e:
+            logger.error(f"Failed to call reconcile with {e}")
+            sys.exit(1)
 
     try:
         required_licenses = get_required_licenses_for_job(job_licenses)

--- a/agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
+++ b/agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
@@ -14,8 +14,8 @@ import asyncio
 import sys
 
 from lm_agent.backend_utils import get_config_from_backend
-from lm_agent.logs import init_logging, logger
 from lm_agent.config import settings
+from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import update_report
 from lm_agent.workload_managers.slurm.cmd_utils import (
     LicenseBookingRequest,

--- a/agent/tests/workload_managers/slurm/test_slurmctld_epilog.py
+++ b/agent/tests/workload_managers/slurm/test_slurmctld_epilog.py
@@ -36,3 +36,40 @@ async def test_epilog(
     update_report_mock.assert_awaited_once()
     get_required_licenses_for_job_mock.assert_called_once_with("test.feature@flexlm:10")
     remove_booking_for_job_mock.assert_awaited_once_with("1")
+
+
+@pytest.mark.asyncio
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_epilog.settings")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_epilog.get_job_context")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_epilog.update_report")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_epilog.get_required_licenses_for_job")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_epilog._remove_booking_for_job")
+async def test_epilog_without_triggering_reconcile(
+    remove_booking_for_job_mock,
+    get_required_licenses_for_job_mock,
+    update_report_mock,
+    get_job_context_mock,
+    settings_mock,
+):
+    bookings_mock = mock.MagicMock()
+    bookings_mock.product_feature = "test.feature"
+    bookings_mock.license_server_type = "flexlm"
+    bookings_mock.tokens = 10
+    get_required_licenses_for_job_mock.return_value = [bookings_mock]
+
+    get_job_context_mock.return_value = {
+        "job_id": "1",
+        "user_name": "user1",
+        "lead_host": "host1",
+        "cluster_name": "cluster1",
+        "job_licenses": "test.feature@flexlm:10",
+    }
+
+    settings_mock.USE_RECONCILE_IN_PROLOG_EPILOG = False
+
+    await epilog()
+
+    get_required_licenses_for_job_mock.assert_called_once_with("test.feature@flexlm:10")
+    remove_booking_for_job_mock.assert_awaited_once_with("1")
+
+    update_report_mock.assert_not_called()

--- a/agent/tests/workload_managers/slurm/test_slurmctld_prolog.py
+++ b/agent/tests/workload_managers/slurm/test_slurmctld_prolog.py
@@ -134,3 +134,50 @@ async def test_main(
     get_required_licenses_for_job_mock.assert_called_once_with("test.feature@flexlm:10")
     update_report_mock.assert_awaited_once()
     make_booking_request_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.sys")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.settings")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.get_job_context")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.get_required_licenses_for_job")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.get_config_from_backend")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.update_report")
+@mock.patch("lm_agent.workload_managers.slurm.slurmctld_prolog.make_booking_request")
+async def test_main_without_triggering_reconciliation(
+    make_booking_request_mock,
+    update_report_mock,
+    get_config_from_backend_mock,
+    get_required_licenses_for_job_mock,
+    get_job_context_mock,
+    settings_mock,
+    sys_mock,
+):
+    get_job_context_mock.return_value = {
+        "job_id": "1",
+        "user_name": "user1",
+        "lead_host": "host1",
+        "cluster_name": "cluster1",
+        "job_licenses": "test.feature@flexlm:10",
+    }
+
+    bookings_mock = mock.MagicMock()
+    bookings_mock.product_feature = "test.feature"
+    bookings_mock.license_server_type = "flexlm"
+    bookings_mock.tokens = 10
+    get_required_licenses_for_job_mock.return_value = [bookings_mock]
+
+    backend_return_mock = mock.MagicMock()
+    backend_return_mock.product = "test"
+    backend_return_mock.features = ["feature"]
+    get_config_from_backend_mock.return_value = [backend_return_mock]
+
+    settings_mock.USE_RECONCILE_IN_PROLOG_EPILOG = False
+
+    await main()
+
+    get_config_from_backend_mock.assert_awaited_once()
+    get_required_licenses_for_job_mock.assert_called_once_with("test.feature@flexlm:10")
+    make_booking_request_mock.assert_awaited_once()
+
+    update_report_mock.assert_not_called()


### PR DESCRIPTION
#### What
Add a env var to flag if reconciliation should be triggered by Prolog/Epilog execution.
The env var can be set via charm config.

#### Why
To be able to run Prolog/Epilog without triggering a forced reconciliation.

`Task`: https://app.clickup.com/t/18022949/LM-190

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
