### PR TITLE
Change token file ownership to slurm user and group

### DIFF
--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -1,6 +1,7 @@
 """
 Provide utilities that communicate with the backend.
 """
+import shutil
 import typing
 
 import httpx
@@ -55,6 +56,7 @@ def _write_token_to_cache(token: str):
     try:
         token_path.touch(mode=0o600, exist_ok=True)
         token_path.write_text(token)
+        shutil.chown(token_path, "slurm", "slurm")
     except Exception as err:
         logger.warning(f"Couldn't save token to {token_path}: {err}")
 


### PR DESCRIPTION
#### What
Change token file ownership to `slurm` user and group.

#### Why
When the token cache file is created during reconcile (which is run by `root`), the file is owned by `root`:

>  /var/cache/license-manager# ls -la
> total 4
> drwx------  2 slurm root    3 Mar 23 01:13 .
> drwxr-xr-x 16 root  root   18 Mar 10 12:09 ..
> -rw-------  1 root  root 1352 Mar 23 01:13 access.token

But when the file is needed during Prolog/Epilog execution (which is run by `slurm` user), it can't be read:

> [2022-03-21 15:13:26,598;WARNING] backend_utils.py:33 - _load_token_from_cache Couldn't load token from cache file /var/cache/license-manager/access.token. Will acquire a new one: [Errno 13] Permission denied: '/var/cache/license-manager/access.token'

Using chown to make `slurm` owner of the file makes it readable during Prolog/Epilog execution:

> /var/cache/license-manager# ls -la
total 4
drwx------  2 slurm root     3 Mar 23 01:22 .
drwxr-xr-x 16 root  root    18 Mar 10 12:09 ..
-rw-------  1 slurm slurm 1352 Mar 23 01:22 access.token

> [2022-03-23 01:37:57,853;DEBUG] backend_utils.py:68 -        acquire_token Attempting to use cached token
[2022-03-23 01:37:57,853;DEBUG] backend_utils.py:89 -        acquire_token Successfully acquired auth token from Auth0