### PR TITLE
Raise exception if Sentry DSN is not set

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Raise explicit exception if Sentry DSN is not set
 
 2.2.5 -- 2022-04-04
 -------------------

--- a/agent/lm_agent/exceptions.py
+++ b/agent/lm_agent/exceptions.py
@@ -27,3 +27,7 @@ class LicenseManagerNonSupportedServerTypeError(Buzz):
 
 class LicenseManagerBadServerOutput(Buzz):
     """Exception for license server bad output."""
+
+
+class LicenseManagerSentryDsnNotSet(Buzz):
+    """Exception for Sentry DSN not set."""

--- a/agent/lm_agent/reconcile.py
+++ b/agent/lm_agent/reconcile.py
@@ -7,15 +7,19 @@ import sentry_sdk
 
 from lm_agent.backend_utils import check_backend_health
 from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerSentryDsnNotSet
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import reconcile
 
-if settings.SENTRY_DSN:
-    sentry_sdk.init(
-        dsn=settings.SENTRY_DSN,
-        sample_rate=typing.cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
-        environment=settings.DEPLOY_ENV,
-    )
+
+if settings.SENTRY_DSN is None:
+    raise LicenseManagerSentryDsnNotSet("Sentry DSN must be set.")
+
+sentry_sdk.init(
+    dsn=settings.SENTRY_DSN,
+    sample_rate=typing.cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
+    environment=settings.DEPLOY_ENV,
+)
 
 
 def begin_logging():

--- a/agent/lm_agent/reconcile.py
+++ b/agent/lm_agent/reconcile.py
@@ -11,7 +11,6 @@ from lm_agent.exceptions import LicenseManagerSentryDsnNotSet
 from lm_agent.logs import init_logging, logger
 from lm_agent.reconciliation import reconcile
 
-
 if settings.SENTRY_DSN is None:
     raise LicenseManagerSentryDsnNotSet("Sentry DSN must be set.")
 


### PR DESCRIPTION
#### What
Raise an exception when the Sentry DSN is not set in the agent charm config.

#### Why
To make it easier to identify when the service crashes because of Sentry DSN not set.

`Task`: https://app.clickup.com/t/18022949/ARMADA-462

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
