### PR TITLE
Fix license config row filtering

### DIFF
--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -47,7 +47,7 @@ def get_local_license_configurations(
         for feature in entry.features.keys():
             if f"{entry.product}.{feature}" in local_licenses:
                 filtered_entries.append(entry)
-                continue
+                break
     return filtered_entries
 
 


### PR DESCRIPTION
#### What
Fix config row filtering in tokenstat.

#### Why
If the config row has more than one feature added in the cluster, the entry is being duplicated.
Breaking the inner for after appending the entry fixes the duplication.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
