### PR TITLE
Add filtering to cluster update response during reconciliation

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,7 +7,11 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 
-2.2.6 -- 2022-03-03
+2.2.7 -- 2022-05-03
+-------------------
+* Filter cluster update response to only update licenses in the cluster
+
+2.2.6 -- 2022-05-03
 -------------------
 * Fixed local licenses filtering
 

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -49,10 +49,8 @@ class RLMLicenseServer(LicenseServerInterface):
         parsed_output = self.parser(server_output)
 
         (_, feature) = product_feature.split(".")
-        
-        current_feature_item = self._filter_current_feature(
-            parsed_output["total"], feature
-        )
+
+        current_feature_item = self._filter_current_feature(parsed_output["total"], feature)
         used_licenses = self._filter_used_features(parsed_output["uses"], feature)
 
         # raise exception if parser didn't output license information

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -12,27 +12,7 @@ from lm_agent.server_interfaces.license_server_interface import LicenseServerInt
 from lm_agent.server_interfaces.lmx import LMXLicenseServer
 from lm_agent.server_interfaces.lsdyna import LSDynaLicenseServer
 from lm_agent.server_interfaces.rlm import RLMLicenseServer
-from lm_agent.workload_managers.slurm.cmd_utils import scontrol_show_lic
-
-
-def get_all_product_features_from_cluster(show_lic_output: str) -> typing.List[str]:
-    """
-    Returns a list of all product.feature in the cluster.
-    """
-    PRODUCT_FEATURE = r"LicenseName=(?P<product>[a-zA-Z0-9_]+)[_\-.](?P<feature>\w+)"
-    RX_PRODUCT_FEATURE = re.compile(PRODUCT_FEATURE)
-
-    parsed_features = []
-    output = show_lic_output.split("\n")
-    for line in output:
-        parsed_line = RX_PRODUCT_FEATURE.match(line)
-        if parsed_line:
-            parsed_data = parsed_line.groupdict()
-            product = parsed_data["product"]
-            feature = parsed_data["feature"]
-            parsed_features.append(f"{product}.{feature}")
-
-    return parsed_features
+from lm_agent.workload_managers.slurm.cmd_utils import get_all_product_features_from_cluster
 
 
 def get_local_license_configurations(
@@ -66,7 +46,7 @@ async def report() -> typing.List[dict]:
     report_items = []
 
     license_configurations = await get_config_from_backend()
-    local_licenses = get_all_product_features_from_cluster(await scontrol_show_lic())
+    local_licenses = await get_all_product_features_from_cluster()
     filtered_entries = get_local_license_configurations(license_configurations, local_licenses)
 
     logger.debug("#### Getting reconciliation report ####")

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -1,7 +1,6 @@
 """
 Invoke license stat tools to build a view of license token counts.
 """
-import re
 import typing
 
 from lm_agent.backend_utils import BackendConfigurationRow, get_config_from_backend

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -267,6 +267,28 @@ async def sacctmgr_modify_resource(product: str, feature: str, num_tokens) -> bo
     return True
 
 
+async def get_all_product_features_from_cluster() -> List[str]:
+    """
+    Returns a list of all product.feature in the cluster.
+    """
+    show_lic_output = await scontrol_show_lic()
+
+    PRODUCT_FEATURE = r"LicenseName=(?P<product>[a-zA-Z0-9_]+)[_\-.](?P<feature>\w+)"
+    RX_PRODUCT_FEATURE = re.compile(PRODUCT_FEATURE)
+
+    parsed_features = []
+    output = show_lic_output.split("\n")
+    for line in output:
+        parsed_line = RX_PRODUCT_FEATURE.match(line)
+        if parsed_line:
+            parsed_data = parsed_line.groupdict()
+            product = parsed_data["product"]
+            feature = parsed_data["feature"]
+            parsed_features.append(f"{product}.{feature}")
+
+    return parsed_features
+
+
 def return_formatted_squeue_out() -> str:
     """
     Call squeue via Popen and return the formatted output.

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.2.6"
+version = "2.2.7"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -365,45 +365,6 @@ async def test_lmx_report_with_empty_backend(
     assert reconcile_list == []
 
 
-@mark.parametrize(
-    "show_lic_output,features_from_cluster",
-    [
-        (
-            dedent(
-                """
-                LicenseName=testproduct1.feature1@flexlm
-                    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
-                """
-            ),
-            ["testproduct1.feature1"],
-        ),
-        (
-            dedent(
-                """
-                LicenseName=product_name.feature_name@flexlm
-                    Total=10 Used=0 Free=10 Reserved=0 Remote=yes
-                """
-            ),
-            ["product_name.feature_name"],
-        ),
-        (
-            dedent(
-                """
-                LicenseName=converge_super@rlm
-                    Total=9 Used=0 Free=9 Reserved=0 Remote=yes
-                LicenseName=converge_tecplot@rlm
-                    Total=45 Used=0 Free=45 Reserved=0 Remote=yes
-                """
-            ),
-            ["converge.super", "converge.tecplot"],
-        ),
-        ("", []),
-    ],
-)
-def test_get_product_features_from_cluster(show_lic_output: str, features_from_cluster: List[str]):
-    assert features_from_cluster == tokenstat.get_all_product_features_from_cluster(show_lic_output)
-
-
 def test_get_local_license_configurations():
     configuration_super = BackendConfigurationRow(
         product="converge",

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -1,5 +1,4 @@
 from textwrap import dedent
-from typing import List
 from unittest import mock
 
 from pytest import fixture, mark
@@ -82,7 +81,7 @@ def scontrol_show_lic_output_lmx():
     ],
 )
 @mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_flexlm_get_report(
     get_config_from_backend_mock: mock.MagicMock,
@@ -152,7 +151,7 @@ async def test_flexlm_get_report(
     ],
 )
 @mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_output_from_server")
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_rlm_get_report(
     get_config_from_backend_mock: mock.MagicMock,
@@ -213,7 +212,7 @@ async def test_rlm_get_report(
     ],
 )
 @mock.patch("lm_agent.server_interfaces.lsdyna.LSDynaLicenseServer.get_output_from_server")
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_lsdyna_get_report(
     get_config_from_backend_mock: mock.MagicMock,
@@ -269,7 +268,7 @@ async def test_lsdyna_get_report(
     ],
 )
 @mock.patch("lm_agent.server_interfaces.lmx.LMXLicenseServer.get_output_from_server")
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_lmx_get_report(
     get_config_from_backend_mock: mock.MagicMock,
@@ -295,7 +294,7 @@ async def test_lmx_get_report(
 
 
 @mark.asyncio
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_flexlm_report_with_empty_backend(
     get_config_from_backend_mock: mock.MagicMock,
@@ -313,7 +312,7 @@ async def test_flexlm_report_with_empty_backend(
 
 
 @mark.asyncio
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_rlm_report_with_empty_backend(
     get_config_from_backend_mock: mock.MagicMock,
@@ -331,7 +330,7 @@ async def test_rlm_report_with_empty_backend(
 
 
 @mark.asyncio
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_lsdyna_report_with_empty_backend(
     get_config_from_backend_mock: mock.MagicMock,
@@ -349,7 +348,7 @@ async def test_lsdyna_report_with_empty_backend(
 
 
 @mark.asyncio
-@mock.patch("lm_agent.tokenstat.scontrol_show_lic")
+@mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
 @mock.patch("lm_agent.tokenstat.get_config_from_backend")
 async def test_lmx_report_with_empty_backend(
     get_config_from_backend_mock: mock.MagicMock,


### PR DESCRIPTION
#### What
Create a function to filter the `cluster_update` endpoint response to only update licenses available in the cluster.
Also move function to get local licenses to the `cmd_utils module`, since it interacts with scontrol.

#### Why
The reconciliation was trying to update licenses that don't exist in the cluster.

`Task`: https://app.clickup.com/t/18022949/ARMADA-516

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
