### PR TITLE
Change docker-compose to use 'postgresql' instead of 'postgres'

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Update docker-compose to use postgresql instead of postgres
 
 2.2.5 -- 2022-04-12
 -------------------

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -23,7 +23,6 @@ services:
       - ./lm_backend:/app/lm_backend
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:123@postgres-back:5432/postgres}
-      DATABASE_URL: ${DATABASE_URL:-postgres://postgres:123@postgres-back:5432/postgres}
       ARMASEC_DOMAIN: ${ARMASEC_DOMAIN}
       ARMASEC_AUDIENCE: ${ARMASEC_AUDIENCE}
       ARMASEC_DEBUG: ${ARMASEC_DEBUG}

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
     volumes:
       - ./lm_backend:/app/lm_backend
     environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:123@postgres-back:5432/postgres}
       DATABASE_URL: ${DATABASE_URL:-postgres://postgres:123@postgres-back:5432/postgres}
       ARMASEC_DOMAIN: ${ARMASEC_DOMAIN}
       ARMASEC_AUDIENCE: ${ARMASEC_AUDIENCE}


### PR DESCRIPTION
#### What
Change the database URL in `docker-compose` to use `'postgresql'`.

#### Why
The support for `'postgres'` was dropped from SQLAlchemy.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
