### PR TITLE
Fix RLM integration to use correct feature name

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Update RLM integration to use the same feature name displayed in the license server
 
 2.2.7 -- 2022-05-03
 -------------------

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -71,23 +71,9 @@ class RLMLicenseServer(LicenseServerInterface):
         The output from the RLM server returns information about all the licenses
         in the server. This function filters the output to return only the information
         about the feature we want.
-
-        Also, the output from the RLM server returns only a ``feature`` identifier,
-        which can be the ``product`` and the ``feature`` concatenated.
-        To extract the ``feature``, we check if it has more than one word concatenated with ``_``.
-        If so, we consider the first word as the ``product`` and the rest as the ``feature``.
-        If it's only one word, we consider it as both the ``product`` and the ``feature``.
-
-        Example:
-        "converge" -> "converge.converge"
-        "converge_super" -> "converge.super"
-        "converge_gui_polygonica" -> "converge.gui_polygonica"
         """
         for feature_item in parsed_list:
-            if feature_item["feature"].count("_") == 0:
-                if feature_item["feature"] == feature:
-                    return feature_item
-            elif "_".join(feature_item["feature"].split("_")[1:]) == feature:
+            if feature_item["feature"] == feature:
                 return feature_item
 
     def _filter_used_features(self, parsed_list, feature):
@@ -95,24 +81,10 @@ class RLMLicenseServer(LicenseServerInterface):
         The output from the RLM server returns information about all the licenses
         that are in use. This function filters the output to return only the information
         about the usage of the feature we want.
-
-        Also, the output from the RLM server returns only a ``feature`` identifier,
-        which can be the ``product`` and the ``feature`` concatenated.
-        To extract the ``feature``, we check if it has more than one word concatenated with ``_``.
-        If so, we consider the first word as the ``product`` and the rest as the ``feature``.
-        If it's only one word, we consider it as both the ``product`` and the ``feature``.
-
-        Example:
-        "converge" -> "converge.converge"
-        "converge_super" -> "converge.super"
-        "converge_gui_polygonica" -> "converge.gui_polygonica"
         """
         used_licenses = []
         for feature_booked in parsed_list:
-            if feature_booked["feature"].count("_") == 0:
-                if feature_booked["feature"] == feature:
-                    used_licenses.append(feature_booked)
-            elif "_".join(feature_booked["feature"].split("_")[1:]) == feature:
+            if feature_booked["feature"] == feature:
                 used_licenses.append(feature_booked)
 
         for license in used_licenses:

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -57,7 +57,7 @@ def one_configuration_row_flexlm():
 def one_configuration_row_rlm():
     return BackendConfigurationRow(
         product="converge",
-        features={"super": 10},
+        features={"converge_super": 10},
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,

--- a/agent/tests/server_interfaces/test_rlm.py
+++ b/agent/tests/server_interfaces/test_rlm.py
@@ -49,8 +49,8 @@ async def test_rlm_get_report_item(
     """
     get_output_from_server_mock.return_value = rlm_output
 
-    assert await rlm_server.get_report_item("converge.super") == LicenseReportItem(
-        product_feature="converge.super",
+    assert await rlm_server.get_report_item("converge.converge_super") == LicenseReportItem(
+        product_feature="converge.converge_super",
         used=93,
         total=1000,
         used_licenses=[
@@ -72,7 +72,7 @@ async def test_rlm_get_report_item_with_bad_output(
     get_output_from_server_mock.return_value = lsdyna_output_bad
 
     with raises(LicenseManagerBadServerOutput):
-        await rlm_server.get_report_item("converge.super")
+        await rlm_server.get_report_item("converge.converge_super")
 
 
 @mark.asyncio
@@ -85,8 +85,8 @@ async def test_rlm_get_report_item_with_no_used_licenses(
     """
     get_output_from_server_mock.return_value = rlm_output_no_licenses
 
-    assert await rlm_server.get_report_item("converge.super") == LicenseReportItem(
-        product_feature="converge.super",
+    assert await rlm_server.get_report_item("converge.converge_super") == LicenseReportItem(
+        product_feature="converge.converge_super",
         used=0,
         total=1000,
         used_licenses=[],

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -376,7 +376,7 @@ def test_get_local_license_configurations():
 
     configuration_polygonica = BackendConfigurationRow(
         product="converge",
-        features={"converge_polygonica": 10},
+        features={"converge_gui_polygonica": 10},
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -21,7 +21,7 @@ def scontrol_show_lic_output_flexlm():
 def scontrol_show_lic_output_rlm():
     return dedent(
         """
-        LicenseName=converge.super@rlm
+        LicenseName=converge.converge_super@rlm
             Total=10 Used=0 Free=10 Reserved=0 Remote=yes
         """
     )
@@ -114,7 +114,7 @@ async def test_flexlm_get_report(
             "rlm_output",
             [
                 {
-                    "product_feature": "converge.super",
+                    "product_feature": "converge.converge_super",
                     "used": 93,
                     "total": 1000,
                     "used_licenses": [
@@ -141,7 +141,7 @@ async def test_flexlm_get_report(
             "rlm_output_no_licenses",
             [
                 {
-                    "product_feature": "converge.super",
+                    "product_feature": "converge.converge_super",
                     "used": 0,
                     "total": 1000,
                     "used_licenses": [],
@@ -368,7 +368,7 @@ async def test_lmx_report_with_empty_backend(
 def test_get_local_license_configurations():
     configuration_super = BackendConfigurationRow(
         product="converge",
-        features={"super": 10},
+        features={"converge_super": 10},
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
@@ -376,14 +376,14 @@ def test_get_local_license_configurations():
 
     configuration_polygonica = BackendConfigurationRow(
         product="converge",
-        features={"polygonica": 10},
+        features={"converge_polygonica": 10},
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
     )
 
     license_configurations = [configuration_super, configuration_polygonica]
-    local_licenses = ["converge.super"]
+    local_licenses = ["converge.converge_super"]
 
     assert tokenstat.get_local_license_configurations(license_configurations, local_licenses) == [
         configuration_super


### PR DESCRIPTION
#### What
Fix RLM integration to use the same feature name displayed in the license server.

#### Why
To follow the standard used in all the other integrations.

`Task`: https://app.clickup.com/t/18022949/ARMADA-477
---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
