### PR TITLE
Add async gather to run license server checks in parallel

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,7 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
-* Add async calls to license servers to fetch informationn in parallel
+* Implement async calls to license servers to fetch information in parallel
 
 2.2.8 -- 2022-05-16
 -------------------

--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Add async calls to license servers to fetch informationn in parallel
 
 2.2.8 -- 2022-05-16
 -------------------

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -85,15 +85,15 @@ async def report() -> typing.List[dict]:
         for product_feature in product_features_to_check:
             get_report_awaitables.append(license_server_interface.get_report_item(product_feature))
 
-        results = await asyncio.gather(*get_report_awaitables, return_exceptions=True)
+    results = await asyncio.gather(*get_report_awaitables, return_exceptions=True)
 
-        for product_feature, result in zip(product_features_to_check, results):
-            if isinstance(result, Exception):
-                formatted = traceback.format_exception(type(result), result, result.__traceback__)
-                logger.error(f"#### Report for feature {product_feature} failed! ####")
-                logger.error("".join(formatted))
-            else:
-                report_items.append(result)
+    for product_feature, result in zip(product_features_to_check, results):
+        if isinstance(result, Exception):
+            formatted = traceback.format_exception(type(result), result, result.__traceback__)
+            logger.error(f"#### Report for feature {product_feature} failed! ####")
+            logger.error("".join(formatted))
+        else:
+            report_items.append(result)
 
     reconciliation = [item.dict() for item in report_items]
     logger.debug("#### Reconciliation items:")

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -2,7 +2,6 @@
 Invoke license stat tools to build a view of license token counts.
 """
 import asyncio
-import traceback
 import typing
 
 from lm_agent.backend_utils import BackendConfigurationRow, get_config_from_backend
@@ -91,10 +90,7 @@ async def report() -> typing.List[dict]:
 
     for result, product_feature in zip(results, product_features_awaited):
         if isinstance(result, Exception):
-            formatted = traceback.format_exception(type(result), result, result.__traceback__)
-            logger.error(f"#### Report for feature {product_feature} failed! ####")
-            logger.error("#### Traceback: ####")
-            logger.error("".join(formatted))
+            logger.error(f"#### Report for feature {product_feature} failed with: {result} ####")
         else:
             report_items.append(result)
 

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -1,10 +1,12 @@
 """
 Invoke license stat tools to build a view of license token counts.
 """
+import asyncio
+import traceback
 import typing
 
 from lm_agent.backend_utils import BackendConfigurationRow, get_config_from_backend
-from lm_agent.exceptions import LicenseManagerBadServerOutput, LicenseManagerNonSupportedServerTypeError
+from lm_agent.exceptions import LicenseManagerNonSupportedServerTypeError
 from lm_agent.logs import logger
 from lm_agent.server_interfaces.flexlm import FlexLMLicenseServer
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
@@ -43,6 +45,7 @@ async def report() -> typing.List[dict]:
     license server database.
     """
     report_items = []
+    get_report_awaitables = []
 
     license_configurations = await get_config_from_backend()
     local_licenses = await get_all_product_features_from_cluster()
@@ -80,12 +83,17 @@ async def report() -> typing.List[dict]:
         license_server_interface = server_type(entry.license_servers)
 
         for product_feature in product_features_to_check:
-            try:
-                report_item = await license_server_interface.get_report_item(product_feature)
-                report_items.append(report_item)
-            except LicenseManagerBadServerOutput:
+            get_report_awaitables.append(license_server_interface.get_report_item(product_feature))
+
+        results = await asyncio.gather(*get_report_awaitables, return_exceptions=True)
+
+        for product_feature, result in zip(product_features_to_check, results):
+            if isinstance(result, Exception):
+                formatted = traceback.format_exception(type(result), result, result.__traceback__)
                 logger.error(f"#### Report for feature {product_feature} failed! ####")
-                continue
+                logger.error("".join(formatted))
+            else:
+                report_items.append(result)
 
     reconciliation = [item.dict() for item in report_items]
     logger.debug("#### Reconciliation items:")


### PR DESCRIPTION
#### What
Refactor the tokenstat module to use asyncronous calls to run license server checks in parallel.

#### Why
To make the code more efficient and faster.

`Task`: https://app.clickup.com/t/18022949/ARMADA-498

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
