### PR TITLE
Add client_id field to backend config row schema

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 * Implement async calls to license servers to fetch information in parallel
+* Update backend configuration row schema to include new client_id field
 
 2.2.8 -- 2022-05-16
 -------------------

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -159,6 +159,7 @@ class BackendConfigurationRow(BaseModel):
     license_servers: typing.List[str]
     license_server_type: str
     grace_time: int
+    client_id: str
 
 
 class BackendBookingRow(BaseModel):

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -50,6 +50,7 @@ def one_configuration_row_flexlm():
         license_servers=["flexlm:127.0.0.1:2345"],
         license_server_type="flexlm",
         grace_time=10000,
+        client_id="cluster-staging",
     )
 
 
@@ -61,6 +62,7 @@ def one_configuration_row_rlm():
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
+        client_id="cluster-staging",
     )
 
 
@@ -72,6 +74,7 @@ def one_configuration_row_lsdyna():
         license_servers=["lsdyna:127.0.0.1:2345"],
         license_server_type="lsdyna",
         grace_time=10000,
+        client_id="cluster-staging",
     )
 
 
@@ -83,6 +86,7 @@ def one_configuration_row_lmx():
         license_servers=["lmx:127.0.0.1:2345"],
         license_server_type="lmx",
         grace_time=10000,
+        client_id="cluster-staging",
     )
 
 

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -202,6 +202,7 @@ async def test_get_config_from_backend__omits_invalid_config_rows(
                     license_servers=["A", "list", "of", "license", "servers"],
                     license_server_type="O-Negative",
                     grace_time=13,
+                    client_id="cluster-staging",
                 ),
                 # Invalid config row
                 dict(bad="Data. Should NOT work"),
@@ -212,6 +213,7 @@ async def test_get_config_from_backend__omits_invalid_config_rows(
                     license_servers=["A", "collection", "of", "license", "servers"],
                     license_server_type="AB-Positive",
                     grace_time=21,
+                    client_id="cluster-staging",
                 ),
             ],
         ),

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -372,6 +372,7 @@ def test_get_local_license_configurations():
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
+        client_id="cluster-staging",
     )
 
     configuration_polygonica = BackendConfigurationRow(
@@ -380,6 +381,7 @@ def test_get_local_license_configurations():
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
+        client_id="cluster-staging",
     )
 
     license_configurations = [configuration_super, configuration_polygonica]


### PR DESCRIPTION
#### What
Update the configuration row schema to include the new `client_id` column added to the config table in the backend.

#### Why
To ensure that the agent will be able to parse the new config row schema.

`Task`: https://app.clickup.com/t/18022949/ARMADA-468

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
