### PR TITLE
Revert client_id PR (#147)

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,7 +7,6 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 * Implement async calls to license servers to fetch information in parallel
-* Update backend configuration row schema to include new client_id field
 
 2.2.8 -- 2022-05-16
 -------------------

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -159,7 +159,6 @@ class BackendConfigurationRow(BaseModel):
     license_servers: typing.List[str]
     license_server_type: str
     grace_time: int
-    client_id: str
 
 
 class BackendBookingRow(BaseModel):

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -50,7 +50,6 @@ def one_configuration_row_flexlm():
         license_servers=["flexlm:127.0.0.1:2345"],
         license_server_type="flexlm",
         grace_time=10000,
-        client_id="cluster-staging",
     )
 
 
@@ -62,7 +61,6 @@ def one_configuration_row_rlm():
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
-        client_id="cluster-staging",
     )
 
 
@@ -74,7 +72,6 @@ def one_configuration_row_lsdyna():
         license_servers=["lsdyna:127.0.0.1:2345"],
         license_server_type="lsdyna",
         grace_time=10000,
-        client_id="cluster-staging",
     )
 
 
@@ -86,7 +83,6 @@ def one_configuration_row_lmx():
         license_servers=["lmx:127.0.0.1:2345"],
         license_server_type="lmx",
         grace_time=10000,
-        client_id="cluster-staging",
     )
 
 

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -202,7 +202,6 @@ async def test_get_config_from_backend__omits_invalid_config_rows(
                     license_servers=["A", "list", "of", "license", "servers"],
                     license_server_type="O-Negative",
                     grace_time=13,
-                    client_id="cluster-staging",
                 ),
                 # Invalid config row
                 dict(bad="Data. Should NOT work"),
@@ -213,7 +212,6 @@ async def test_get_config_from_backend__omits_invalid_config_rows(
                     license_servers=["A", "collection", "of", "license", "servers"],
                     license_server_type="AB-Positive",
                     grace_time=21,
-                    client_id="cluster-staging",
                 ),
             ],
         ),

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -372,7 +372,6 @@ def test_get_local_license_configurations():
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
-        client_id="cluster-staging",
     )
 
     configuration_polygonica = BackendConfigurationRow(
@@ -381,7 +380,6 @@ def test_get_local_license_configurations():
         license_servers=["rlm:127.0.0.1:2345"],
         license_server_type="rlm",
         grace_time=10000,
-        client_id="cluster-staging",
     )
 
     license_configurations = [configuration_super, configuration_polygonica]


### PR DESCRIPTION
#### What
Revert the modifications in the agent regarding the client_id PR (#147).

#### Why
These modifications will be deployed after the backend database migration.

Obs: The branch `client-id-agent-modification` still has this code, to be deployed later.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
