### PR TITLE
Add booked column to license usage information

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Added a new endpoint to retrieve license usage with booked information
 
 2.2.11 -- 2022-07-11
 --------------------

--- a/backend/lm_backend/api/license.py
+++ b/backend/lm_backend/api/license.py
@@ -63,7 +63,7 @@ async def licenses_all_with_booking(
     sort_ascending: bool = Query(True),
 ):
     """
-    All license counts we are tracking with booked tokens included
+    All license counts we are tracking with booked tokens included.
     """
     query = (
         select([*license_table.c, func.sum(func.coalesce(booking_table.c.booked, 0)).label("booked")])

--- a/backend/lm_backend/api/license.py
+++ b/backend/lm_backend/api/license.py
@@ -22,6 +22,7 @@ from lm_backend.table_schemas import (
     license_sortable_fields,
     license_table,
 )
+from lm_backend.helpers import LicenseUseWithBookingSortFieldChecker
 
 PRODUCT_FEATURE_RX = r"^.+?\..+$"
 router = APIRouter()
@@ -58,7 +59,7 @@ async def licenses_all(
 )
 async def licenses_all_with_booking(
     search: Optional[str] = Query(None),
-    sort_field: Optional[str] = Query(None),
+    sort_field: Optional[str] = Depends(LicenseUseWithBookingSortFieldChecker()),
     sort_ascending: bool = Query(True),
 ):
     """

--- a/backend/lm_backend/api/license.py
+++ b/backend/lm_backend/api/license.py
@@ -2,7 +2,8 @@ import asyncio
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy.sql import select, update
+from sqlalchemy import func
+from sqlalchemy.sql import join, select, update
 
 from lm_backend.api.permissions import Permissions
 from lm_backend.api_schemas import (
@@ -11,6 +12,7 @@ from lm_backend.api_schemas import (
     LicenseUseBase,
     LicenseUseReconcile,
     LicenseUseReconcileRequest,
+    LicenseUseWithBooking,
 )
 from lm_backend.security import guard
 from lm_backend.storage import database, search_clause, sort_clause
@@ -47,6 +49,44 @@ async def licenses_all(
         query = query.order_by(license_table.c.product_feature)
     fetched = await database.fetch_all(query)
     return [LicenseUse.parse_obj(x) for x in fetched]
+
+
+@router.get(
+    "/complete/all",
+    response_model=List[LicenseUseWithBooking],
+    dependencies=[Depends(guard.lockdown(Permissions.LICENSE_VIEW))],
+)
+async def licenses_all_with_booking(
+    search: Optional[str] = Query(None),
+    sort_field: Optional[str] = Query(None),
+    sort_ascending: bool = Query(True),
+):
+    """
+    All license counts we are tracking with booked tokens included
+    """
+    query = (
+        select([*license_table.c, func.sum(func.coalesce(booking_table.c.booked, 0)).label("booked")])
+        .select_from(
+            join(
+                license_table,
+                booking_table,
+                license_table.c.product_feature == booking_table.c.product_feature,
+                isouter=True,
+            )
+        )
+        .group_by(
+            license_table.c.id,
+            license_table.c.product_feature,
+        )
+    )
+    if search is not None:
+        query = query.where(search_clause(search, license_searchable_fields))
+    if sort_field is not None:
+        query = query.order_by(sort_clause(sort_field, license_sortable_fields, sort_ascending))
+    else:
+        query = query.order_by(license_table.c.product_feature)
+    fetched = await database.fetch_all(query)
+    return [LicenseUseWithBooking.parse_obj(x) for x in fetched]
 
 
 @router.get(

--- a/backend/lm_backend/api/license.py
+++ b/backend/lm_backend/api/license.py
@@ -14,6 +14,7 @@ from lm_backend.api_schemas import (
     LicenseUseReconcileRequest,
     LicenseUseWithBooking,
 )
+from lm_backend.helpers import LicenseUseWithBookingSortFieldChecker
 from lm_backend.security import guard
 from lm_backend.storage import database, search_clause, sort_clause
 from lm_backend.table_schemas import (
@@ -22,7 +23,6 @@ from lm_backend.table_schemas import (
     license_sortable_fields,
     license_table,
 )
-from lm_backend.helpers import LicenseUseWithBookingSortFieldChecker
 
 PRODUCT_FEATURE_RX = r"^.+?\..+$"
 router = APIRouter()

--- a/backend/lm_backend/api/license.py
+++ b/backend/lm_backend/api/license.py
@@ -59,7 +59,7 @@ async def licenses_all(
 )
 async def licenses_all_with_booking(
     search: Optional[str] = Query(None),
-    sort_field: Optional[str] = Depends(LicenseUseWithBookingSortFieldChecker()),
+    sort_field: str = Depends(LicenseUseWithBookingSortFieldChecker()),
     sort_ascending: bool = Query(True),
 ):
     """

--- a/backend/lm_backend/api_schemas.py
+++ b/backend/lm_backend/api_schemas.py
@@ -149,6 +149,25 @@ class LicenseUse(LicenseUseBase):
         return values["total"] - values["used"]
 
 
+class LicenseUseWithBooking(LicenseUseBase):
+    """
+    Used/Available/Booked/Total counts for a product.feature license category
+
+    Returned by GET queries, including `available` for convenience
+    """
+
+    total: int
+    booked: Optional[int]
+    available: Optional[int]
+
+    @validator("available", always=True)
+    def validate_available(cls, value, values):
+        """
+        Set available as a function of the other fields
+        """
+        return values["total"] - (values["used"] + values["booked"])
+
+
 class LicenseUseBooking(LicenseUseBase):
     """
     A booking [PUT] object, specifying how many tokens are needed and no total

--- a/backend/lm_backend/api_schemas.py
+++ b/backend/lm_backend/api_schemas.py
@@ -151,9 +151,9 @@ class LicenseUse(LicenseUseBase):
 
 class LicenseUseWithBooking(LicenseUseBase):
     """
-    Used/Available/Booked/Total counts for a product.feature license category
+    Used/Available/Booked/Total counts for a product.feature license category.
 
-    Returned by GET queries, including `available` for convenience
+    Returned by GET queries, including `available` for convenience.
     """
 
     total: int

--- a/backend/lm_backend/helpers.py
+++ b/backend/lm_backend/helpers.py
@@ -1,0 +1,28 @@
+"""
+Functions to help with field validations for sorting model instances.
+"""
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+from lm_backend.api_schemas import LicenseUseWithBooking
+
+
+class LicenseUseWithBookingSortFieldChecker:
+    """
+    Validate if the sort field is a valid field in the model.
+    """
+    _model = LicenseUseWithBooking
+
+    def __call__(self, sort_field: Optional[str] = None) -> str:
+        if sort_field is not None:
+            if sort_field not in LicenseUseWithBooking.__fields__.keys():
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid sorting column requested: {sort_field}. Must be one of {self.available_fields()}.",
+                )
+        return sort_field
+
+    @classmethod
+    def available_fields(cls):
+        return list(cls._model.__fields__.keys())

--- a/backend/lm_backend/helpers.py
+++ b/backend/lm_backend/helpers.py
@@ -20,7 +20,10 @@ class LicenseUseWithBookingSortFieldChecker:
             if sort_field not in LicenseUseWithBooking.__fields__.keys():
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid sorting column requested: {sort_field}. Must be one of {self.available_fields()}.",
+                    detail=(
+                        f"Invalid sorting column requested: {sort_field}. "
+                        f"Must be one of {self.available_fields()}."
+                    ),
                 )
         return sort_field
 

--- a/backend/lm_backend/helpers.py
+++ b/backend/lm_backend/helpers.py
@@ -14,7 +14,7 @@ class LicenseUseWithBookingSortFieldChecker:
     """
     _model = LicenseUseWithBooking
 
-    def __call__(self, sort_field: Optional[str] = None) -> str:
+    def __call__(self, sort_field: Optional[str] = "") -> Optional[str]:
         if sort_field is not None:
             if sort_field not in LicenseUseWithBooking.__fields__.keys():
                 raise HTTPException(

--- a/backend/lm_backend/helpers.py
+++ b/backend/lm_backend/helpers.py
@@ -12,9 +12,10 @@ class LicenseUseWithBookingSortFieldChecker:
     """
     Validate if the sort field is a valid field in the model.
     """
+
     _model = LicenseUseWithBooking
 
-    def __call__(self, sort_field: Optional[str] = "") -> Optional[str]:
+    def __call__(self, sort_field: Optional[str] = None) -> Optional[str]:
         if sort_field is not None:
             if sort_field not in LicenseUseWithBooking.__fields__.keys():
                 raise HTTPException(

--- a/lm-cli/CHANGELOG.rst
+++ b/lm-cli/CHANGELOG.rst
@@ -6,4 +6,5 @@ This file keeps track of all notable changes to License Manager CLI.
 
 Unreleased
 ----------
-Created the project. Features: commands to list licenses, list bookings, list, create and delete configurations.
+* Created the project. Features: commands to list licenses, list bookings, list, create and delete configurations.
+* Update license list command to include booked information in license usage table

--- a/lm-cli/lm_cli/subapps/licenses.py
+++ b/lm-cli/lm_cli/subapps/licenses.py
@@ -17,6 +17,7 @@ style_mapper = StyleMapper(
     product_feature="green",
     used="cyan",
     total="magenta",
+    booked="blue",
     available="yellow",
 )
 

--- a/lm-cli/lm_cli/subapps/licenses.py
+++ b/lm-cli/lm_cli/subapps/licenses.py
@@ -47,7 +47,7 @@ def list_all(
         List,
         make_request(
             lm_ctx.client,
-            "/license/all",
+            "/license/complete/all",
             "GET",
             expected_status=200,
             abort_message="Couldn't retrieve license list from API",

--- a/lm-cli/tests/subapps/test_licenses.py
+++ b/lm-cli/tests/subapps/test_licenses.py
@@ -14,7 +14,7 @@ def test_list_all__makes_request_and_renders_results(
     """
     Test if the list all command fetches and renders the licenses result.
     """
-    respx_mock.get(f"{dummy_domain}/license/all").mock(
+    respx_mock.get(f"{dummy_domain}/license/complete/all").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dummy_license_data,


### PR DESCRIPTION
#### What
Add a new enpoint to retrieve license usage and booked quantity. The `booked` counter is subtracted from the`available` counter to display the correct amount of licenses available.

#### Why
The stakeholders asked to have the booked counter together with the license usage information.

`Task`: https://app.clickup.com/t/18022949/ARMADA-658

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
