### PR TITLE
Fix config PUT route to allow editing client_id field

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 
+2.2.13 -- 2022-09-06
+--------------------
+* Bumped version to keep in sync with backend
+
 2.2.12 -- 2022-09-06
 --------------------
 * Update backend configuration row schema to include new client_id field

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.2.12"
+version = "2.2.13"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,9 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+
+2.2.13 -- 2022-09-06
+--------------------
 * Update configuration edit endpoint to allow the client id field to be updated
 
 2.2.12 -- 2022-09-06

--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Update configuration edit endpoint to allow the client id field to be updated
 
 2.2.12 -- 2022-09-06
 --------------------

--- a/backend/lm_backend/api/config.py
+++ b/backend/lm_backend/api/config.py
@@ -150,6 +150,7 @@ async def update_configuration(
     license_servers: Optional[List[str]] = Body(None),
     license_server_type: Optional[str] = Body(None),
     grace_time: Optional[int] = Body(None),
+    client_id: Optional[str] = Body(None),
 ):
     """
     Update a configuration row in the database with all of the
@@ -166,6 +167,8 @@ async def update_configuration(
         update_dict["license_server_type"] = license_server_type
     if grace_time is not None:
         update_dict["grace_time"] = grace_time
+    if client_id is not None:
+        update_dict["client_id"] = client_id
     q_update = config_table.update().where(config_table.c.id == config_id).values(update_dict)
     async with database.transaction():
         try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "2.2.12"
+version = "2.2.13"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-cli/CHANGELOG.rst
+++ b/lm-cli/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to License Manager CLI.
 Unreleased
 ----------
 
+2.2.13 -- 2022-09-06
+--------------------
+* Bumped version to keep in sync with backend
+
 2.2.12 -- 2022-09-06
 --------------------
 * Created the project. Features: commands to list licenses, list bookings, list, create and delete configurations.

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lm-cli"
-version = "2.2.12"
+version = "2.2.13"
 description = "License Manager CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Fix the config edit route to accept editing client_id field.

#### Why
To ensure the endpoint works correctly with the new client_id column.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
