### PR TITLE
Release 2.2.14

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 
+2.2.14 -- 2022-09-13
+--------------------
+
 2.2.13 -- 2022-09-06
 --------------------
 * Bumped version to keep in sync with backend

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.2.13"
+version = "2.2.14"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to license-manager-backend
 Unreleased
 ----------
 
+2.2.14 -- 2022-09-13
+--------------------
+
 2.2.13 -- 2022-09-06
 --------------------
 * Update configuration edit endpoint to allow the client id field to be updated

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "2.2.13"
+version = "2.2.14"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-cli/CHANGELOG.rst
+++ b/lm-cli/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to License Manager CLI.
 Unreleased
 ----------
 
+2.2.14 -- 2022-09-13
+--------------------
+
 2.2.13 -- 2022-09-06
 --------------------
 * Bumped version to keep in sync with backend

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lm-cli"
-version = "2.2.13"
+version = "2.2.14"
 description = "License Manager CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
Automated changes by [prepare_release](https://github.com/omnivector-solutions/license-manager/blob/main/.github/workflows/prepare_release.yaml) GitHub action.