### PR TITLE
Change agent to use cluster specific route to fetch config rows

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 
+2.2.15 -- 2022-10-26
+--------------------
+* Updated route to fetch licenses' configuration to use cluster specific route
+
 2.2.14 -- 2022-10-03
 --------------------
 * Bumped version to keep in sync with lm-cli

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -210,7 +210,7 @@ async def get_config_id_from_backend(product_feature: str) -> int:
 
 async def get_config_from_backend() -> typing.List[BackendConfigurationRow]:
     """Get all config rows from the backend."""
-    path = "/lm/api/v1/config/all"
+    path = "/lm/api/v1/config/agent/all"
 
     try:
         resp = await backend_client.get(path)

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "2.2.14"
+version = "2.2.15"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -191,7 +191,7 @@ async def test_get_config_from_backend__omits_invalid_config_rows(
     caplog,
     respx_mock,
 ):
-    respx.get(f"{settings.BACKEND_BASE_URL}/lm/api/v1/config/all").mock(
+    respx.get(f"{settings.BACKEND_BASE_URL}/lm/api/v1/config/agent/all").mock(
         return_value=Response(
             200,
             json=[
@@ -228,7 +228,7 @@ async def test_get_config_from_backend__returns_empty_list_on_connect_error(
     caplog,
     respx_mock,
 ):
-    respx.get(f"{settings.BACKEND_BASE_URL}/lm/api/v1/config/all").mock(
+    respx.get(f"{settings.BACKEND_BASE_URL}/lm/api/v1/config/agent/all").mock(
         side_effect=ConnectError("BOOM"),
     )
     configs = await get_config_from_backend()

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -187,7 +187,7 @@ async def test_reconcile(clean_booked_grace_time_mock, report_mock, respx_mock):
             status_code=200,
         )
     )
-    respx_mock.get("/lm/api/v1/config/all").mock(return_value=Response(status_code=200, json={}))
+    respx_mock.get("/lm/api/v1/config/agent/all").mock(return_value=Response(status_code=200, json={}))
     respx_mock.get("/lm/api/v1/config/?product_feature=product.feature").mock(
         return_value=Response(status_code=200, json={})
     )

--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to license-manager-backend
 Unreleased
 ----------
 
+2.2.15 -- 2022-10-26
+--------------------
+* Bump to sync with lm-agent version
+
 2.2.14 -- 2022-10-03
 --------------------
 * Bump to sync with lm-cli version

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "2.2.14"
+version = "2.2.15"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-cli/CHANGELOG.rst
+++ b/lm-cli/CHANGELOG.rst
@@ -7,6 +7,10 @@ This file keeps track of all notable changes to License Manager CLI.
 Unreleased
 ----------
 
+2.2.15 -- 2022-10-26
+--------------------
+* Bumped version to keep in sync with lm-agent
+
 2.2.14 -- 2022-10-03
 --------------------
 * Changed Python version to 3.6.2 for compatibility

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-cli"
-version = "2.2.14"
+version = "2.2.15"
 description = "License Manager CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Change the agent to use the new route to fetch config rows for a specific cluster client_id.

#### Why
To ensure the agent only receives the licenses configured in it.

`Task`: https://app.clickup.com/t/18022949/ARMADA-588

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
