### PR TITLE
Add OLicense license server support

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Add OLicense license server support
 
 2.2.15 -- 2022-10-26
 --------------------

--- a/agent/lm_agent/config.py
+++ b/agent/lm_agent/config.py
@@ -63,6 +63,9 @@ class Settings(BaseSettings):
     # path to the binary for lmxendutil (needed for LM-X licenses)
     LMXENDUTIL_PATH: Path = _DEFAULT_BIN_PATH
 
+    # path to the binary for olixtool (needed for OLicense licenses)
+    OLIXTOOL_PATH: Path = _DEFAULT_BIN_PATH
+
     # debug mode turns on certain dangerous operations
     DEBUG: bool = False
 

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -29,7 +29,7 @@ RX_USAGE = re.compile(USAGE_LINE)
 
 def parse_feature_line(line: str) -> Optional[dict]:
     """
-    Parse the feature line in the OLicense output.
+    Parse the "feature" line in the OLicense output.
     Data we need:
     - ``feature``: license name
     - ``total``: total amount of licenses
@@ -51,15 +51,15 @@ def parse_feature_line(line: str) -> Optional[dict]:
 
 def parse_in_use_line(line: str) -> Optional[int]:
     """
-    Parse the in use line in the Olicense output.
+    Parse the "in use" line in the Olicense output.
     Data we need:
     - ``in_use``: quantity of licenses being used by each user
 
     Obs: this line doesn't include the license name.
     The license in use is the last one parsed before this line.
     It also doesn't include the user name.
-    The user using the license is the next usage line parsed after this line.
-    The total amount of licenses being used is the sum of all in use lines.
+    The user using the license is the next "usage" line parsed after this line.
+    The total amount of licenses being used is the sum of all "in use" lines.
     """
 
     parsed_in_use = RX_IN_USE.match(line)
@@ -100,7 +100,7 @@ def parse(server_output: str) -> dict:
     -``in use line``: info about licenses in use
     -``usage line``: info about users using licenses
 
-    Since the in use and usage line don't have the name of the license in use,
+    Since the "in use" and "usage" linea don't have the name of the license in use,
     we're saving each parsed license in a list. This way, we can find which
     license is being used by checking the last parsed license in the list.
 

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -100,12 +100,25 @@ def parse(server_output: str) -> dict:
     -``in use line``: info about licenses in use
     -``usage line``: info about users using licenses
 
-    Since the "in use" and "usage" linea don't have the name of the license in use,
+    Since the "in use" and "usage" lines don't have the name of the license in use,
     we're saving each parsed license in a list. This way, we can find which
     license is being used by checking the last parsed license in the list.
 
     If a feature has more than one license associated with it, the total amount
     of licenses is the sum of all licenses with the same name.
+
+    Example of output:
+        ...
+        ftire_adams;         	FreeFloating;	3;	2022-12-31 23:59:59;
+        1 FloatsLockedBy:
+        sbhyma@RD0087712 #1
+        ...
+        ftire_adams;         	FreeFloating;	1;	2023-02-28 23:59:00;
+
+    This would be parsed as:
+        "ftire_adams": {"total": 4, "used" 1, "uses": {
+            "user_name": "sbhyma", "lead_host": "RD0087712", "booked": 1
+        }}
     """
     parsed_data: dict = {}
     feature_list: list = []

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -131,7 +131,5 @@ def parse(server_output: str) -> dict:
         elif parsed_usage:
             feature = feature_list[-1]
             parsed_data[feature]["uses"].append(parsed_usage)
-        else:
-            continue
 
     return parsed_data

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -1,0 +1,137 @@
+"""
+Parser for OLicense
+"""
+import re
+from typing import Optional
+
+HOSTWORD = r"[a-zA-Z0-9-]+"
+HOSTNAME = rf"{HOSTWORD}(\.{HOSTWORD})*"
+INT = r"\d+"
+EXPIRATION_DATE = (
+    r"[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]"
+)
+
+FEATURE_LINE = (
+    r"^\s+(?P<feature>\w+);"
+    r"\s+(?P<license_type>\w+);"
+    rf"\s+(?P<total>{INT});"
+    rf"\s+(?P<expiration_date>{EXPIRATION_DATE});"
+)
+
+IN_USE_LINE = rf"^\s+(?P<in_use>{INT})\s+FloatsLockedBy:$"
+
+USAGE_LINE = rf"^\s+(?P<user>\S+)@(?P<lead_host>{HOSTNAME})\s+#{INT}$"
+
+RX_FEATURE = re.compile(FEATURE_LINE)
+RX_IN_USE = re.compile(IN_USE_LINE)
+RX_USAGE = re.compile(USAGE_LINE)
+
+
+def parse_feature_line(line: str) -> Optional[str]:
+    """
+    Parse the feature line in the OLicense output.
+    Data we need:
+    - ``feature``: license name
+    - ``total``: total amount of licenses
+
+    Obs: OLicense supports more than one license with the same feature name.
+    In case a feature has more than one license associated with it,
+    the total amount of licenses is the sum of all licenses with the same name.
+    """
+    parsed_feature = RX_FEATURE.match(line)
+    if parsed_feature is None:
+        return None
+    feature_data = parsed_feature.groupdict()
+
+    return {
+        "feature": feature_data["feature"].lower(),
+        "total": int(feature_data["total"]),
+    }
+
+
+def parse_in_use_line(line: str) -> Optional[dict]:
+    """
+    Parse the in use line in the Olicense output.
+    Data we need:
+    - ``in_use``: quantity of licenses being used by each user
+
+    Obs: this line doesn't include the license name.
+    The license in use is the last one parsed before this line.
+    It also doesn't include the user name.
+    The user using the license is the next usage line parsed after this line.
+    This line is printed for each user using the license.
+    The total amount of licenses being used is the sum of all in use lines.
+    """
+
+    parsed_in_use = RX_IN_USE.match(line)
+    if parsed_in_use is None:
+        return None
+    in_use_data = parsed_in_use.groupdict()
+
+    return int(in_use_data["in_use"])
+
+
+def parse_usage_line(line: str) -> Optional[dict]:
+    """
+    Parse the usage line in the Olicense output.
+    Data we need:
+    -``user_name``: user who booked the license
+    -``lead_host``: host using the license
+
+    Obs: this line also doesn't include the license name.
+    The license in use is the last one parsed before this line.
+    It also doesn't include the quantity of licenses being used.
+    Since this line is printed for each license used by the user, the booked quantity is always 1.
+    """
+    parsed_usage = RX_USAGE.match(line)
+    if parsed_usage is None:
+        return None
+    usage_data = parsed_usage.groupdict()
+
+    return {
+        "user_name": usage_data["user"],
+        "lead_host": usage_data["lead_host"],
+        "booked": 1,
+    }
+
+
+def parse(server_output: str) -> dict:
+    """
+    Parse the OLicense output using regex to match the lines we need:
+    -``feature line``: info about each license
+    -``in use line``: info about licenses in use
+    -``usage line``: info about users using licenses
+
+    Since the in use and usage line don't have the name of the license in use,
+    we're saving each parsed license in a list. This way, we can find which
+    license is being used by checking the last parsed license in the list.
+
+    If a feature has more than one license associated with it, the total amount
+    of licenses is the sum of all licenses with the same name.
+    """
+    parsed_data: dict = {}
+    feature_list: list = []
+
+    for line in server_output.splitlines():
+        parsed_feature = parse_feature_line(line)
+        parsed_in_use = parse_in_use_line(line)
+        parsed_usage = parse_usage_line(line)
+
+        if parsed_feature:
+            feature = parsed_feature["feature"]
+            total = parsed_feature["total"]
+            if feature not in feature_list:
+                feature_list.append(feature)
+                parsed_data[feature] = {"used": 0, "total": total, "uses": []}
+            else:
+                parsed_data[feature]["total"] += total
+        elif parsed_in_use:
+            feature = feature_list[-1]
+            parsed_data[feature]["used"] += parsed_in_use
+        elif parsed_usage:
+            feature = feature_list[-1]
+            parsed_data[feature]["uses"].append(parsed_usage)
+        else:
+            continue
+
+    return parsed_data

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -125,9 +125,6 @@ def parse(server_output: str) -> dict:
 
     for line in server_output.splitlines():
         parsed_feature = parse_feature_line(line)
-        parsed_in_use = parse_in_use_line(line)
-        parsed_usage = parse_usage_line(line)
-
         if parsed_feature:
             feature = parsed_feature["feature"]
             total = parsed_feature["total"]
@@ -136,10 +133,16 @@ def parse(server_output: str) -> dict:
                 parsed_data[feature] = {"used": 0, "total": total, "uses": []}
             else:
                 parsed_data[feature]["total"] += total
-        elif parsed_in_use:
+            continue
+
+        parsed_in_use = parse_in_use_line(line)
+        if parsed_in_use:
             feature = feature_list[-1]
             parsed_data[feature]["used"] += parsed_in_use
-        elif parsed_usage:
+            continue
+
+        parsed_usage = parse_usage_line(line)
+        if parsed_usage:
             feature = feature_list[-1]
             parsed_data[feature]["uses"].append(parsed_usage)
 

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -20,7 +20,7 @@ FEATURE_LINE = (
 
 IN_USE_LINE = rf"^\s+(?P<in_use>{INT})\s+FloatsLockedBy:$"
 
-USAGE_LINE = rf"^\s+(?P<user>\S+)@(?P<lead_host>{HOSTNAME})\s+#{INT}$"
+USAGE_LINE = rf"^\s+(?P<user>\S+)@(?P<lead_host>{HOSTNAME})\s+#(?P<booked>{INT})$"
 
 RX_FEATURE = re.compile(FEATURE_LINE)
 RX_IN_USE = re.compile(IN_USE_LINE)
@@ -59,7 +59,6 @@ def parse_in_use_line(line: str) -> Optional[int]:
     The license in use is the last one parsed before this line.
     It also doesn't include the user name.
     The user using the license is the next usage line parsed after this line.
-    This line is printed for each user using the license.
     The total amount of licenses being used is the sum of all in use lines.
     """
 
@@ -77,11 +76,10 @@ def parse_usage_line(line: str) -> Optional[dict]:
     Data we need:
     -``user_name``: user who booked the license
     -``lead_host``: host using the license
+    -``booked``: quantity of licenses booked by the user
 
     Obs: this line also doesn't include the license name.
     The license in use is the last one parsed before this line.
-    It also doesn't include the quantity of licenses being used.
-    Since this line is printed for each license used by the user, the booked quantity is always 1.
     """
     parsed_usage = RX_USAGE.match(line)
     if parsed_usage is None:
@@ -91,7 +89,7 @@ def parse_usage_line(line: str) -> Optional[dict]:
     return {
         "user_name": usage_data["user"],
         "lead_host": usage_data["lead_host"],
-        "booked": 1,
+        "booked": int(usage_data["booked"]),
     }
 
 

--- a/agent/lm_agent/parsing/olicense.py
+++ b/agent/lm_agent/parsing/olicense.py
@@ -27,7 +27,7 @@ RX_IN_USE = re.compile(IN_USE_LINE)
 RX_USAGE = re.compile(USAGE_LINE)
 
 
-def parse_feature_line(line: str) -> Optional[str]:
+def parse_feature_line(line: str) -> Optional[dict]:
     """
     Parse the feature line in the OLicense output.
     Data we need:
@@ -49,7 +49,7 @@ def parse_feature_line(line: str) -> Optional[str]:
     }
 
 
-def parse_in_use_line(line: str) -> Optional[dict]:
+def parse_in_use_line(line: str) -> Optional[int]:
     """
     Parse the in use line in the Olicense output.
     Data we need:

--- a/agent/lm_agent/server_interfaces/olicense.py
+++ b/agent/lm_agent/server_interfaces/olicense.py
@@ -16,7 +16,7 @@ class OLicenseLicenseServer(LicenseServerInterface):
         self.license_servers = license_servers
         self.parser = olicense.parse
 
-    def get_commands_list(self):
+    def get_commands_list(self) -> typing.List[str]:
         """Generate a list of commands with the available license server hosts."""
 
         host_ports = [(server.split(":")[1:]) for server in self.license_servers]

--- a/agent/lm_agent/server_interfaces/olicense.py
+++ b/agent/lm_agent/server_interfaces/olicense.py
@@ -1,0 +1,67 @@
+"""OLicense license server interface."""
+import typing
+
+from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.parsing import olicense
+from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
+from lm_agent.server_interfaces.utils import run_command
+
+
+class OLicenseLicenseServer(LicenseServerInterface):
+    """Extract license information from OLicense license server."""
+
+    def __init__(self, license_servers: typing.List[str]):
+        """Initialize the license server instance with the license server host and parser."""
+        self.license_servers = license_servers
+        self.parser = olicense.parse
+
+    def get_commands_list(self):
+        """Generate a list of commands with the available license server hosts."""
+
+        host_ports = [(server.split(":")[1:]) for server in self.license_servers]
+        commands_to_run = []
+        for host, port in host_ports:
+            command_line = f"{settings.OLIXTOOL_PATH} -sv {host}:{port}"
+            commands_to_run.append(command_line)
+        return commands_to_run
+
+    async def get_output_from_server(self):
+        """Override abstract method to get output from OLicense license server."""
+
+        # get the list of commands for each license server host
+        commands_to_run = self.get_commands_list()
+
+        # run each command in the list, one at a time, until one succeds
+        for cmd in commands_to_run:
+            output = await run_command(cmd)
+
+            # try the next server if the previous didn't return the expected data
+            if output is None:
+                continue
+            return output
+
+        raise RuntimeError("None of the checks for OLicense succeeded!")
+
+    async def get_report_item(self, product_feature: str):
+        """Override abstract method to parse OLicense license server output into License Report Item."""
+
+        server_output = await self.get_output_from_server()
+        parsed_output = self.parser(server_output)
+
+        (_, feature) = product_feature.split(".")
+
+        current_feature_item = parsed_output.get(feature)
+
+        # raise exception if parser didn't output license information
+        if current_feature_item is None:
+            raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
+
+        report_item = LicenseReportItem(
+            product_feature=product_feature,
+            used=current_feature_item["used"],
+            total=current_feature_item["total"],
+            used_licenses=current_feature_item["uses"],
+        )
+
+        return report_item

--- a/agent/lm_agent/tokenstat.py
+++ b/agent/lm_agent/tokenstat.py
@@ -11,6 +11,7 @@ from lm_agent.server_interfaces.flexlm import FlexLMLicenseServer
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.server_interfaces.lmx import LMXLicenseServer
 from lm_agent.server_interfaces.lsdyna import LSDynaLicenseServer
+from lm_agent.server_interfaces.olicense import OLicenseLicenseServer
 from lm_agent.server_interfaces.rlm import RLMLicenseServer
 from lm_agent.workload_managers.slurm.cmd_utils import get_all_product_features_from_cluster
 
@@ -64,6 +65,7 @@ async def report() -> typing.List[dict]:
         rlm=RLMLicenseServer,
         lsdyna=LSDynaLicenseServer,
         lmx=LMXLicenseServer,
+        olicense=OLicenseLicenseServer,
     )
 
     for entry in filtered_entries:

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -91,6 +91,18 @@ def one_configuration_row_lmx():
 
 
 @fixture
+def one_configuration_row_olicense():
+    return BackendConfigurationRow(
+        product="cosin",
+        features={"ftire_adams": 4},
+        license_servers=["olicense:127.0.0.1:2345"],
+        license_server_type="olicense",
+        grace_time=10000,
+        client_id="cluster-staging",
+    )
+
+
+@fixture
 def scontrol_show_lic_output_flexlm():
     return dedent(
         """
@@ -126,6 +138,16 @@ def scontrol_show_lic_output_lmx():
         """
         LicenseName=hyperworks.hyperworks@lmx
             Total=1000000 Used=0 Free=500 Reserved=0 Remote=yes
+        """
+    )
+
+
+@fixture
+def scontrol_show_lic_output_olicense():
+    return dedent(
+        """
+        LicenseName=cosin.ftire_adams@olicense
+            Total=4 Used=0 Free=4 Reserved=0 Remote=yes
         """
     )
 
@@ -583,5 +605,107 @@ def lmx_output_no_licenses():
         Key type: EXCLUSIVE License sharing: CUSTOM VIRTUAL
 
         0 of 1000000 license(s) used
+        """
+    )
+
+
+@fixture
+def olicense_output_bad():
+    """
+    Some OLicense unparseable  output
+    """
+    return dedent(
+        """\
+        olixtool 4.8.0 - OLicense XML Status Application
+        Copyright (C) 2007-2013 Optimum GmbH, Karlsruhe, Germany
+
+        Server: <123:80:0> (Proxy: <>)
+
+        OlComm 454 Request cannot connect to target
+        """
+    )
+
+
+@fixture
+def olicense_output():
+    """
+    Some OLicense output to parse
+    """
+    return dedent(
+        """\
+        olixtool 4.8.0 - OLicense XML Status Application
+        Copyright (C) 2007-2013 Optimum GmbH, Karlsruhe, Germany
+
+        Server: <138.106.32.97:31212:0> (Proxy: <>)
+
+        List of requested licenses:
+
+        ==============================================
+        Application:	cosin
+        VersionRange:	0-20231
+        Licenser:	cosin scientific software
+        Licensee:	Tomas Fjällström
+        License-ID:	cosin-faf71fdc@cos550218
+        Modules:
+          Name; LicenseType; FloatCount; Expiration
+          --------------------------------------------
+          ftire_adams;         	FreeFloating;	3;	2022-12-31 23:59:59;
+            2 FloatsLockedBy:
+              sbhyma@RD0087712 #1
+              sbhyma@RD0087713 #2
+
+            1 FloatsLockedBy:
+              user22@RD0087713 #1
+
+
+        ==============================================
+        Application:	cosin
+        VersionRange:	0-20231
+        Licenser:	cosin scientific software
+        Licensee:	Tomas Fjällström
+        License-ID:	cosin-faf71fdc@cos558164
+        Modules:
+          Name; LicenseType; FloatCount; Expiration
+          --------------------------------------------
+          ftire_adams;         	FreeFloating;	1;	2023-02-28 23:59:00;
+        """
+    )
+
+
+@fixture
+def olicense_output_no_licenses():
+    """
+    Some OLicense output with no licenses in use to parse
+    """
+    return dedent(
+        """\
+        olixtool 4.8.0 - OLicense XML Status Application
+        Copyright (C) 2007-2013 Optimum GmbH, Karlsruhe, Germany
+
+        Server: <138.106.32.97:31212:0> (Proxy: <>)
+
+        List of requested licenses:
+
+        ==============================================
+        Application:	cosin
+        VersionRange:	0-20231
+        Licenser:	cosin scientific software
+        Licensee:	Tomas Fjällström
+        License-ID:	cosin-faf71fdc@cos550218
+        Modules:
+          Name; LicenseType; FloatCount; Expiration
+          --------------------------------------------
+          ftire_adams;         	FreeFloating;	3;	2022-12-31 23:59:59;	
+
+        ==============================================
+        Application:	cosin
+        VersionRange:	0-20231
+        Licenser:	cosin scientific software
+        Licensee:	Tomas Fjällström
+        License-ID:	cosin-faf71fdc@cos558164
+        Modules:
+          Name; LicenseType; FloatCount; Expiration
+          --------------------------------------------
+          ftire_adams;         	FreeFloating;	1;	2023-02-28 23:59:00;	
         """
     )

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -91,6 +91,46 @@ def one_configuration_row_lmx():
 
 
 @fixture
+def scontrol_show_lic_output_flexlm():
+    return dedent(
+        """
+        LicenseName=testproduct.testfeature@flexlm
+            Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+        """
+    )
+
+
+@fixture
+def scontrol_show_lic_output_rlm():
+    return dedent(
+        """
+        LicenseName=converge.converge_super@rlm
+            Total=10 Used=0 Free=10 Reserved=0 Remote=yes
+        """
+    )
+
+
+@fixture
+def scontrol_show_lic_output_lsdyna():
+    return dedent(
+        """
+        LicenseName=mppdyna.mppdyna@lsdyna
+            Total=500 Used=0 Free=500 Reserved=0 Remote=yes
+        """
+    )
+
+
+@fixture
+def scontrol_show_lic_output_lmx():
+    return dedent(
+        """
+        LicenseName=hyperworks.hyperworks@lmx
+            Total=1000000 Used=0 Free=500 Reserved=0 Remote=yes
+        """
+    )
+
+
+@fixture
 def lmstat_output_bad():
     """
     Some unparseable lmstat output

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Configuration of pytest for agent tests
+Configuration of pytest for agent tests.
 """
 from pathlib import Path
 from textwrap import dedent
@@ -17,6 +17,7 @@ MOCK_BIN_PATH = Path(__file__).parent / "mock_tools"
 
 @fixture(autouse=True)
 def mock_cache_dir(tmp_path):
+    """Mock a cache directory."""
     _cache_dir = tmp_path / "license-manager-cache"
     assert not _cache_dir.exists()
     with patch("lm_agent.config.settings.CACHE_DIR", new=_cache_dir):
@@ -25,6 +26,7 @@ def mock_cache_dir(tmp_path):
 
 @fixture
 def license_servers():
+    """List of license servers."""
     return ["172.0.1.2 2345", "172.0.1.3 2345"]
 
 
@@ -44,6 +46,7 @@ def respx_mock():
 
 @fixture
 def one_configuration_row_flexlm():
+    """A FlexLM configuration row."""
     return BackendConfigurationRow(
         product="testproduct",
         features={"testfeature": 10},
@@ -56,6 +59,7 @@ def one_configuration_row_flexlm():
 
 @fixture
 def one_configuration_row_rlm():
+    """A RLM configuration row."""
     return BackendConfigurationRow(
         product="converge",
         features={"converge_super": 10},
@@ -68,6 +72,7 @@ def one_configuration_row_rlm():
 
 @fixture
 def one_configuration_row_lsdyna():
+    """A LSDyna configuration row."""
     return BackendConfigurationRow(
         product="mppdyna",
         features={"mppdyna": 500},
@@ -80,6 +85,7 @@ def one_configuration_row_lsdyna():
 
 @fixture
 def one_configuration_row_lmx():
+    """A LM-X configuration row."""
     return BackendConfigurationRow(
         product="hyperworks",
         features={"hyperworks": 1000000},
@@ -92,6 +98,7 @@ def one_configuration_row_lmx():
 
 @fixture
 def one_configuration_row_olicense():
+    """An OLicense configuration row."""
     return BackendConfigurationRow(
         product="cosin",
         features={"ftire_adams": 4},
@@ -104,6 +111,7 @@ def one_configuration_row_olicense():
 
 @fixture
 def scontrol_show_lic_output_flexlm():
+    """An output of scontrol show lic command for FlexLM license."""
     return dedent(
         """
         LicenseName=testproduct.testfeature@flexlm
@@ -114,6 +122,7 @@ def scontrol_show_lic_output_flexlm():
 
 @fixture
 def scontrol_show_lic_output_rlm():
+    """An output of scontrol show lic command for RLM license."""
     return dedent(
         """
         LicenseName=converge.converge_super@rlm
@@ -124,6 +133,7 @@ def scontrol_show_lic_output_rlm():
 
 @fixture
 def scontrol_show_lic_output_lsdyna():
+    """An output of scontrol show lic command for LSDyna license."""
     return dedent(
         """
         LicenseName=mppdyna.mppdyna@lsdyna
@@ -134,6 +144,7 @@ def scontrol_show_lic_output_lsdyna():
 
 @fixture
 def scontrol_show_lic_output_lmx():
+    """An output of scontrol show lic command for LM-X license."""
     return dedent(
         """
         LicenseName=hyperworks.hyperworks@lmx
@@ -144,6 +155,7 @@ def scontrol_show_lic_output_lmx():
 
 @fixture
 def scontrol_show_lic_output_olicense():
+    """An output of scontrol show lic command for OLicense license."""
     return dedent(
         """
         LicenseName=cosin.ftire_adams@olicense
@@ -154,9 +166,7 @@ def scontrol_show_lic_output_olicense():
 
 @fixture
 def lmstat_output_bad():
-    """
-    Some unparseable lmstat output
-    """
+    """Some unparseable lmstat output."""
     return dedent(
         """\
         lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
@@ -169,9 +179,7 @@ def lmstat_output_bad():
 
 @fixture
 def lmstat_output():
-    """
-    Some lmstat output to parse
-    """
+    """Some lmstat output to parse."""
     return dedent(
         """\
         lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
@@ -194,9 +202,7 @@ def lmstat_output():
 
 @fixture
 def lmstat_output_no_licenses():
-    """
-    Some lmstat output with no licenses in use to parse
-    """
+    """Some lmstat output with no licenses in use to parse."""
     return dedent(
         """\
         lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
@@ -212,9 +218,7 @@ def lmstat_output_no_licenses():
 
 @fixture
 def rlm_output_bad():
-    """
-    Some unparseable lmstat output
-    """
+    """Some unparseable rlm output."""
     return dedent(
         """\
         rlmutil v12.2
@@ -232,9 +236,7 @@ def rlm_output_bad():
 
 @fixture
 def rlm_output():
-    """
-    Some rlm output to parse
-    """
+    """Some rlm output to parse."""
     return dedent(
         """\
         Setting license file path to 10@licserv.server.com
@@ -312,9 +314,7 @@ def rlm_output():
 
 @fixture
 def rlm_output_no_licenses():
-    """
-    Some rlm output with no licenses in use to parse
-    """
+    """Some rlm output with no licenses in use to parse."""
     return dedent(
         """\
         Setting license file path to 35015@licserv0011.com:35015@licserv0012.com
@@ -382,22 +382,18 @@ def rlm_output_no_licenses():
 
 @fixture
 def lsdyna_output_bad():
-    """
-    Some unparseable lsdyna output
-    """
+    """Some unparseable lsdyna output."""
     return dedent(
         """\
-		Using default server 31010@localhost
-		*** ERROR failed to open server localhost
-		"""
+        Using default server 31010@localhost
+        *** ERROR failed to open server localhost
+        """
     )
 
 
 @fixture
 def lsdyna_output():
-    """
-    Some lsdyna output to parse
-    """
+    """Some lsdyna output to parse."""
     return dedent(
         """\
         Using user specified server 31010@licserv0004.com
@@ -427,9 +423,7 @@ def lsdyna_output():
 
 @fixture
 def lsdyna_output_no_licenses():
-    """
-    Some lsdyna output with no licenses in use to parse
-    """
+    """Some lsdyna output with no licenses in use to parse."""
     return dedent(
         """\
         Using user specified server 31010@licserv0004.com
@@ -453,9 +447,7 @@ def lsdyna_output_no_licenses():
 
 @fixture
 def lmx_output_bad():
-    """
-    Some unparseable  output
-    """
+    """Some unparseable LM-X output."""
     return dedent(
         """\
         LM-X End-user Utility v3.32
@@ -471,9 +463,7 @@ def lmx_output_bad():
 
 @fixture
 def lmx_output():
-    """
-    Some LM-X output to parse
-    """
+    """Some LM-X output to parse."""
     return dedent(
         """\
         LM-X End-user Utility v3.32
@@ -551,9 +541,7 @@ def lmx_output():
 
 @fixture
 def lmx_output_no_licenses():
-    """
-    Some LM-X output with no licenses in use to parse
-    """
+    """Some LM-X output with no licenses in use to parse."""
     return dedent(
         """\
         LM-X End-user Utility v3.32
@@ -611,9 +599,7 @@ def lmx_output_no_licenses():
 
 @fixture
 def olicense_output_bad():
-    """
-    Some OLicense unparseable  output
-    """
+    """Some OLicense unparseable  output."""
     return dedent(
         """\
         olixtool 4.8.0 - OLicense XML Status Application
@@ -628,9 +614,7 @@ def olicense_output_bad():
 
 @fixture
 def olicense_output():
-    """
-    Some OLicense output to parse
-    """
+    """Some OLicense output to parse."""
     return dedent(
         """\
         olixtool 4.8.0 - OLicense XML Status Application
@@ -674,9 +658,7 @@ def olicense_output():
 
 @fixture
 def olicense_output_no_licenses():
-    """
-    Some OLicense output with no licenses in use to parse
-    """
+    """Some OLicense output with no licenses in use to parse."""
     return dedent(
         """\
         olixtool 4.8.0 - OLicense XML Status Application

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -634,11 +634,9 @@ def olicense_output():
           Name; LicenseType; FloatCount; Expiration
           --------------------------------------------
           ftire_adams;         	FreeFloating;	3;	2022-12-31 23:59:59;
-            2 FloatsLockedBy:
+            3 FloatsLockedBy:
               sbhyma@RD0087712 #1
-              sbhyma@RD0087713 #2
-
-            1 FloatsLockedBy:
+              sbhyma@RD0087713 #1
               user22@RD0087713 #1
 
 

--- a/agent/tests/parsing/test_olicense.py
+++ b/agent/tests/parsing/test_olicense.py
@@ -1,0 +1,98 @@
+"""
+Test the OLicense parser
+"""
+
+from lm_agent.parsing.olicense import parse, parse_feature_line, parse_in_use_line, parse_usage_line
+
+
+def test_parse_feature_line():
+    """
+    Does the regex for the feature line match the lines in the output?
+    The line contains:
+    - feature
+    - license type
+    - total
+    - expiration date
+    From these, we only need to extract ``feature`` and ``total``.
+    """
+    assert parse_feature_line("  ftire_adams;         	FreeFloating;	3;	2022-12-31 23:59:59;") == {
+        "feature": "ftire_adams",
+        "total": 3,
+    }
+    assert parse_feature_line("  ftire_adams;         	FreeFloating;	1;	2023-02-28 23:59:00;") == {
+        "feature": "ftire_adams",
+        "total": 1,
+    }
+    assert parse_feature_line("not a feature line") is None
+    assert parse_feature_line("Licenser:	cosin scientific software") is None
+    assert parse_feature_line("") is None
+
+
+def test_parse_in_use_line():
+    """
+    Does the regex for the in use line match the lines in the output?
+    The line contains:
+    - in_use
+    """
+    assert parse_in_use_line("    2 FloatsLockedBy:") == 2
+    assert parse_in_use_line("not a in use license") is None
+    assert parse_in_use_line("") is None
+
+
+def test_parse_usage_line():
+    """
+    Does the regex for the usage line match the line in the output?
+    The line contains:
+    - user name
+    - lead host
+    - booked
+    """
+    assert parse_usage_line("        sbhyma@RD0087712 #1") == {
+        "user_name": "sbhyma",
+        "lead_host": "RD0087712",
+        "booked": 1,
+    }
+    assert parse_usage_line("        sbhyma@p-c39.maas.rnd.com #1") == {
+        "user_name": "sbhyma",
+        "lead_host": "p-c39.maas.rnd.com",
+        "booked": 1,
+    }
+    assert parse_usage_line("not a usage line") is None
+    assert parse_usage_line("") is None
+
+
+def test_parse__correct_output(olicense_output):
+    """
+    Does the parser return the correct data for this output?
+    - olicense_output: expected output from the license server,
+    which contain licenses and usage information.
+    """
+    assert parse(olicense_output) == {
+        "ftire_adams": {
+            "total": 4,
+            "used": 3,
+            "uses": [
+                {"user_name": "sbhyma", "lead_host": "RD0087712", "booked": 1},
+                {"user_name": "sbhyma", "lead_host": "RD0087713", "booked": 1},
+                {"user_name": "user22", "lead_host": "RD0087713", "booked": 1},
+            ],
+        }
+    }
+
+
+def test_parse__bad_output(olicense_output_bad):
+    """
+    Does the parser return the correct data for this output?
+    - olicense_output_bad: unparseable output from the license server,
+    which can happen when a connection error occours.
+    """
+    assert parse(olicense_output_bad) == {}
+
+
+def test_parse__no_licenses_output(olicense_output_no_licenses):
+    """
+    Does the parser return the correct data for this output?
+    - olicense_output_no_licenses: expected output from the server
+    when none of the licenses are in use by users.
+    """
+    assert parse(olicense_output_no_licenses) == {"ftire_adams": {"total": 4, "used": 0, "uses": []}}

--- a/agent/tests/server_interfaces/test_olicense.py
+++ b/agent/tests/server_interfaces/test_olicense.py
@@ -77,7 +77,7 @@ async def test_olicense_get_report_item_with_bad_output(
 
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.olicense.OLicenseLicenseServer.get_output_from_server")
-async def test_lmx_get_report_item_with_no_used_licenses(
+async def test_olicense_get_report_item_with_no_used_licenses(
     get_output_from_server_mock: mock.MagicMock,
     olicense_server: OLicenseLicenseServer,
     olicense_output_no_licenses: str,

--- a/agent/tests/server_interfaces/test_olicense.py
+++ b/agent/tests/server_interfaces/test_olicense.py
@@ -1,0 +1,95 @@
+"""Test the OLicense license server interface."""
+from unittest import mock
+
+from pytest import fixture, mark, raises
+
+from lm_agent.backend_utils import BackendConfigurationRow
+from lm_agent.config import settings
+from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
+from lm_agent.server_interfaces.olicense import OLicenseLicenseServer
+
+
+@fixture
+def olicense_server(one_configuration_row_olicense: BackendConfigurationRow) -> OLicenseLicenseServer:
+    return OLicenseLicenseServer(one_configuration_row_olicense.license_servers)
+
+
+def test_get_olicense_commands_list(olicense_server: OLicenseLicenseServer):
+    """
+    Do the commands for invoking the license server have the correct data?
+    """
+    commands_list = olicense_server.get_commands_list()
+    assert commands_list == [f"{settings.OLIXTOOL_PATH} -sv 127.0.0.1:2345"]
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.olicense.run_command")
+async def test_olicense_get_output_from_server(
+    run_command_mock: mock.MagicMock,
+    olicense_server: OLicenseLicenseServer,
+    olicense_output: str,
+):
+    """
+    Do the license server interface return the output from the license server?
+    """
+    run_command_mock.return_value = olicense_output
+
+    output = await olicense_server.get_output_from_server()
+    assert output == olicense_output
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.olicense.OLicenseLicenseServer.get_output_from_server")
+async def test_olicense_get_report_item(
+    get_output_from_server_mock: mock.MagicMock, olicense_server: OLicenseLicenseServer, olicense_output: str
+):
+    """
+    Do the OLicense server interface generate a report item for the product?
+    """
+    get_output_from_server_mock.return_value = olicense_output
+
+    assert await olicense_server.get_report_item("cosin.ftire_adams") == LicenseReportItem(
+        product_feature="cosin.ftire_adams",
+        used=3,
+        total=4,
+        used_licenses=[
+            {"user_name": "sbhyma", "lead_host": "RD0087712", "booked": 1},
+            {"user_name": "sbhyma", "lead_host": "RD0087713", "booked": 1},
+            {"user_name": "user22", "lead_host": "RD0087713", "booked": 1},
+        ],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.olicense.OLicenseLicenseServer.get_output_from_server")
+async def test_olicense_get_report_item_with_bad_output(
+    get_output_from_server_mock: mock.MagicMock, olicense_server: OLicenseLicenseServer, olicense_output_bad: str
+):
+    """
+    Do the OLicense server interface raise an exception when the server returns an unparseable output?
+    """
+    get_output_from_server_mock.return_value = olicense_output_bad
+
+    with raises(LicenseManagerBadServerOutput):
+        await olicense_server.get_report_item("cosin.ftire_adams")
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.olicense.OLicenseLicenseServer.get_output_from_server")
+async def test_lmx_get_report_item_with_no_used_licenses(
+    get_output_from_server_mock: mock.MagicMock,
+    olicense_server: OLicenseLicenseServer,
+    olicense_output_no_licenses: str,
+):
+    """
+    Do the OLicense server interface generate a report item when no licenses are in use?
+    """
+    get_output_from_server_mock.return_value = olicense_output_no_licenses
+
+    assert await olicense_server.get_report_item("cosin.ftire_adams") == LicenseReportItem(
+        product_feature="cosin.ftire_adams",
+        used=0,
+        total=4,
+        used_licenses=[],
+    )

--- a/agent/tests/server_interfaces/test_olicense.py
+++ b/agent/tests/server_interfaces/test_olicense.py
@@ -64,7 +64,9 @@ async def test_olicense_get_report_item(
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.olicense.OLicenseLicenseServer.get_output_from_server")
 async def test_olicense_get_report_item_with_bad_output(
-    get_output_from_server_mock: mock.MagicMock, olicense_server: OLicenseLicenseServer, olicense_output_bad: str
+    get_output_from_server_mock: mock.MagicMock,
+    olicense_server: OLicenseLicenseServer,
+    olicense_output_bad: str,
 ):
     """
     Do the OLicense server interface raise an exception when the server returns an unparseable output?

--- a/agent/tests/test_tokenstat.py
+++ b/agent/tests/test_tokenstat.py
@@ -7,46 +7,6 @@ from lm_agent import tokenstat
 from lm_agent.backend_utils import BackendConfigurationRow
 
 
-@fixture
-def scontrol_show_lic_output_flexlm():
-    return dedent(
-        """
-        LicenseName=testproduct.testfeature@flexlm
-            Total=10 Used=0 Free=10 Reserved=0 Remote=yes
-        """
-    )
-
-
-@fixture
-def scontrol_show_lic_output_rlm():
-    return dedent(
-        """
-        LicenseName=converge.converge_super@rlm
-            Total=10 Used=0 Free=10 Reserved=0 Remote=yes
-        """
-    )
-
-
-@fixture
-def scontrol_show_lic_output_lsdyna():
-    return dedent(
-        """
-        LicenseName=mppdyna.mppdyna@lsdyna
-            Total=500 Used=0 Free=500 Reserved=0 Remote=yes
-        """
-    )
-
-
-@fixture
-def scontrol_show_lic_output_lmx():
-    return dedent(
-        """
-        LicenseName=hyperworks.hyperworks@lmx
-            Total=1000000 Used=0 Free=500 Reserved=0 Remote=yes
-        """
-    )
-
-
 @mark.asyncio
 @mark.parametrize(
     "output,reconciliation",


### PR DESCRIPTION
#### What
Add support for the OLicense license server.

#### Why
It was requested by AdamsCar users so they can track the `cosin.ftire_adams` license in License Manager.

`Task`: https://app.clickup.com/t/18022949/ARMADA-784

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
