### PR TITLE
Add full path for backend route in each lm-cli request

### DIFF
--- a/lm-cli/CHANGELOG.rst
+++ b/lm-cli/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to License Manager CLI.
 Unreleased
 ----------
 * Updated configuration create command help text to include new configuration format
+* Updated requests to the backend API to use full path for routes
 
 2.2.15 -- 2022-10-26
 --------------------

--- a/lm-cli/lm_cli/subapps/bookings.py
+++ b/lm-cli/lm_cli/subapps/bookings.py
@@ -51,7 +51,7 @@ def list_all(
         List,
         make_request(
             lm_ctx.client,
-            "/booking/all",
+            "/lm/api/v1/booking/all",
             "GET",
             expected_status=200,
             abort_message="Couldn't retrieve booking list from API",

--- a/lm-cli/lm_cli/subapps/configurations.py
+++ b/lm-cli/lm_cli/subapps/configurations.py
@@ -52,7 +52,7 @@ def list_all(
         List,
         make_request(
             lm_ctx.client,
-            "/config/all",
+            "/lm/api/v1/config/all",
             "GET",
             expected_status=200,
             abort_message="Couldn't retrieve configuration list from API",
@@ -92,7 +92,7 @@ def get_one(
         Dict,
         make_request(
             lm_ctx.client,
-            f"/config/{id}",
+            f"/lm/api/v1/config/{id}",
             "GET",
             expected_status=200,
             abort_message="Couldn't get the configuration from the API",
@@ -173,7 +173,7 @@ def create(
 
     make_request(
         lm_ctx.client,
-        "/config/",
+        "/lm/api/v1/config/",
         "POST",
         expected_status=200,
         abort_message="Couldn't create configuration",
@@ -207,7 +207,7 @@ def delete(
 
     make_request(
         lm_ctx.client,
-        f"/config/{id}",
+        f"/lm/api/v1/config/{id}",
         "DELETE",
         expected_status=200,
         abort_message="Request to delete configuration was not accepted by the API",

--- a/lm-cli/lm_cli/subapps/licenses.py
+++ b/lm-cli/lm_cli/subapps/licenses.py
@@ -48,7 +48,7 @@ def list_all(
         List,
         make_request(
             lm_ctx.client,
-            "/license/complete/all",
+            "/lm/api/v1/license/complete/all",
             "GET",
             expected_status=200,
             abort_message="Couldn't retrieve license list from API",


### PR DESCRIPTION
#### What
Add full path for backend route in each lm-cli request.

#### Why
The lm-cli project was the only one with the prefix for the LM API in the configuration. Adding the prefix in the code allows us to remove it from the bundles.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
