### PR TITLE
[ASP-2216] Refactor configuration create endpoint

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Changed return code for configuration create endpoint to 201
+* Improved configuration endpoints message responses
 
 2.2.16 -- 2022-11-22
 --------------------

--- a/backend/lm_backend/api/config.py
+++ b/backend/lm_backend/api/config.py
@@ -128,15 +128,18 @@ async def add_configuration(configuration: ConfigurationRow):
         # It is necessary to exclude None so the database won't attempt to insert a null id
         **configuration.dict(exclude_none=True),
     )
+
     try:
-        await database.execute(query)
-    except INTEGRITY_CHECK_EXCEPTIONS:
+        inserted_id = await database.execute(query)
+    except INTEGRITY_CHECK_EXCEPTIONS as e:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=(f"Couldn't insert config {configuration.id}), it already exists."),
+            detail=(f"Couldn't create configuration. Error: {str(e)}"),
         )
 
-    return dict(message=f"inserted {configuration.id}")
+    return dict(
+        message=f"Configuration id {inserted_id} created.",
+    )
 
 
 @database.transaction()

--- a/backend/lm_backend/api/config.py
+++ b/backend/lm_backend/api/config.py
@@ -117,6 +117,7 @@ async def get_config_id(product_feature: str):
 @database.transaction()
 @router.post(
     "/",
+    status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(guard.lockdown(Permissions.CONFIG_EDIT))],
 )
 async def add_configuration(configuration: ConfigurationRow):

--- a/backend/tests/api/test_config.py
+++ b/backend/tests/api/test_config.py
@@ -373,7 +373,7 @@ async def test_add_configuration__success(
 
     inject_security_header("owner1", Permissions.CONFIG_EDIT)
     response = await backend_client.post("/lm/api/v1/config", json=data)
-    assert response.status_code == 200
+    assert response.status_code == 201
 
     query = table_schemas.config_table.select().where(
         table_schemas.config_table.c.name == "Product 1: Features 1, 2, 3"
@@ -517,7 +517,7 @@ async def test_delete_configuration__success(
     inject_security_header("owner1", Permissions.CONFIG_EDIT)
     resp = await backend_client.delete("/lm/api/v1/config/100")
     assert resp.status_code == 200
-    assert resp.json()["message"] == "Deleted 100 from the configuration table."
+    assert resp.json()["message"] == "Configuration id 100 deleted."
 
 
 @mark.asyncio

--- a/lm-cli/CHANGELOG.rst
+++ b/lm-cli/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 --------------------
 * Updated configuration create command help text to include new configuration format
 * Updated requests to the backend API to use full path for routes
+* Improved error message handling when a request to the API fails
 
 2.2.15 -- 2022-10-26
 --------------------

--- a/lm-cli/lm_cli/requests.py
+++ b/lm-cli/lm_cli/requests.py
@@ -145,7 +145,7 @@ def make_request(
             unwrap(
                 f"""
                 {abort_message}:
-                Communication with the API failed.
+                Communication with the API failed. Error: [red]{str(err)}[/red]
                 """
             ),
             subject=abort_subject,
@@ -155,11 +155,15 @@ def make_request(
         )
 
     if expected_status is not None and response.status_code != expected_status:
+        try:
+            error_message_text = response.json()["detail"]
+        except Exception:
+            error_message_text = response.text
+
         raise Abort(
             unwrap(
                 f"""
-                {abort_message}:
-                Received an error response [red]({response.text})[/red].
+                {abort_message}: Received an error response. Error message: [red]{error_message_text}[/red].
                 """
             ),
             subject=abort_subject,

--- a/lm-cli/lm_cli/subapps/configurations.py
+++ b/lm-cli/lm_cli/subapps/configurations.py
@@ -175,8 +175,8 @@ def create(
         lm_ctx.client,
         "/lm/api/v1/config/",
         "POST",
-        expected_status=200,
-        abort_message="Couldn't create configuration",
+        expected_status=201,
+        abort_message="Configuration creation failed",
         support=True,
         request_model=request_data,
     )

--- a/lm-cli/tests/subapps/test_bookings.py
+++ b/lm-cli/tests/subapps/test_bookings.py
@@ -14,7 +14,7 @@ def test_list_all__makes_request_and_renders_results(
     """
     Test if the list all command fetches and renders the bookings result.
     """
-    respx_mock.get(f"{dummy_domain}/booking/all").mock(
+    respx_mock.get(f"{dummy_domain}/lm/api/v1/booking/all").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dummy_booking_data,

--- a/lm-cli/tests/subapps/test_configurations.py
+++ b/lm-cli/tests/subapps/test_configurations.py
@@ -77,7 +77,7 @@ def test_create__success(
     """
     create_route = respx_mock.post(f"{dummy_domain}/lm/api/v1/config/").mock(
         return_value=httpx.Response(
-            httpx.codes.OK,
+            httpx.codes.CREATED,
             json={"message": "inserted 1"},
         ),
     )

--- a/lm-cli/tests/subapps/test_configurations.py
+++ b/lm-cli/tests/subapps/test_configurations.py
@@ -18,7 +18,7 @@ def test_list_all__makes_request_and_renders_results(
     """
     Test if the list all command fetches and renders the configurations result.
     """
-    respx_mock.get(f"{dummy_domain}/config/all").mock(
+    respx_mock.get(f"{dummy_domain}/lm/api/v1/config/all").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dummy_configuration_data,
@@ -47,7 +47,7 @@ def test_get_one__success(
     """
     Test if the get one command fetches and renders a single configuration by id.
     """
-    respx_mock.get(f"{dummy_domain}/config/1").mock(
+    respx_mock.get(f"{dummy_domain}/lm/api/v1/config/1").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dummy_configuration_data[0],
@@ -75,7 +75,7 @@ def test_create__success(
     """
     Test if the create command makes the request with the parsed arguments to create the configuration.
     """
-    create_route = respx_mock.post(f"{dummy_domain}/config/").mock(
+    create_route = respx_mock.post(f"{dummy_domain}/lm/api/v1/config/").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json={"message": "inserted 1"},
@@ -110,7 +110,7 @@ def test_delete__success(respx_mock, make_test_app, dummy_domain, cli_runner, mo
     """
     Test if the delete command makes the request to delete the configuration by id.
     """
-    delete_route = respx_mock.delete(f"{dummy_domain}/config/1").mock(
+    delete_route = respx_mock.delete(f"{dummy_domain}/lm/api/v1/config/1").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json={"message": "Deleted 1 from the configuration table."},

--- a/lm-cli/tests/subapps/test_licenses.py
+++ b/lm-cli/tests/subapps/test_licenses.py
@@ -14,7 +14,7 @@ def test_list_all__makes_request_and_renders_results(
     """
     Test if the list all command fetches and renders the licenses result.
     """
-    respx_mock.get(f"{dummy_domain}/license/complete/all").mock(
+    respx_mock.get(f"{dummy_domain}/lm/api/v1/license/complete/all").mock(
         return_value=httpx.Response(
             httpx.codes.OK,
             json=dummy_license_data,


### PR DESCRIPTION
#### What
Refactor the configuration create endpoint to return an informative message:
- returns the created config id if succeeded
- returns the error that caused it to fail in if it fails
Also changed return code to 201 (Created) upon successful creation.

Update the lm-cli request wrapper to include the error message from a failed request.

#### Why
To improve the usability of the API and the CLI to facing customers.

`Task`: https://jira.scania.com/browse/ASP-2216

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
