### PR TITLE
[ASP-2214] Move utils module to main folder

### DIFF
--- a/agent/lm_agent/exceptions.py
+++ b/agent/lm_agent/exceptions.py
@@ -27,3 +27,7 @@ class LicenseManagerNonSupportedServerTypeError(Buzz):
 
 class LicenseManagerBadServerOutput(Buzz):
     """Exception for license server bad output."""
+
+
+class CommandFailedToExecute(Buzz):
+    """Exception for failed execution of command."""

--- a/agent/lm_agent/server_interfaces/flexlm.py
+++ b/agent/lm_agent/server_interfaces/flexlm.py
@@ -5,7 +5,7 @@ from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.parsing import flexlm
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
-from lm_agent.server_interfaces.utils import run_command
+from lm_agent.utils import run_command
 
 
 class FlexLMLicenseServer(LicenseServerInterface):
@@ -38,7 +38,7 @@ class FlexLMLicenseServer(LicenseServerInterface):
             output = await run_command(feature_cmd)
 
             # try the next server if the previous didn't return the expected data
-            if output is None:
+            if not output:
                 continue
             return output
 

--- a/agent/lm_agent/server_interfaces/lmx.py
+++ b/agent/lm_agent/server_interfaces/lmx.py
@@ -5,7 +5,7 @@ from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.parsing import lmx
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
-from lm_agent.server_interfaces.utils import run_command
+from lm_agent.utils import run_command
 
 
 class LMXLicenseServer(LicenseServerInterface):
@@ -37,7 +37,7 @@ class LMXLicenseServer(LicenseServerInterface):
             output = await run_command(cmd)
 
             # try the next server if the previous didn't return the expected data
-            if output is None:
+            if not output:
                 continue
             return output
 

--- a/agent/lm_agent/server_interfaces/lsdyna.py
+++ b/agent/lm_agent/server_interfaces/lsdyna.py
@@ -5,7 +5,7 @@ from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.parsing import lsdyna
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
-from lm_agent.server_interfaces.utils import run_command
+from lm_agent.utils import run_command
 
 
 class LSDynaLicenseServer(LicenseServerInterface):
@@ -37,7 +37,7 @@ class LSDynaLicenseServer(LicenseServerInterface):
             output = await run_command(cmd)
 
             # try the next server if the previous didn't return the expected data
-            if output is None:
+            if not output:
                 continue
             return output
 

--- a/agent/lm_agent/server_interfaces/olicense.py
+++ b/agent/lm_agent/server_interfaces/olicense.py
@@ -5,7 +5,7 @@ from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.parsing import olicense
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
-from lm_agent.server_interfaces.utils import run_command
+from lm_agent.utils import run_command
 
 
 class OLicenseLicenseServer(LicenseServerInterface):
@@ -37,7 +37,7 @@ class OLicenseLicenseServer(LicenseServerInterface):
             output = await run_command(cmd)
 
             # try the next server if the previous didn't return the expected data
-            if output is None:
+            if not output:
                 continue
             return output
 

--- a/agent/lm_agent/server_interfaces/rlm.py
+++ b/agent/lm_agent/server_interfaces/rlm.py
@@ -5,7 +5,7 @@ from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBadServerOutput
 from lm_agent.parsing import rlm
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem, LicenseServerInterface
-from lm_agent.server_interfaces.utils import run_command
+from lm_agent.utils import run_command
 
 
 class RLMLicenseServer(LicenseServerInterface):
@@ -36,7 +36,7 @@ class RLMLicenseServer(LicenseServerInterface):
             output = await run_command(cmd)
 
             # try the next server if the previous didn't return the expected data
-            if output is None:
+            if not output:
                 continue
             return output
 

--- a/agent/lm_agent/utils.py
+++ b/agent/lm_agent/utils.py
@@ -7,13 +7,14 @@ from lm_agent.exceptions import CommandFailedToExecute
 from lm_agent.logs import logger
 
 
-async def run_command(command_line: str) -> str:
+async def run_command(*command_line_parts: str) -> str:
     """
     Run a command using a subprocess shell.
     Returns the output as string if the command succeeds.
     Raises CommandFailedToExecute exception if return code is not zero.
     """
 
+    command_line = shlex.join(command_line_parts)
     proc = await asyncio.create_subprocess_shell(
         command_line, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
     )

--- a/agent/lm_agent/utils.py
+++ b/agent/lm_agent/utils.py
@@ -1,11 +1,12 @@
-"""Provide utilities to be used by some of the license server interfaces."""
+"""Provide utilities to be used by interfaces."""
 import asyncio
+from typing import Union
 
 from lm_agent.config import ENCODING, TOOL_TIMEOUT
 from lm_agent.logs import logger
 
 
-async def run_command(command_line: str):
+async def run_command(command_line: str) -> Union[str, bool]:
     """Run a command using a subprocess shell."""
 
     proc = await asyncio.create_subprocess_shell(
@@ -17,6 +18,10 @@ async def run_command(command_line: str):
     output = str(stdout, encoding=ENCODING)
 
     if proc.returncode != 0:
-        logger.error(f"Error: {output} | Return Code: {proc.returncode}")
-        return None
+        logger.error(
+            f"Command {command_line} failed!",
+            f"Error: {output}",
+            f"Return code: {proc.returncode}",
+        )
+        return False
     return output


### PR DESCRIPTION
#### What
Move utils model to main folder.
It was in the `server_interfaces` folder before because it was only used by the license server interfaces.

#### Why
This file will be used by the reservation interface as well.

`Task`: https://jira.scania.com/browse/ASP-2214

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
