### PR TITLE
Fix Python version in GitHub Actions

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8
 
       - uses: Gr1N/setup-poetry@v7
         with:

--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8
   
       - uses: Gr1N/setup-poetry@v7
 


### PR DESCRIPTION
#### What
Fix Python version in GitHub Actions.

#### Why
The actions were broken with the version 3.8.10.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
