### PR TITLE
[ASP-2678] Fix overbooking issue

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Updated the booking create endpoint to fix overbooking issues
 
 2.2.18 -- 2023-01-26
 --------------------

--- a/backend/lm_backend/api/booking.py
+++ b/backend/lm_backend/api/booking.py
@@ -17,7 +17,6 @@ from lm_backend.api_schemas import (
     ConfigurationItem,
     ConfigurationRow,
     LicenseUse,
-    LicenseUseBooking,
 )
 from lm_backend.compat import INTEGRITY_CHECK_EXCEPTIONS
 from lm_backend.exceptions import LicenseManagerFeatureConfigurationIncorrect
@@ -33,6 +32,7 @@ from lm_backend.table_schemas import (
 
 router = APIRouter()
 
+# Lock used to prevent concurrent updates to the booking table
 lock = Lock()
 
 


### PR DESCRIPTION
#### What
Add an `async lock` to the create booking endpoint to ensure that concurrent requests won't be able to overbook licenses. Also remove leftover from code.

#### Why
To solve the overbooking issue reported by KTH.

`Task`: https://jira.scania.com/browse/ASP-2678

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
