### PR TITLE
[ASP-2544] Fix issue with create_or_update_reservation

### DIFF
--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -176,9 +176,9 @@ async def create_or_update_reservation(reservation_data):
             LicenseManagerReservationFailure.require_condition(
                 deleted, "Could not update or delete reservation."
             )
-
-    created = await scontrol_create_reservation(reservation_data, "30:00")
-    LicenseManagerReservationFailure.require_condition(created, "Could not create reservation.")
+    else:
+        created = await scontrol_create_reservation(reservation_data, "30:00")
+        LicenseManagerReservationFailure.require_condition(created, "Could not create reservation.")
 
 
 async def reconcile():


### PR DESCRIPTION
#### What
Fix issue with logic in the function `create_or_update_reservation`.

#### Why
The function was creating a reservation even if an existing one was already updated.

`Task`: https://jira.scania.com/browse/ASP-2544

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
