### PR TITLE
[ASP-2544] Change access token permission

### DIFF
--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -1,7 +1,7 @@
 """
 Provide utilities that communicate with the backend.
 """
-import shutil
+import getpass
 import typing
 
 import httpx
@@ -12,7 +12,8 @@ from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerAuthTokenError, LicenseManagerBackendConnectionError
 from lm_agent.logs import logger
 
-TOKEN_FILE_NAME = "access.token"
+USER_NAME = getpass.getuser()
+TOKEN_FILE_NAME = f"{USER_NAME}.token"
 
 
 def _load_token_from_cache() -> typing.Union[str, None]:
@@ -55,8 +56,8 @@ def _write_token_to_cache(token: str):
 
     token_path = settings.CACHE_DIR / TOKEN_FILE_NAME
     try:
-        token_path.touch(mode=0o660, exist_ok=True)
         token_path.write_text(token)
+        token_path.chmod(0o600)
         logger.debug(f"Successfully saved token to {token_path}")
     except Exception as err:
         logger.warning(f"Couldn't save token to {token_path}: {err}")

--- a/agent/lm_agent/backend_utils.py
+++ b/agent/lm_agent/backend_utils.py
@@ -40,6 +40,7 @@ def _load_token_from_cache() -> typing.Union[str, None]:
         logger.warning("Cached token is expired. Will acquire a new one.")
         return None
 
+    logger.debug(f"Successfully loaded token from cache file {token_path}.")
     return token
 
 
@@ -54,9 +55,9 @@ def _write_token_to_cache(token: str):
 
     token_path = settings.CACHE_DIR / TOKEN_FILE_NAME
     try:
-        token_path.touch(mode=0o600, exist_ok=True)
+        token_path.touch(mode=0o660, exist_ok=True)
         token_path.write_text(token)
-        shutil.chown(token_path, "slurm", "slurm")
+        logger.debug(f"Successfully saved token to {token_path}")
     except Exception as err:
         logger.warning(f"Couldn't save token to {token_path}: {err}")
 
@@ -84,9 +85,10 @@ def acquire_token() -> str:
         )
         with LicenseManagerAuthTokenError.handle_errors("Malformed response payload from OIDC"):
             token = response.json()["access_token"]
+
+        logger.debug("Successfully acquired auth token from OIDC")
         _write_token_to_cache(token)
 
-    logger.debug("Successfully acquired auth token from OIDC")
     return token
 
 

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -28,8 +28,8 @@ def test__write_token_to_cache__caches_a_token(mock_cache_dir):
     assert token_path.exists()
     assert token_path.read_text() == "dummy-token"
 
-    # Assert that the permissions for the file are read/write only for the current user
-    assert token_path.stat().st_mode & (stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO) == 0o600
+    # Assert that the permissions for the file are read/write for the current user and its group
+    assert token_path.stat().st_mode & (stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO) == 0o660
 
 
 def test__write_token_to_cache__warns_if_cache_dir_does_not_exist(caplog, mock_cache_dir):

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -28,8 +28,8 @@ def test__write_token_to_cache__caches_a_token(mock_cache_dir):
     assert token_path.exists()
     assert token_path.read_text() == "dummy-token"
 
-    # Assert that the permissions for the file are read/write for the current user and its group
-    assert token_path.stat().st_mode & (stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO) == 0o660
+    # Assert that the permissions for the file are read/write for the current user
+    assert token_path.stat().st_mode & (stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO) == 0o600
 
 
 def test__write_token_to_cache__warns_if_cache_dir_does_not_exist(caplog, mock_cache_dir):

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -28,7 +28,7 @@ def test__write_token_to_cache__caches_a_token(mock_cache_dir):
     assert token_path.exists()
     assert token_path.read_text() == "dummy-token"
 
-    # Assert that the permissions for the file are read/write for the current user
+    # Assert that the permissions for the file are read/write only for the current user
     assert token_path.stat().st_mode & (stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO) == 0o600
 
 


### PR DESCRIPTION
#### What
Change the cached access token creation to create one file for each user running the reconcile process.
Also improve log messages regarding token read/write operations.

#### Why
The agent runs as user `license-manager` (not `root` anymore), which is causing issues with the access token file owned by user `slurm`.
To solve this, each user will create its own access token in the cache directory, with permission 600 (read/write only for the owner). This also addresses security concerns regarding sharing a token file with multiple users.

`Task`: https://jira.scania.com/browse/ASP-2544

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
