### PR TITLE
[ASP-3467] Fix scontrol show lic regex parser bug

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Fix regex bug on scontrol show lic parser
 
 2.3.1 -- 2023-04-28
 -------------------

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -100,7 +100,7 @@ async def get_tokens_for_license(
         for line in scontrol_output.split("\n"):
             if matched:
                 return line
-            if len(re.findall(rf"({product_feature_server})", line)) > 0:
+            if re.fullmatch(rf"LicenseName={product_feature_server}", line) is not None:
                 matched = True
         return None
 


### PR DESCRIPTION
#### What
Change the method used to parse the license name from the scontrol show lic output.

#### Why
The previous method was matching licenses with similar product names.

`Task`: https://jira.scania.com/browse/ASP-3467

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
