### PR TITLE
Add force_refresh to read method and where needed

### DIFF
--- a/backend/lm_backend/api/cruds/generic.py
+++ b/backend/lm_backend/api/cruds/generic.py
@@ -62,7 +62,9 @@ class GenericCRUD:
 
         return db_obj
 
-    async def read(self, db_session: AsyncSession, id: Union[Column[int], int]) -> Optional[ModelType]:
+    async def read(
+        self, db_session: AsyncSession, id: Union[Column[int], int], force_refresh: bool = False
+    ) -> Optional[ModelType]:
         """
         Read an object from the database with the given id.
         Returns the object or raise an exception if it does not exist.
@@ -76,6 +78,9 @@ class GenericCRUD:
 
         if db_obj is None:
             raise HTTPException(status_code=404, detail=f"{self.model.__name__} not found.")
+
+        if force_refresh:
+            await db_session.refresh(db_obj)
 
         return db_obj
 

--- a/backend/lm_backend/api/routes/configurations.py
+++ b/backend/lm_backend/api/routes/configurations.py
@@ -48,6 +48,7 @@ async def read_all_configurations(
         search=search,
         sort_field=sort_field,
         sort_ascending=sort_ascending,
+        force_refresh=True,
     )
 
 
@@ -61,7 +62,7 @@ async def read_configuration(
     secure_session: SecureSession = Depends(secure_session(Permissions.CONFIG_VIEW)),
 ):
     """Return a configuration with the associated license severs and features with a given id."""
-    return await crud.read(db_session=secure_session.session, id=configuration_id)
+    return await crud.read(db_session=secure_session.session, id=configuration_id, force_refresh=True)
 
 
 @router.put(

--- a/backend/lm_backend/api/routes/features.py
+++ b/backend/lm_backend/api/routes/features.py
@@ -30,7 +30,9 @@ async def create_feature(
     feature_created: Feature = await crud_feature.create(db_session=secure_session.session, obj=feature)
     inventory = InventoryCreateSchema(feature_id=feature_created.id, total=0, used=0)
     await crud_inventory.create(db_session=secure_session.session, obj=inventory)
-    return await crud_feature.read(db_session=secure_session.session, id=feature_created.id)
+    return await crud_feature.read(
+        db_session=secure_session.session, id=feature_created.id, force_refresh=True
+    )
 
 
 @router.get(
@@ -64,7 +66,7 @@ async def read_feature(
     secure_session: SecureSession = Depends(secure_session(Permissions.FEATURE_VIEW)),
 ):
     """Return a feature with associated bookings and inventory with the given id."""
-    return await crud_feature.read(db_session=secure_session.session, id=feature_id)
+    return await crud_feature.read(db_session=secure_session.session, id=feature_id, force_refresh=True)
 
 
 @router.put(
@@ -106,7 +108,7 @@ async def update_inventory(
             obj=inventory_update,
         )
 
-    return await crud_feature.read(db_session=secure_session.session, id=feature_id)
+    return await crud_feature.read(db_session=secure_session.session, id=feature_id, force_refresh=True)
 
 
 @router.delete(

--- a/backend/lm_backend/api/routes/jobs.py
+++ b/backend/lm_backend/api/routes/jobs.py
@@ -45,7 +45,7 @@ async def create_job(
             await crud_job.delete(db_session=secure_session.session, id=job_created.id)
             raise
 
-    return await crud_job.read(db_session=secure_session.session, id=job_created.id)
+    return await crud_job.read(db_session=secure_session.session, id=job_created.id, force_refresh=True)
 
 
 @router.get(
@@ -61,7 +61,11 @@ async def read_all_jobs(
 ):
     """Return all jobs."""
     return await crud_job.read_all(
-        db_session=secure_session.session, search=search, sort_field=sort_field, sort_ascending=sort_ascending
+        db_session=secure_session.session,
+        search=search,
+        sort_field=sort_field,
+        sort_ascending=sort_ascending,
+        force_refresh=True,
     )
 
 
@@ -75,7 +79,7 @@ async def read_job(
     secure_session: SecureSession = Depends(secure_session(Permissions.JOB_VIEW)),
 ):
     """Return a job with associated bookings with the given id."""
-    return await crud_job.read(db_session=secure_session.session, id=job_id)
+    return await crud_job.read(db_session=secure_session.session, id=job_id, force_refresh=True)
 
 
 @router.delete(
@@ -107,7 +111,9 @@ async def delete_job_by_slurm_id(
 
     Since the slurm_job_id can be the same across clusters, we need the cluster_id to validate.
     """
-    jobs: List[Job] = await crud_job.read_all(db_session=secure_session.session, search=slurm_job_id)
+    jobs: List[Job] = await crud_job.read_all(
+        db_session=secure_session.session, search=slurm_job_id, force_refresh=True
+    )
 
     for job in jobs:
         if job.cluster_id == cluster_id:
@@ -133,7 +139,9 @@ async def read_job_by_slurm_id(
 
     Since the slurm_job_id can be the same across clusters, we need the cluster_id to validate.
     """
-    jobs: List[Job] = await crud_job.read_all(db_session=secure_session.session, search=slurm_job_id)
+    jobs: List[Job] = await crud_job.read_all(
+        db_session=secure_session.session, search=slurm_job_id, force_refresh=True
+    )
 
     for job in jobs:
         if job.cluster_id == cluster_id:


### PR DESCRIPTION
#### What
Add `force_refresh` parameter to the Generic CRUD `read` method and use it in the routes where the relationships need to be loaded.

#### Why
When creating a job with bookings or a feature with inventory, the nested relationship was returning empty because the refresh was not being done in the `read` method.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
