### PR TITLE
Fix organization payload

### DIFF
--- a/backend/lm_backend/security.py
+++ b/backend/lm_backend/security.py
@@ -68,15 +68,21 @@ class IdentityPayload(TokenPayload):
             }
         }
         """
-        organization_dict = values.pop("organization", None)
-        if organization_dict is None:
+        organization_payload = values.pop("organization", None)
+        if organization_payload is None:
             return values
-
-        if not isinstance(organization_dict, dict):
-            raise ValueError(f"Invalid organization payload: {organization_dict}")
-        elif len(organization_dict) != 1:
-            raise ValueError(f"Organization payload did not include exactly one value: {organization_dict}")
-        return {**values, "organization_id": next(iter(organization_dict))}
+        if not isinstance(organization_payload, dict) and not isinstance(organization_payload, str):
+            raise ValueError(f"Invalid organization payload: {organization_payload}")
+        elif len(organization_payload) != 1 and isinstance(organization_payload, dict):
+            raise ValueError(
+                f"Organization payload did not include exactly one value: {organization_payload}"
+            )
+        return {
+            **values,
+            "organization_id": next(iter(organization_payload))
+            if isinstance(organization_payload, dict)
+            else organization_payload,
+        }
 
 
 def lockdown_with_identity(*scopes: str, permission_mode: PermissionMode = PermissionMode.ALL):

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -66,12 +66,12 @@ def test_identity_payload__extracts_organization_id_successfully():
     assert identity.organization_id == "dummy-organization-id"
 
 
-def test_identity_payload__fails_validation_with_non_dict_organization():
+def test_identity_payload__fails_validation_with_non_dict_organization_or_non_string():
     token_payload = {
         "exp": 1689105153,
         "sub": "dummy-sub",
         "azp": "dummy-client-id",
-        "organization": "dummy-organization-id",
+        "organization": 1234,
     }
     with pytest.raises(ValidationError, match="Invalid organization payload"):
         IdentityPayload(**token_payload)


### PR DESCRIPTION
#### What
Fix the organization validation in the token payload.

#### Why
The token payload from the CLI device code authentication didn't fit the previous validation.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
