### PR TITLE
Fix bug in reconciliation

### DIFF
--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -194,10 +194,15 @@ async def reconcile():
         if reservation_amount:
             reservation_data.append(f"{product_feature}@{license_server_type}:{reservation_amount}")
 
-    # Create the reservation or update the existing one
-    logger.debug(f"Reservation data: {reservation_data}")
-    await create_or_update_reservation(",".join(reservation_data))
-    logger.debug("Reconciliation done")
+        if reservation_data:
+            logger.debug(f"Reservation data: {reservation_data}")
+
+            # Create the reservation or update the existing one
+            await create_or_update_reservation(",".join(reservation_data))
+        else:
+            logger.debug("No reservation needed")
+
+        logger.debug("Reconciliation done")
 
 
 async def update_features() -> List[dict]:


### PR DESCRIPTION
#### What
Fix the bug in the reconciliation when no reservation is needed.

#### Why
In the case where no reservation is needed, it was trying to create a blank reservation, which fails and prevents the reconciliation from running.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
