### PR TITLE
Fix bug in /types route

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Fixed bug in /license_servers/types route and updated it to use authentication
 
 3.0.0 -- 2023-08-08
 -------------------

--- a/backend/lm_backend/api/routes/license_servers.py
+++ b/backend/lm_backend/api/routes/license_servers.py
@@ -19,6 +19,18 @@ router = APIRouter()
 crud_license_server = GenericCRUD(LicenseServer, LicenseServerCreateSchema, LicenseServerUpdateSchema)
 
 
+@router.get(
+    "/types/",
+    status_code=status.HTTP_200_OK,
+    response_model=List[LicenseServerType],
+)
+async def get_license_server_types(
+    secure_session: SecureSession = Depends(secure_session(Permissions.LICENSE_SERVER_VIEW)),
+):
+    """Return a list of the available license server types."""
+    return list(LicenseServerType)
+
+
 @router.post(
     "",
     response_model=LicenseServerSchema,
@@ -90,13 +102,3 @@ async def delete_license_server(
 ):
     """Delete a license server from the database."""
     return await crud_license_server.delete(db_session=secure_session.session, id=license_server_id)
-
-
-@router.get(
-    "/types/",
-    status_code=status.HTTP_200_OK,
-    response_model=List[LicenseServerType],
-)
-async def get_license_server_types():
-    """Return a list of the available license server types."""
-    return LicenseServerType


### PR DESCRIPTION
#### What
Fix bug in `/license_servers/types` route that was preventing it from returning a list of license servers type.
Also add authentication to the route.

#### Why
To ensure it's working as expected.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
