### PR TITLE
Fix features sort fields

### DIFF
--- a/backend/CHANGELOG.rst
+++ b/backend/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-backend
 
 Unreleased
 ----------
+* Added total and used as sortable fields in /features route
 
 3.0.1 -- 2023-08-10
 -------------------

--- a/backend/lm_backend/api/models/feature.py
+++ b/backend/lm_backend/api/models/feature.py
@@ -30,7 +30,7 @@ class Feature(Base):
     configurations = relationship("Configuration", back_populates="features", lazy="selectin")
 
     searchable_fields = [name]
-    sortable_fields = [name, product_id, config_id]
+    sortable_fields = [name, product_id, config_id, total, used, reserved]
 
     @hybrid_property
     def booked_total(self) -> int:


### PR DESCRIPTION
#### What
Add `total` and `used` as sort fields in `/features` endpoint.

#### Why
After those fields were migrated from `/inventories` to `/features`, the sort fields were not updated accordingly.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
