### PR TITLE
[ASP-3748] Reduce scontrol show lic calls

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 * Improve function to get bookings sum from backend
+* Improve function to get used values from cluster
 
 3.0.3 -- 2023-08-17
 -------------------

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -20,7 +20,7 @@ from lm_agent.license_report import report
 from lm_agent.logs import logger
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
 from lm_agent.workload_managers.slurm.cmd_utils import (
-    get_tokens_for_license,
+    get_all_features_used_values,
     return_formatted_squeue_out,
     squeue_parser,
 )
@@ -138,6 +138,9 @@ async def reconcile():
     # Get feature bookings sum
     all_features_bookings_sum = await get_all_features_bookings_sum()
 
+    # Get license usage from the cluster
+    all_features_used_value = await get_all_features_used_values()
+
     # Delete bookings for jobs that reached the grace time
     logger.debug("Cleaning jobs by grace time")
     await clean_jobs_by_grace_time()
@@ -168,7 +171,7 @@ async def reconcile():
                     reserved = feature.reserved
 
         # Get license usage from the cluster
-        slurm_used = await get_tokens_for_license(f"{product_feature}@{license_server_type}", "Used")
+        slurm_used = all_features_used_value[product_feature]
 
         """
         The reserved amount represents how many licenses are already in use:

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -179,7 +179,7 @@ async def test__clean_jobs_by_grace_time__dont_delete_if_no_jobs(
 @pytest.mark.asyncio
 @pytest.mark.respx(base_url="http://backend")
 @mock.patch("lm_agent.reconciliation.create_or_update_reservation")
-@mock.patch("lm_agent.reconciliation.get_tokens_for_license")
+@mock.patch("lm_agent.reconciliation.get_all_features_used_values")
 @mock.patch("lm_agent.reconciliation.get_cluster_configs_from_backend")
 @mock.patch("lm_agent.reconciliation.get_all_features_bookings_sum")
 @mock.patch("lm_agent.reconciliation.update_features")
@@ -189,7 +189,7 @@ async def test__reconcile__success(
     update_features_mock,
     get_bookings_sum_mock,
     get_configs_from_backend_mock,
-    get_tokens_mock,
+    get_all_used_mock,
     create_or_update_reservation_mock,
     respx_mock,
     parsed_configurations,
@@ -227,7 +227,7 @@ async def test__reconcile__success(
     ]
     get_configs_from_backend_mock.return_value = parsed_configurations
     get_bookings_sum_mock.return_value = {"abaqus.abaqus": 103}
-    get_tokens_mock.return_value = 23
+    get_all_used_mock.return_value = {"abaqus.abaqus": 23}
 
     await reconcile()
     create_or_update_reservation_mock.assert_called_with("abaqus.abaqus@flexlm:380")


### PR DESCRIPTION
#### What
Update the function to get `used` values from cluster to make one `scontrol show lic` call instead of `n` calls for `n` features.

#### Why
The agent was timing out due to the number of requests/commands being invoked during the reconciliation, which can be prevented with optimizations such as this one.

`Task`: https://jira.scania.com/browse/ASP-3748

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
