### PR TITLE
Fix job not found issue

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Fix bug when retrieving bookings for non existing job
 
 3.0.5 -- 2023-08-29
 -------------------

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -344,7 +344,7 @@ async def test__make_feature_update__success(respx_mock):
             "total": 500,
             "used": 50,
         },
-        {   
+        {
             "product_name": "converge",
             "feature_name": "converge_super",
             "total": 100,
@@ -499,7 +499,7 @@ async def test__get_bookings_for_job_id__success(jobs, respx_mock):
 
 @pytest.mark.asyncio
 @pytest.mark.respx(base_url="http://backend")
-async def test__get_bookings_for_job_id__raises_exception_on_non_two_hundred(respx_mock):
+async def test__get_bookings_for_job_id__return_empty_on_non_two_hundred(respx_mock):
     """
     Test that get_bookings_for_job_id handles failure to retrieve bookings for a given job ID.
     """
@@ -512,5 +512,4 @@ async def test__get_bookings_for_job_id__raises_exception_on_non_two_hundred(res
         )
     )
 
-    with pytest.raises(LicenseManagerBackendConnectionError):
-        await get_bookings_for_job_id(slurm_job_id)
+    assert await get_bookings_for_job_id(slurm_job_id) == []

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -9,7 +9,6 @@ from lm_agent.reconciliation import (
     clean_jobs,
     clean_jobs_by_grace_time,
     create_or_update_reservation,
-    get_all_features_bookings_sum,
     get_greatest_grace_time_for_job,
     reconcile,
     update_features,
@@ -29,6 +28,23 @@ def test__get_greatest_grace_time_for_job(parsed_jobs):
     job_bookings = parsed_jobs[0].bookings
 
     expected_result = 20
+
+    result = get_greatest_grace_time_for_job(grace_times, job_bookings)
+    assert result == expected_result
+
+
+def test__get_greatest_grace_time_for_job__no_bookings():
+    """
+    Test if the function works when no bookings are provided.
+    """
+    grace_times = {
+        1: 10,
+        2: 20,
+    }
+
+    job_bookings = []
+
+    expected_result = -1
 
     result = get_greatest_grace_time_for_job(grace_times, job_bookings)
     assert result == expected_result


### PR DESCRIPTION
#### What
Fix issue with function to get bookings for a job when the job doesn't exist.

#### Why
If there's a job running on the cluster that doesn't have a job related to it in the database, the agent should not attempt to remove it. To do so, the booking's list should be empty, since it's used to determine if the job should be deleted.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
