### PR TITLE
Reduce requests to get bookings

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Update logic to fetch bookings for all jobs using one request
 
 3.0.6 -- 2023-08-29
 -------------------

--- a/agent/lm_agent/backend_utils/utils.py
+++ b/agent/lm_agent/backend_utils/utils.py
@@ -239,13 +239,13 @@ async def remove_job_by_slurm_job_id(slurm_job_id: str):
     logger.debug("##### Job removed successfully #####")
 
 
-async def get_bookings_for_all_jobs() -> Dict[int, List[BookingSchema]]:
+async def get_bookings_for_all_jobs() -> Dict[str, List[BookingSchema]]:
     """
     Return the bookings for all jobs in the cluster.
     """
     jobs = await get_cluster_jobs_from_backend()
 
-    bookings_for_all_jobs = {int(job.slurm_job_id): job.bookings for job in jobs}
+    bookings_for_all_jobs = {job.slurm_job_id: job.bookings for job in jobs}
 
     return bookings_for_all_jobs
 

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -69,7 +69,7 @@ async def clean_jobs_by_grace_time():
 
     # get the grace_time for each job
     for job in squeue_running_jobs:
-        slurm_job_id = job["job_id"]
+        slurm_job_id = str(job["job_id"])
         greatest_grace_time = get_greatest_grace_time_for_job(
             grace_times, cluster_jobs_bookings.get(slurm_job_id, [])
         )

--- a/agent/tests/test_backend_utils.py
+++ b/agent/tests/test_backend_utils.py
@@ -491,15 +491,15 @@ async def test__get_bookings_for_all_jobs__success(jobs, respx_mock):
     all_bookings = await get_bookings_for_all_jobs()
 
     assert all_bookings == {
-        123: [
+        "123": [
             BookingSchema(id=1, job_id=1, feature_id=1, quantity=12),
             BookingSchema(id=2, job_id=1, feature_id=2, quantity=50),
         ],
-        456: [
+        "456": [
             BookingSchema(id=3, job_id=2, feature_id=4, quantity=15),
             BookingSchema(id=4, job_id=2, feature_id=7, quantity=25),
         ],
-        789: [
+        "789": [
             BookingSchema(id=14, job_id=6, feature_id=4, quantity=5),
             BookingSchema(id=15, job_id=6, feature_id=7, quantity=17),
         ],

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -67,14 +67,14 @@ async def test__clean_jobs_by_grace_time__on_delete(
     """
     Test for cleaning jobs when running time is greater than grace_time.
     """
-    slurm_job_id = 123
+    slurm_job_id = "123"
     formatted_squeue_out = "123|5:00|RUNNING"
     grace_times = {1: 10, 2: 20}
 
     get_bookings_for_all_jobs_mock.return_value = {
-        123: parsed_jobs[0].bookings,
-        456: parsed_jobs[1].bookings,
-        789: parsed_jobs[2].bookings,
+        "123": parsed_jobs[0].bookings,
+        "456": parsed_jobs[1].bookings,
+        "789": parsed_jobs[2].bookings,
     }
     remove_job_by_slurm_job_id_mock.return_value = True
     return_formatted_squeue_out_mock.return_value = formatted_squeue_out
@@ -296,9 +296,9 @@ async def test__clean_jobs(remove_job_by_slurm_job_id_mock):
         {"job_id": 3, "state": "SUSPENDED"},
     ]
     cluster_jobs_bookings = {
-        1: [mock.Mock()],
-        2: [mock.Mock()],
-        3: [mock.Mock()],
+        "1": [mock.Mock()],
+        "2": [mock.Mock()],
+        "3": [mock.Mock()],
     }
     await clean_jobs(squeue_parsed, cluster_jobs_bookings)
 
@@ -313,13 +313,9 @@ async def test__clean_jobs__not_in_squeue(remove_job_by_slurm_job_id_mock):
     """
     squeue_parsed = [{"job_id": 1, "state": "RUNNING"}]
     cluster_jobs_bookings = {
-        1: [mock.Mock()],
-        2: [mock.Mock()],
+        "1": [mock.Mock()],
+        "2": [mock.Mock()],
     }
-    booking_mock_1 = mock.Mock()
-    booking_mock_1.job_id = 1
-    booking_mock_2 = mock.Mock()
-    booking_mock_2.job_id = 2
     await clean_jobs(squeue_parsed, cluster_jobs_bookings)
 
     remove_job_by_slurm_job_id_mock.call_count == 1

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -53,15 +53,13 @@ def test__get_greatest_grace_time_for_job__no_bookings():
 @pytest.mark.asyncio
 @mock.patch("lm_agent.reconciliation.return_formatted_squeue_out")
 @mock.patch("lm_agent.reconciliation.get_cluster_grace_times")
-@mock.patch("lm_agent.reconciliation.get_bookings_for_job_id")
+@mock.patch("lm_agent.reconciliation.get_bookings_for_all_jobs")
 @mock.patch("lm_agent.reconciliation.remove_job_by_slurm_job_id")
-@mock.patch("lm_agent.reconciliation.get_cluster_jobs_from_backend")
 @mock.patch("lm_agent.reconciliation.clean_jobs")
 async def test__clean_jobs_by_grace_time__on_delete(
     clean_jobs_mock,
-    get_cluster_jobs_from_backend_mock,
     remove_job_by_slurm_job_id_mock,
-    get_bookings_for_job_id_mock,
+    get_bookings_for_all_jobs_mock,
     get_cluster_grace_times_mock,
     return_formatted_squeue_out_mock,
     parsed_jobs,
@@ -69,13 +67,15 @@ async def test__clean_jobs_by_grace_time__on_delete(
     """
     Test for cleaning jobs when running time is greater than grace_time.
     """
-    slurm_job_id = 1
-    formatted_squeue_out = "1|5:00|RUNNING"
+    slurm_job_id = 123
+    formatted_squeue_out = "123|5:00|RUNNING"
     grace_times = {1: 10, 2: 20}
-    job_bookings = parsed_jobs[0].bookings
 
-    get_cluster_jobs_from_backend_mock.return_value = parsed_jobs
-    get_bookings_for_job_id_mock.return_value = job_bookings
+    get_bookings_for_all_jobs_mock.return_value = {
+        123: parsed_jobs[0].bookings,
+        456: parsed_jobs[1].bookings,
+        789: parsed_jobs[2].bookings,
+    }
     remove_job_by_slurm_job_id_mock.return_value = True
     return_formatted_squeue_out_mock.return_value = formatted_squeue_out
     get_cluster_grace_times_mock.return_value = grace_times
@@ -83,22 +83,20 @@ async def test__clean_jobs_by_grace_time__on_delete(
     await clean_jobs_by_grace_time()
 
     remove_job_by_slurm_job_id_mock.assert_awaited_once_with(slurm_job_id)
-    get_bookings_for_job_id_mock.assert_awaited_once_with(slurm_job_id)
+    get_bookings_for_all_jobs_mock.assert_called_once()
     get_cluster_grace_times_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
 @mock.patch("lm_agent.reconciliation.return_formatted_squeue_out")
 @mock.patch("lm_agent.reconciliation.get_cluster_grace_times")
-@mock.patch("lm_agent.reconciliation.get_bookings_for_job_id")
+@mock.patch("lm_agent.reconciliation.get_bookings_for_all_jobs")
 @mock.patch("lm_agent.reconciliation.remove_job_by_slurm_job_id")
-@mock.patch("lm_agent.reconciliation.get_cluster_jobs_from_backend")
 @mock.patch("lm_agent.reconciliation.clean_jobs")
 async def test__clean_jobs_by_grace_time__dont_delete(
     clean_jobs_mock,
-    get_jobs_from_backend_mock,
     remove_job_by_slurm_job_id_mock,
-    get_bookings_for_job_id_mock,
+    get_bookings_for_all_jobs_mock,
     get_cluster_grace_times_mock,
     return_formatted_squeue_out_mock,
     parsed_jobs,
@@ -106,35 +104,34 @@ async def test__clean_jobs_by_grace_time__dont_delete(
     """
     Test for when the running time is smaller than the grace_time, then don't delete the booking.
     """
-    slurm_job_id = 1
-    formatted_squeue_out = "1|5:00|RUNNING"
+    formatted_squeue_out = "123|5:00|RUNNING"
     grace_times = {1: 1000, 2: 3000}
-    job_bookings = parsed_jobs[0].bookings
 
-    get_jobs_from_backend_mock.return_value = parsed_jobs
-    get_bookings_for_job_id_mock.return_value = job_bookings
+    get_bookings_for_all_jobs_mock.return_value = {
+        123: parsed_jobs[0].bookings,
+        456: parsed_jobs[1].bookings,
+        789: parsed_jobs[2].bookings,
+    }
     return_formatted_squeue_out_mock.return_value = formatted_squeue_out
     get_cluster_grace_times_mock.return_value = grace_times
 
     await clean_jobs_by_grace_time()
 
     remove_job_by_slurm_job_id_mock.assert_not_awaited()
-    get_bookings_for_job_id_mock.assert_awaited_once_with(slurm_job_id)
+    get_bookings_for_all_jobs_mock.assert_called_once()
     get_cluster_grace_times_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
 @mock.patch("lm_agent.reconciliation.return_formatted_squeue_out")
 @mock.patch("lm_agent.reconciliation.get_cluster_grace_times")
-@mock.patch("lm_agent.reconciliation.get_bookings_for_job_id")
+@mock.patch("lm_agent.reconciliation.get_bookings_for_all_jobs")
 @mock.patch("lm_agent.reconciliation.remove_job_by_slurm_job_id")
-@mock.patch("lm_agent.reconciliation.get_cluster_jobs_from_backend")
 @mock.patch("lm_agent.reconciliation.clean_jobs")
 async def test__clean_jobs_by_grace_time__dont_delete_if_grace_time_invalid(
     clean_jobs_mock,
-    get_jobs_from_backend_mock,
     remove_job_by_slurm_job_id_mock,
-    get_bookings_for_job_id_mock,
+    get_bookings_for_all_jobs_mock,
     get_cluster_grace_times_mock,
     return_formatted_squeue_out_mock,
     parsed_jobs,
@@ -142,34 +139,34 @@ async def test__clean_jobs_by_grace_time__dont_delete_if_grace_time_invalid(
     """
     Test for when the grace_time is invalid because there aren't bookings in the job.
     """
-    slurm_job_id = 1
-    formatted_squeue_out = "1|5:00|RUNNING"
+    formatted_squeue_out = "123|5:00|RUNNING"
     grace_times = {1: 10, 2: 20}
 
-    get_jobs_from_backend_mock.return_value = parsed_jobs
-    get_bookings_for_job_id_mock.return_value = []
+    get_bookings_for_all_jobs_mock.return_value = {
+        123: [],
+        456: [],
+        789: [],
+    }
     return_formatted_squeue_out_mock.return_value = formatted_squeue_out
     get_cluster_grace_times_mock.return_value = grace_times
 
     await clean_jobs_by_grace_time()
 
     remove_job_by_slurm_job_id_mock.assert_not_awaited()
-    get_bookings_for_job_id_mock.assert_awaited_once_with(slurm_job_id)
+    get_bookings_for_all_jobs_mock.assert_awaited_once()
     get_cluster_grace_times_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
 @mock.patch("lm_agent.reconciliation.return_formatted_squeue_out")
 @mock.patch("lm_agent.reconciliation.get_cluster_grace_times")
-@mock.patch("lm_agent.reconciliation.get_bookings_for_job_id")
+@mock.patch("lm_agent.reconciliation.get_bookings_for_all_jobs")
 @mock.patch("lm_agent.reconciliation.remove_job_by_slurm_job_id")
-@mock.patch("lm_agent.reconciliation.get_cluster_jobs_from_backend")
 @mock.patch("lm_agent.reconciliation.clean_jobs")
 async def test__clean_jobs_by_grace_time__dont_delete_if_no_jobs(
     clean_jobs_mock,
-    get_jobs_from_backend_mock,
     remove_job_by_slurm_job_id_mock,
-    get_bookings_for_job_id_mock,
+    get_bookings_for_all_jobs_mock,
     get_cluster_grace_times_mock,
     return_formatted_squeue_out_mock,
     parsed_jobs,
@@ -180,15 +177,18 @@ async def test__clean_jobs_by_grace_time__dont_delete_if_no_jobs(
     formatted_squeue_out = ""
     grace_times = {1: 10, 2: 20}
 
-    get_jobs_from_backend_mock.return_value = parsed_jobs
-    get_bookings_for_job_id_mock.return_value = []
+    get_bookings_for_all_jobs_mock.return_value = {
+        123: parsed_jobs[0].bookings,
+        456: parsed_jobs[1].bookings,
+        789: parsed_jobs[2].bookings,
+    }
     return_formatted_squeue_out_mock.return_value = formatted_squeue_out
     get_cluster_grace_times_mock.return_value = grace_times
 
     await clean_jobs_by_grace_time()
 
     remove_job_by_slurm_job_id_mock.assert_not_awaited()
-    get_bookings_for_job_id_mock.assert_not_awaited()
+    get_bookings_for_all_jobs_mock.assert_not_awaited()
     get_cluster_grace_times_mock.assert_not_called()
 
 
@@ -285,9 +285,8 @@ async def test__update_features__put_failed(
 
 
 @pytest.mark.asyncio
-@mock.patch("lm_agent.reconciliation.get_cluster_jobs_from_backend")
 @mock.patch("lm_agent.reconciliation.remove_job_by_slurm_job_id")
-async def test__clean_jobs(remove_job_by_slurm_job_id_mock, get_jobs_from_backend_mock):
+async def test__clean_jobs(remove_job_by_slurm_job_id_mock):
     """
     Check that the jobs that aren't running are cleaned.
     """
@@ -296,30 +295,32 @@ async def test__clean_jobs(remove_job_by_slurm_job_id_mock, get_jobs_from_backen
         {"job_id": 2, "state": "COMPLETED"},
         {"job_id": 3, "state": "SUSPENDED"},
     ]
-    booking_mock_2 = mock.Mock()
-    booking_mock_2.job_id = 2
-    booking_mock_3 = mock.Mock()
-    booking_mock_3.job_id = 3
-    get_jobs_from_backend_mock.return_value = [booking_mock_2, booking_mock_3]
-    await clean_jobs(squeue_parsed)
+    cluster_jobs_bookings = {
+        1: [mock.Mock()],
+        2: [mock.Mock()],
+        3: [mock.Mock()],
+    }
+    await clean_jobs(squeue_parsed, cluster_jobs_bookings)
 
     remove_job_by_slurm_job_id_mock.call_count == 2
 
 
 @pytest.mark.asyncio
-@mock.patch("lm_agent.reconciliation.get_cluster_jobs_from_backend")
 @mock.patch("lm_agent.reconciliation.remove_job_by_slurm_job_id")
-async def test__clean_jobs__not_in_squeue(remove_job_by_slurm_job_id_mock, get_jobs_from_backend_mock):
+async def test__clean_jobs__not_in_squeue(remove_job_by_slurm_job_id_mock):
     """
     Check that jobs that aren't in squeue are cleaned.
     """
     squeue_parsed = [{"job_id": 1, "state": "RUNNING"}]
+    cluster_jobs_bookings = {
+        1: [mock.Mock()],
+        2: [mock.Mock()],
+    }
     booking_mock_1 = mock.Mock()
     booking_mock_1.job_id = 1
     booking_mock_2 = mock.Mock()
     booking_mock_2.job_id = 2
-    get_jobs_from_backend_mock.return_value = [booking_mock_1, booking_mock_2]
-    await clean_jobs(squeue_parsed)
+    await clean_jobs(squeue_parsed, cluster_jobs_bookings)
 
     remove_job_by_slurm_job_id_mock.call_count == 1
 


### PR DESCRIPTION
#### What
Reduces the number of requests needed to get the bookings for all jobs in the cluster.

#### Why
The previous version was making one request per job, which was hindering the performance of the agent.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
