### PR TITLE
[ASP-3519] Change default behavior upon report failure

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Change reconciliation to fully reserve licenses when the license server doesn't respond
 
 3.0.7 -- 2023-09-14
 -------------------

--- a/agent/lm_agent/license_report.py
+++ b/agent/lm_agent/license_report.py
@@ -97,9 +97,13 @@ async def report() -> typing.List[LicenseReportItem]:
 
     for result, product_feature in zip(results, product_features_awaited):
         if isinstance(result, Exception):
-            logger.error(f"#### Report for feature {product_feature} failed with: {result} ####")
-        else:
-            report_items.append(result)
+            # If the report for a feature failed, the total will set to 0, preventing jobs from running
+            logger.error(f"#### Report for feature {product_feature} failed with: {str(result)} ####")
+
+            failed_report_item = LicenseReportItem(product_feature=product_feature, used=0, total=0)
+            report_items.append(failed_report_item)
+            continue
+        report_items.append(result)
 
     logger.debug("#### Reconciliation items:")
     logger.debug(report_items)

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -19,7 +19,7 @@ from lm_agent.license_report import report
 from lm_agent.logs import logger
 from lm_agent.server_interfaces.license_server_interface import LicenseReportItem
 from lm_agent.workload_managers.slurm.cmd_utils import (
-    get_all_features_used_values,
+    get_all_features_cluster_values,
     return_formatted_squeue_out,
     squeue_parser,
 )
@@ -135,7 +135,7 @@ async def reconcile():
     all_features_bookings_sum = await get_all_features_bookings_sum()
 
     # Get license usage from the cluster
-    all_features_used_value = await get_all_features_used_values()
+    all_features_cluster_value = await get_all_features_cluster_values()
 
     # Delete bookings for jobs that reached the grace time
     logger.debug("Cleaning jobs by grace time")
@@ -153,8 +153,8 @@ async def reconcile():
     for license_data in license_usage_info:
         # Get license usage from license report
         product_feature = license_data.product_feature
-        server_used = license_data.used
-        total = license_data.total
+        report_used = license_data.used
+        report_total = license_data.total
 
         # Get booking information from backend
         booking_sum = all_features_bookings_sum[product_feature]
@@ -167,23 +167,32 @@ async def reconcile():
                     reserved = feature.reserved
 
         # Get license usage from the cluster
-        slurm_used = all_features_used_value[product_feature]
+        slurm_used = all_features_cluster_value[product_feature]["used"]
+        slurm_total = all_features_cluster_value[product_feature]["total"]
 
         """
         The reserved amount represents how many licenses are already in use:
         Either in the license server or booked for a job (bookings from other cluster as well).
-        If the license has a reserved value, it should be reserved too.
 
-        The reservation is not meant to be used by any user, it's a way to block usage of licenses
+        If the license has a reserved value (licenses exclusive for usage in desktop environments),
+        it should be added to the reservation too.
+
+        The reservation is not meant to be used by any user, it's a way to block usage of licenses.
+
+        If the report total is 0, it means that the license is not available in the license server
+        and it should be fully reserved to prevent jobs from running and crashing.
         """
 
-        reservation_amount = server_used - slurm_used + booking_sum + reserved
+        if report_total == 0:
+            reservation_amount = slurm_total
+        else:
+            reservation_amount = report_used - slurm_used + booking_sum + reserved
 
         if reservation_amount < 0:
             reservation_amount = 0
 
-        if reservation_amount > total:
-            reservation_amount = total
+        if reservation_amount > slurm_total:
+            reservation_amount = slurm_total
 
         if reservation_amount:
             reservation_data.append(f"{product_feature}@{license_server_type}:{reservation_amount}")

--- a/agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -85,10 +85,10 @@ def get_required_licenses_for_job(job_licenses: str) -> List:
     return required_licenses
 
 
-async def get_all_features_used_values() -> Optional[Dict[str, int]]:
+async def get_all_features_cluster_values() -> Optional[Dict[str, Dict[str, int]]]:
     """
     Parse the output from `scontrol show lic` and return a dictionary of
-    product_feature: used_tokens.
+    product_feature: {"total": <total>, "used": <used>}.
 
     Note: the line with the counters doesn't include the feature name,
     so to find the feature it's necessary to look at the previous line.
@@ -118,7 +118,7 @@ async def get_all_features_used_values() -> Optional[Dict[str, int]]:
         if parsed_used_tokens:
             used_data = parsed_used_tokens.groupdict()
             product_feature = product_feature_list[-1]
-            parsed_data[product_feature] = int(used_data["used"])
+            parsed_data[product_feature] = {"total": int(used_data["total"]), "used": int(used_data["used"])}
             continue
 
     return parsed_data

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -195,7 +195,7 @@ async def test__clean_jobs_by_grace_time__dont_delete_if_no_jobs(
 @pytest.mark.asyncio
 @pytest.mark.respx(base_url="http://backend")
 @mock.patch("lm_agent.reconciliation.create_or_update_reservation")
-@mock.patch("lm_agent.reconciliation.get_all_features_used_values")
+@mock.patch("lm_agent.reconciliation.get_all_features_cluster_values")
 @mock.patch("lm_agent.reconciliation.get_cluster_configs_from_backend")
 @mock.patch("lm_agent.reconciliation.get_all_features_bookings_sum")
 @mock.patch("lm_agent.reconciliation.update_features")
@@ -205,7 +205,7 @@ async def test__reconcile__success(
     update_features_mock,
     get_bookings_sum_mock,
     get_configs_from_backend_mock,
-    get_all_used_mock,
+    get_all_cluster_values_mock,
     create_or_update_reservation_mock,
     respx_mock,
     parsed_configurations,
@@ -243,7 +243,7 @@ async def test__reconcile__success(
     ]
     get_configs_from_backend_mock.return_value = parsed_configurations
     get_bookings_sum_mock.return_value = {"abaqus.abaqus": 103}
-    get_all_used_mock.return_value = {"abaqus.abaqus": 23}
+    get_all_cluster_values_mock.return_value = {"abaqus.abaqus": {"total": 1000, "used": 23}}
 
     await reconcile()
     create_or_update_reservation_mock.assert_called_with("abaqus.abaqus@flexlm:380")

--- a/agent/tests/workload_managers/slurm/test_cmd_utils.py
+++ b/agent/tests/workload_managers/slurm/test_cmd_utils.py
@@ -11,7 +11,7 @@ from lm_agent.workload_managers.slurm.cmd_utils import (
     LicenseBooking,
     SqueueParserUnexpectedInputError,
     _match_requested_license,
-    get_all_features_used_values,
+    get_all_features_cluster_values,
     get_all_product_features_from_cluster,
     get_required_licenses_for_job,
     squeue_parser,
@@ -215,10 +215,10 @@ async def test_get_product_features_from_cluster(
                 """
             ),
             {
-                "abaqus.abaqus": 90,
-                "product_name.feature_name": 0,
-                "converge.converge_super": 1,
-                "converge.converge_tecplot": 12,
+                "abaqus.abaqus": {"total": 1000, "used": 90},
+                "product_name.feature_name": {"total": 10, "used": 0},
+                "converge.converge_super": {"total": 9, "used": 1},
+                "converge.converge_tecplot": {"total": 45, "used": 12},
             },
         ),
         (
@@ -228,8 +228,8 @@ async def test_get_product_features_from_cluster(
     ],
 )
 @mock.patch("lm_agent.workload_managers.slurm.cmd_utils.scontrol_show_lic")
-async def test_get_all_features_used_values(
+async def test_get_all_features_cluster_values(
     show_lic_mock: mock.MagicMock, show_lic_output: str, used_features: dict
 ):
     show_lic_mock.return_value = show_lic_output
-    assert used_features == await get_all_features_used_values()
+    assert used_features == await get_all_features_cluster_values()


### PR DESCRIPTION
#### What
Change the default behavior of the license report module to output an empty report if the agent can't reach the license server. This will make the reservation fully reserve the license to prevent jobs from running.

#### Why
It was a user request to prevent jobs from running when the license server isn't available. If the job starts but can't reach the license server to checkout the license, it will fail.

`Task`: https://jira.scania.com/browse/ASP-3519
---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
