### PR TITLE
Fix clean jobs arguments

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to license-manager-agent
 
 Unreleased
 ----------
+* Fix issue with clean jobs arguments not being passed to the function
+
 3.0.8 -- 2023-09-20
 -------------------
 * Change reconciliation to fully reserve licenses when the license server doesn't respond

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -53,17 +53,17 @@ async def clean_jobs_by_grace_time():
     """
     logger.debug("GRACE_TIME START")
 
+    cluster_jobs_bookings = await get_bookings_for_all_jobs()
+    
     formatted_squeue_output = return_formatted_squeue_out()
     if not formatted_squeue_output:
         logger.debug("GRACE_TIME no squeue")
-        await clean_jobs(None)
+        await clean_jobs(None, cluster_jobs_bookings)
         logger.debug("GRACE_TIME cleaned bookings that are not in the queue")
         return
 
     squeue_result = squeue_parser(formatted_squeue_output)
     squeue_running_jobs = get_running_jobs(squeue_result)
-
-    cluster_jobs_bookings = await get_bookings_for_all_jobs()
 
     grace_times = await get_cluster_grace_times()
 

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -188,7 +188,7 @@ async def test__clean_jobs_by_grace_time__dont_delete_if_no_jobs(
     await clean_jobs_by_grace_time()
 
     remove_job_by_slurm_job_id_mock.assert_not_awaited()
-    get_bookings_for_all_jobs_mock.assert_not_awaited()
+    get_bookings_for_all_jobs_mock.assert_awaited_once()
     get_cluster_grace_times_mock.assert_not_called()
 
 


### PR DESCRIPTION
#### What
Fix the call to `clean_jobs()` when the squeue output is None.

#### Why
The parameters of `clean_jobs()` changed but this line of code wasn't updated accordingly.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
