### PR TITLE
Remove timeout

### DIFF
--- a/agent/CHANGELOG.rst
+++ b/agent/CHANGELOG.rst
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to license-manager-agent
 Unreleased
 ----------
 * Fix issue with clean jobs arguments not being passed to the function
+* Remove timeout from backend client to avoid issues with long running requests
 
 3.0.8 -- 2023-09-20
 -------------------

--- a/agent/lm_agent/backend_utils/utils.py
+++ b/agent/lm_agent/backend_utils/utils.py
@@ -115,7 +115,7 @@ class AsyncBackendClient(httpx.AsyncClient):
 
     def __init__(self):
         self._token = None
-        super().__init__(base_url=settings.BACKEND_BASE_URL, auth=self._inject_token)
+        super().__init__(base_url=settings.BACKEND_BASE_URL, auth=self._inject_token, timeout=None)
 
     def _inject_token(self, request: httpx.Request) -> httpx.Request:
         if self._token is None:


### PR DESCRIPTION
#### What
Set the timeout in the backend client to None.

#### Why
It was making the reconciliation fail when the API takes more than 5s to respond.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
