### PR TITLE
[PENG-1938] Fix booked_total null values

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to `license-manager-backend`.
 
 ## Unreleased
+* Fix bug in Feature read method that was returning None for the booked_total field
 
 ## 3.0.11 -- 2023-12-12
 * Add support to Python 3.12

--- a/backend/lm_backend/api/models/feature.py
+++ b/backend/lm_backend/api/models/feature.py
@@ -56,6 +56,5 @@ class Feature(CrudBase):
             f"config_id={self.config_id}, "
             f"total={self.total}, "
             f"used={self.used}, "
-            f"reserved={self.reserved}, "
-            f"booked_total={self.booked_total})"
+            f"reserved={self.reserved})"
         )

--- a/backend/lm_backend/api/routes/features.py
+++ b/backend/lm_backend/api/routes/features.py
@@ -61,7 +61,7 @@ async def read_feature(
     secure_session: SecureSession = Depends(secure_session(Permissions.FEATURE_VIEW, commit=False)),
 ):
     """Return a feature with associated bookings with the given id."""
-    return await crud_feature.read(db_session=secure_session.session, id=feature_id, force_refresh=True)
+    return await crud_feature.read(db_session=secure_session.session, id=feature_id)
 
 
 @router.put(

--- a/backend/lm_backend/api/schemas/feature.py
+++ b/backend/lm_backend/api/schemas/feature.py
@@ -147,7 +147,7 @@ class FeatureSchema(BaseModel):
         description="The quantity of the feature that is used.",
     )
     booked_total: Optional[NonNegativeInt] = Field(
-        None,
+        0,
         title="Booked total quantity",
         description="The total quantity of licenses that are booked.",
     )


### PR DESCRIPTION
#### What
Implement a submethod in FeatureCRUD to use a dedicated query for retrieving Features.

#### Why
The previous way of fetching the data was returning None for the booked_total field.

`Task`: https://app.clickup.com/t/18022949/PENG-1938

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
