### PR TITLE
[ASP-4349] Update reservation calcutation to remove the limit

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to `license-manager-agent`.
 
 ## Unreleased
+* Update reservation calculation to remove the reserved (limit) value [ASP-4349]
 
 ## 3.0.11 -- 2023-12-12
 * Add support to Python 3.12

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -205,6 +205,11 @@ async def reconcile():
     else:
         logger.debug("No reservation needed")
 
+        existing_reservation = await scontrol_show_reservation()
+        if existing_reservation:
+            logger.debug("Deleting existing reservation")
+            await scontrol_delete_reservation()
+
     logger.debug("Reconciliation done")
 
 

--- a/agent/lm_agent/reconciliation.py
+++ b/agent/lm_agent/reconciliation.py
@@ -164,7 +164,6 @@ async def reconcile():
             for feature in configuration.features:
                 if f"{feature.product.name}.{feature.name}" == product_feature:
                     license_server_type = configuration.type.value
-                    reserved = feature.reserved
 
         # Get license usage from the cluster
         slurm_used = all_features_cluster_value[product_feature]["used"]
@@ -175,7 +174,8 @@ async def reconcile():
         Either in the license server or booked for a job (bookings from other cluster as well).
 
         If the license has a reserved value (licenses exclusive for usage in desktop environments),
-        it should be added to the reservation too.
+        the value will be decreased from the Slurm counter and will be checked at booking creation
+        time. This implies that the value won't need to be added to the reservation.
 
         The reservation is not meant to be used by any user, it's a way to block usage of licenses.
 
@@ -186,7 +186,7 @@ async def reconcile():
         if report_total == 0:
             reservation_amount = slurm_total
         else:
-            reservation_amount = report_used - slurm_used + booking_sum + reserved
+            reservation_amount = report_used - slurm_used + booking_sum
 
         if reservation_amount < 0:
             reservation_amount = 0

--- a/agent/tests/test_reconciliation.py
+++ b/agent/tests/test_reconciliation.py
@@ -221,18 +221,23 @@ async def test__reconcile__success(
     Used in cluster: 23
 
     Overview of the license:
-    ________________________________________________________________________________
-    |    200   |    15     |     17    |    71    |     100     ||       597       |
-    |   used   |   booked  |   booked  |  booked  |   reserved  ||      free       |
-    | Lic serv | cluster 1 | cluster 2 | cluster3 | not to use  ||     to use      |
-    --------------------------------------------------------------------------------
+    _________________________________________________________________
+    |    200   |    15     |     17    |    71    |       697       |
+    |   used   |   booked  |   booked  |  booked  |      free       |
+    | Lic serv | cluster 1 | cluster 2 | cluster3 |     to use      |
+    -----------------------------------------------------------------
 
-    Since we have 303 licenses in use (booked or license server) and 100 that should
-    not be used (past the limit), the amount of licenses available is 597.
+    Since we have 303 licenses in use (booked or license server), the
+    amount of licenses available is 697.
 
-    This way, we need to block the remaing 403 licenses. But considering that Slurm
-    is already "blocking" 23 licenses that are in use in the cluster, the reservation
-    should block 380 licenses.
+    This way, we need to block the 303 licenses that are in use.
+    But considering that Slurm is already "blocking" 23 licenses
+    that are in use in the cluster, the reservation should block 280 licenses.
+
+    Formula to calculate the reservation:
+    reservation = lic serv used - slurm used + booked sum
+    reservation = 200 - 23 + 103 = 280
+
     """
     update_features_mock.return_value = [
         LicenseReportItem(
@@ -246,7 +251,7 @@ async def test__reconcile__success(
     get_all_cluster_values_mock.return_value = {"abaqus.abaqus": {"total": 1000, "used": 23}}
 
     await reconcile()
-    create_or_update_reservation_mock.assert_called_with("abaqus.abaqus@flexlm:380")
+    create_or_update_reservation_mock.assert_called_with("abaqus.abaqus@flexlm:280")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#### What
Update the reservation calculation to remove the limit (`reserved`) value for the licenses that have it.

The `reserved` value determines how many licenses should be reserved to users that run desktop applications.
These reserved licenses shouldn't be used by cluster users.

Previously, the `reserved` value was being added to the reservation to block those licenses in the cluster, but this approach was causing a bug where all licenses were used even though the reservation was in place.

To solve the issue, the license counters in the cluster will be decreased to exclude the reserved licenses.
This way the cluster won't know about these licenses.

When creating a `booking`, this value will be taken into consideration to determine if the booking can be created.

#### Why
To solve the bug reported by the user.

`Task`: https://jira.scania.com/browse/ASP-4349

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
