### PR TITLE
Release 3.0.13a0

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to `license-manager-agent`.
 
 ## Unreleased
 
+
+## 3.0.13a0 -- 2023-12-21
 ## 3.0.12 -- 2023-12-15
 * Update reservation calculation to remove the reserved (limit) value [ASP-4349]
 

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "3.0.12"
+version = "3.0.13a0"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file keeps track of all notable changes to `license-manager-backend`.
 
 ## Unreleased
+
+
+## 3.0.13a0 -- 2023-12-21
 * Change minimum Python version to 3.12
 * Update Dockerfile to use image python:3.12-slim-bullseye
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "3.0.12"
+version = "3.0.13a0"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-cli/CHANGELOG.md
+++ b/lm-cli/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to `license-manager-cli`.
 
 ## Unreleased
 
+
+## 3.0.13a0 -- 2023-12-21
 ## 3.0.12 -- 2023-12-15
 * Bumped version to keep in sync with backend and agent
 

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-cli"
-version = "3.0.12"
+version = "3.0.13a0"
 description = "License Manager CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
Automated changes by [prepare_release](https://github.com/omnivector-solutions/license-manager/blob/main/.github/workflows/prepare_release.yaml) GitHub action.