### PR TITLE
[PENG-1438] Update constraints to use max integer size

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `license-manager-backend`.
 
 ## Unreleased
-
+* Update constraints to limit int fields to 2**31-1
 
 ## 3.0.13a0 -- 2023-12-21
 * Change minimum Python version to 3.12

--- a/backend/lm_backend/api/schemas/booking.py
+++ b/backend/lm_backend/api/schemas/booking.py
@@ -13,8 +13,12 @@ class BookingCreateSchema(BaseCreateSchema):
 
     job_id: int = Field(..., title="Job ID", description="The ID of the job that booked the feature.")
     feature_id: int = Field(..., title="Feature ID", description="The ID of the feature that was booked.")
-    quantity: PositiveInt = Field(
-        ..., title="Quantity", description="The quantity of the feature that was booked."
+    quantity: int = Field(
+        ...,
+        gt=0,
+        le=2**31 - 1,
+        title="Quantity",
+        description="The quantity of the feature that was booked.",
     )
 
 
@@ -29,8 +33,12 @@ class BookingUpdateSchema(BaseUpdateSchema):
     feature_id: Optional[int] = Field(
         None, title="Feature ID", description="The ID of the feature that was booked."
     )
-    quantity: Optional[PositiveInt] = Field(
-        None, title="Quantity", description="The quantity of the feature that was booked."
+    quantity: Optional[int] = Field(
+        None,
+        gt=0,
+        le=2**31 - 1,
+        title="Quantity",
+        description="The quantity of the feature that was booked.",
     )
 
 

--- a/backend/lm_backend/api/schemas/configuration.py
+++ b/backend/lm_backend/api/schemas/configuration.py
@@ -31,11 +31,14 @@ class ConfigurationCreateSchema(BaseCreateSchema):
         max_length=255,
         description="The client ID of the cluster that will use this configuration.",
     )
-    grace_time: PositiveInt = Field(
-        ...,
+    grace_time: int = Field(
+        60,
+        gt=0,
+        le=2**31 - 1,
         title="Grace time",
         description="The grace time in seconds for the license's bookings to be retained.",
     )
+
     type: LicenseServerType = Field(
         ...,
         title="Type of license server",
@@ -59,8 +62,10 @@ class ConfigurationCompleteCreateSchema(BaseCreateSchema):
         max_length=255,
         description="The client ID of the cluster that will use this configuration.",
     )
-    grace_time: PositiveInt = Field(
-        ...,
+    grace_time: int = Field(
+        60,
+        gt=0,
+        le=2**31 - 1,
         title="Grace time",
         description="The grace time in seconds for the license's bookings to be retained.",
     )
@@ -98,8 +103,10 @@ class ConfigurationUpdateSchema(BaseUpdateSchema):
         max_length=255,
         description="The client ID of the cluster that will use this configuration.",
     )
-    grace_time: Optional[PositiveInt] = Field(
+    grace_time: Optional[int] = Field(
         None,
+        gt=0,
+        le=2**31 - 1,
         title="Grace time",
         description="The grace time in seconds for the license's bookings to be retained.",
     )
@@ -129,8 +136,10 @@ class ConfigurationCompleteUpdateSchema(BaseUpdateSchema):
         max_length=255,
         description="The client ID of the cluster that will use this configuration.",
     )
-    grace_time: Optional[PositiveInt] = Field(
+    grace_time: Optional[int] = Field(
         None,
+        gt=0,
+        le=2**31 - 1,
         title="Grace time",
         description="The grace time in seconds for the license's bookings to be retained.",
     )

--- a/backend/lm_backend/api/schemas/feature.py
+++ b/backend/lm_backend/api/schemas/feature.py
@@ -19,8 +19,10 @@ class FeatureCreateSchema(BaseCreateSchema):
     config_id: int = Field(
         ..., title="Configuration ID", description="The ID of the configuration that the feature belongs to."
     )
-    reserved: NonNegativeInt = Field(
+    reserved: int = Field(
         0,
+        ge=0,
+        le=2**31 - 1,
         title="Reserved quantity",
         description="The quantity of the feature that is reserved for usage in desktop environments.",
     )
@@ -35,8 +37,10 @@ class FeatureWithoutConfigIdCreateSchema(BaseCreateSchema):
         ..., title="Name of the feature", max_length=255, description="The name of the feature."
     )
     product_id: int = Field(..., title="Product ID", description="The ID of the product of the feature.")
-    reserved: NonNegativeInt = Field(
+    reserved: int = Field(
         0,
+        ge=0,
+        le=2**31 - 1,
         title="Reserved quantity",
         description="The quantity of the feature that is reserved for usage in desktop environments.",
     )
@@ -54,8 +58,10 @@ class FeatureWithOptionalIdUpdateSchema(BaseUpdateSchema):
     product_id: Optional[int] = Field(
         None, title="Product ID", description="The ID of the product of the feature."
     )
-    reserved: Optional[NonNegativeInt] = Field(
+    reserved: Optional[int] = Field(
         None,
+        ge=0,
+        le=2**31 - 1,
         title="Reserved quantity",
         description="The quantity of the feature that is reserved for usage in desktop environments.",
     )
@@ -75,18 +81,24 @@ class FeatureUpdateSchema(BaseUpdateSchema):
     config_id: Optional[int] = Field(
         None, title="Configuration ID", description="The ID of the configuration that the feature belongs to."
     )
-    reserved: Optional[NonNegativeInt] = Field(
+    reserved: Optional[int] = Field(
         None,
+        ge=0,
+        le=2**31 - 1,
         title="Reserved quantity",
         description="The quantity of the feature that is reserved for usage in desktop environments.",
     )
-    total: Optional[NonNegativeInt] = Field(
+    total: Optional[int] = Field(
         None,
+        ge=0,
+        le=2**31 - 1,
         title="Total quantity",
         description="The total quantity of licenses.",
     )
-    used: Optional[NonNegativeInt] = Field(
+    used: Optional[int] = Field(
         None,
+        ge=0,
+        le=2**31 - 1,
         title="Used quantity",
         description="The quantity of the feature that is used.",
     )
@@ -104,13 +116,17 @@ class FeatureUpdateByNameSchema(BaseUpdateSchema):
     feature_name: str = Field(
         ..., title="Feature name", max_length=255, description="The name of the feature."
     )
-    total: NonNegativeInt = Field(
+    total: int = Field(
         0,
+        ge=0,
+        le=2**31 - 1,
         title="Total quantity",
         description="The total quantity of licenses.",
     )
-    used: NonNegativeInt = Field(
+    used: int = Field(
         0,
+        ge=0,
+        le=2**31 - 1,
         title="Used quantity",
         description="The quantity of the feature that is used.",
     )

--- a/backend/lm_backend/api/schemas/job.py
+++ b/backend/lm_backend/api/schemas/job.py
@@ -1,7 +1,7 @@
 """Job schemas for the License Manager API."""
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, PositiveInt
+from pydantic import BaseModel, Field
 
 from lm_backend.api.schemas.base import BaseCreateSchema, BaseUpdateSchema
 from lm_backend.api.schemas.booking import BookingSchema
@@ -11,7 +11,9 @@ class JobBookingCreateSchema(BaseCreateSchema):
     product_feature: str = Field(
         ..., title="Product feature", description="The product.feature of the license."
     )
-    quantity: PositiveInt = Field(..., title="Quantity", description="The quantity of booked licenses.")
+    quantity: int = Field(
+        ..., gt=0, le=2**31 - 1, title="Quantity", description="The quantity of booked licenses."
+    )
 
 
 class JobCreateSchema(BaseCreateSchema):


### PR DESCRIPTION
#### What
Update the int fields in the schemas to use maximum integer size defined in the database column (2**31-1)

#### Why
Values bigger than 2**31-1 was causing integer overflow in the database.

`Task`: https://app.clickup.com/t/18022949/PENG-1438

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
