### PR TITLE
Update Python version to 3.12

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - uses: Gr1N/setup-poetry@v8
         with:

--- a/.github/workflows/publish-to-ecr.yaml
+++ b/.github/workflows/publish-to-ecr.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - uses: Gr1N/setup-poetry@v8
 

--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
   
       - uses: Gr1N/setup-poetry@v8
 


### PR DESCRIPTION
#### What
Update all GitHub Actions to use Python 3.12.

#### Why
Since the project is being upgraded to Python 3.12, the actions were failing.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
