### PR TITLE
[ASP-4292] Modernize lm-api Dockerfile

### DIFF
--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -5,6 +5,7 @@ This file keeps track of all notable changes to `License Manager API`.
 ## Unreleased
 * Updated linter and checker to use ruff [ASP-4293]
 * Rename `backend` project to `lm-api` [ASP-4291]
+* Modernize the Dockerfile to use multi-stage builds [ASP-4292]
 
 ## 3.0.13a1 -- 2024-01-05
 * Update constraints to limit int fields to 2**31-1

--- a/lm-api/Dockerfile
+++ b/lm-api/Dockerfile
@@ -1,20 +1,34 @@
-FROM python:3.12-slim-bullseye
+FROM ubuntu AS builder
+ENV PYTHONUNBUFFERED 1
 
 WORKDIR /app
 
-RUN apt update && apt install -y curl libpq-dev gcc
+RUN apt update \
+    && apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
+       libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev libpq-dev -y \
+    && wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
+    && tar -xf Python-3.12.0.tgz \
+    && cd Python-3.12.*/ \
+    && ./configure --enable-optimizations \
+    && make \
+    && make altinstall
 
-RUN curl -sSL https://install.python-poetry.org | \
-    POETRY_HOME=/opt/poetry POETRY_VERSION=1.4.0 python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
+ENV PATH="/opt/venv/bin:$PATH"
 
-COPY ./pyproject.toml ./poetry.lock* /app/
-
-RUN poetry install --no-root --no-dev
-
-COPY ./alembic /app/alembic
+COPY ./README.md ./pyproject.toml ./poetry.lock* /app/
 COPY ./lm_api /app/lm_api
+
+RUN pip3.12 install .
+
+FROM ubuntu AS runner
+WORKDIR /app
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /usr/local/bin/python3.12 /usr/local/bin/
+
+COPY ./lm_api /app/lm_api
+COPY ./alembic /app/alembic
+
+ENV PATH="/opt/venv/bin:$PATH"
 
 CMD ["uvicorn", "lm_api.main:app", "--host", "0.0.0.0", "--port", "80", "--loop", "asyncio"]

--- a/lm-api/Dockerfile
+++ b/lm-api/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bullseye as builder
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y curl libpq-dev gcc
+RUN apt update && apt install -y curl libpq-dev gcc
 RUN pip install poetry==1.4.0
 
 COPY ./pyproject.toml ./poetry.lock /app

--- a/lm-api/Dockerfile
+++ b/lm-api/Dockerfile
@@ -1,34 +1,25 @@
-FROM ubuntu AS builder
-ENV PYTHONUNBUFFERED 1
+FROM python:3.12-slim-bullseye as builder
 
 WORKDIR /app
 
-RUN apt update \
-    && apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
-       libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev libpq-dev -y \
-    && wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
-    && tar -xf Python-3.12.0.tgz \
-    && cd Python-3.12.*/ \
-    && ./configure --enable-optimizations \
-    && make \
-    && make altinstall
+RUN apt-get update && apt-get install -y curl libpq-dev gcc
+RUN pip install poetry==1.4.0
 
-ENV PATH="/opt/venv/bin:$PATH"
+COPY ./pyproject.toml ./poetry.lock /app
 
-COPY ./README.md ./pyproject.toml ./poetry.lock* /app/
-COPY ./lm_api /app/lm_api
+RUN poetry config virtualenvs.in-project true && poetry install --no-root
+RUN poetry install --no-root --no-dev && rm -rf "$POETRY_CACHE_DIR"
 
-RUN pip3.12 install .
 
-FROM ubuntu AS runner
+FROM python:3.12-slim-bullseye as runner
+
 WORKDIR /app
 
-COPY --from=builder /opt/venv /opt/venv
-COPY --from=builder /usr/local/bin/python3.12 /usr/local/bin/
+COPY --from=builder /app /app
 
-COPY ./lm_api /app/lm_api
+ENV PATH="/app/.venv/bin:$PATH"
+
 COPY ./alembic /app/alembic
-
-ENV PATH="/opt/venv/bin:$PATH"
+COPY ./lm_api /app/lm_api
 
 CMD ["uvicorn", "lm_api.main:app", "--host", "0.0.0.0", "--port", "80", "--loop", "asyncio"]

--- a/lm-api/Dockerfile
+++ b/lm-api/Dockerfile
@@ -7,8 +7,9 @@ RUN pip install poetry==1.4.0
 
 COPY ./pyproject.toml ./poetry.lock /app
 
-RUN poetry config virtualenvs.in-project true && poetry install --no-root
-RUN poetry install --no-root --no-dev && rm -rf "$POETRY_CACHE_DIR"
+RUN poetry config virtualenvs.in-project true \
+    && poetry install --no-root --no-dev \
+    && rm -rf "$POETRY_CACHE_DIR"
 
 
 FROM python:3.12-slim-bullseye as runner

--- a/lm-api/Dockerfile-ci
+++ b/lm-api/Dockerfile-ci
@@ -3,14 +3,9 @@ FROM python:3.12-slim-bullseye
 WORKDIR /app
 
 RUN apt update && apt install -y curl libpq-dev gcc
+RUN pip install poetry==1.4.0
 
-RUN curl -sSL https://install.python-poetry.org | \
-    POETRY_HOME=/opt/poetry POETRY_VERSION=1.4.0 python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
-
-COPY ./pyproject.toml ./poetry.lock* /app/
+COPY ./pyproject.toml ./poetry.lock /app/
 
 RUN poetry install --no-root
 

--- a/lm-api/Dockerfile-ci
+++ b/lm-api/Dockerfile-ci
@@ -7,7 +7,7 @@ RUN pip install poetry==1.4.0
 
 COPY ./pyproject.toml ./poetry.lock /app/
 
-RUN poetry install --no-root
+RUN poetry install --no-root && rm -rf "$POETRY_CACHE_DIR"
 
 COPY ./alembic /app/alembic
 COPY ./lm_api /app/lm_api


### PR DESCRIPTION
#### What
Change the Dockerfile for lm-api to use a multi-stage image.

#### Why
This reduced the image size from 517MB to 233MB.

`Task`: https://jira.scania.com/browse/ASP-4292

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
