### PR TITLE
[ASP-4670] Fix parsers for FlexLM, LM-X and OLicense

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
+* Improve FlexLM, LM-X and OLicense parsers to parse multiple versions of the license server output [ASP-4670]
 
 ## 3.1.0 -- 2024-01-24
 * Updated linter and checker to use ruff [ASP-4293]

--- a/lm-agent/lm_agent/parsing/flexlm.py
+++ b/lm-agent/lm_agent/parsing/flexlm.py
@@ -1,7 +1,8 @@
 """
-Parser for flexlm
+Parser for FlexLM
 """
 import re
+from typing import Optional
 
 HOSTWORD = r"[a-zA-Z0-9-]+"
 HOSTNAME = rf"{HOSTWORD}(\.{HOSTWORD})*"
@@ -11,28 +12,12 @@ INT = r"\d+"
 NONPAREN = r"[^() ]+"
 MMDD = rf"{INT}/{INT}"
 HHMM = rf"{INT}:{INT}"
+FEATURE_NAME = r"[A-Za-z0-9\-_:]+"
 
-DATA_LINE = (
-    r"^\s+"
-    rf"(?P<user>{NONWS}) "
-    rf"(?P<user_host>{HOSTNAME}) "
-    rf"(?P<tty>{NONWS}) "
-    rf"\((?P<version>{NONPAREN})\) "
-    r"\("
-    rf"(?P<license_host>{HOSTNAME})/"
-    rf"(?P<license_port>{INT}) "
-    rf"(?P<license_pid>{INT})"
-    r"\), start "
-    rf"(?P<weekday>{NONWS}) "
-    rf"(?P<date>{MMDD}) "
-    rf"(?P<time>{HHMM}), "
-    rf"(?P<tokens>{INT}) "
-    r"licenses$"
-)
 
-TOTALS_LINE = (
+FEATURE_LINE = (
     r"^Users of "
-    rf"(?P<feature>{NONCOLON}):  "
+    rf"(?P<feature>{FEATURE_NAME}):  "
     r"\(Total of "
     rf"(?P<total>{INT}) "
     r"licenses issued;  Total of "
@@ -40,34 +25,171 @@ TOTALS_LINE = (
     rf"licenses in use\)$"
 )
 
+USAGE_LINE_1 = (
+    r"^\s+"
+    rf"(?P<user>{NONWS}) "
+    rf"(?P<user_host>{HOSTNAME}) "
+    rf"(?P<tty>{NONWS}) "
+    rf"\((?P<version>{NONPAREN})\) "
+    rf"\((?P<license_host>{HOSTNAME})/"
+    rf"(?P<license_port>{INT}) "
+    rf"(?P<license_pid>{INT})\), "
+    r"start "
+    rf"(?P<weekday>{NONWS}) "
+    rf"(?P<date>{MMDD}) "
+    rf"(?P<time>{HHMM}), "
+    rf"(?P<tokens>{INT}) "
+    r"licenses$"
+)
 
-RX = re.compile(rf"{DATA_LINE}|{TOTALS_LINE}")
+USAGE_LINE_2 = (
+    r"^\s+"
+    rf"(?P<user>{NONWS}) "
+    rf"(?P<user_host>{HOSTNAME}) "
+    rf"(?P<tty>{NONWS}) "
+    r"feature="
+    rf"(?P<feature>{FEATURE_NAME}) "
+    rf"\(v(?P<version>{NONPAREN})\) "
+    rf"\((?P<license_host>{HOSTNAME})/"
+    rf"(?P<license_port>{INT}) "
+    rf"(?P<license_pid>{INT})\), "
+    r"start "
+    rf"(?P<weekday>{NONWS}) "
+    rf"(?P<date>{MMDD}) "
+    rf"(?P<time>{HHMM}), "
+    rf"(?P<tokens>{INT}) "
+    r"licenses$"
+)
 
 
-def parse(s: str) -> dict:
+USAGE_LINE_3 = (
+    r"^\s+"
+    rf"(?P<user>{NONWS}) "
+    rf"(?P<user_host>{HOSTNAME}) "
+    rf"(?P<tty>{NONWS}) "
+    rf"\(v(?P<version>{NONPAREN})\) "
+    rf"\((?P<license_host>{HOSTNAME})/"
+    rf"(?P<license_port>{INT}) "
+    rf"(?P<license_pid>{INT})\), "
+    r"start "
+    rf"(?P<weekday>{NONWS}) "
+    rf"(?P<date>{MMDD}) "
+    rf"(?P<time>{HHMM})$"
+)
+
+USAGE_LINE_4 = (
+    r"^\s+"
+    rf"(?P<user>{NONWS}) "
+    rf"(?P<user_host>{HOSTNAME}) "
+    rf"(?P<tty>{HOSTNAME}) "
+    rf"(?P<feature>{FEATURE_NAME}) "
+    rf"\(v(?P<version>{NONPAREN})\) "
+    rf"\((?P<license_host>{HOSTNAME})/"
+    rf"(?P<license_port>{INT}) "
+    rf"(?P<license_pid>{INT})\), "
+    r"start "
+    rf"(?P<weekday>{NONWS}) "
+    rf"(?P<date>{MMDD}) "
+    rf"(?P<time>{HHMM}), "
+    rf"(?P<tokens>{INT}) "
+    r"licenses$"
+)
+
+USAGE_LINE_5 = (
+    r"^\s+"
+    rf"(?P<user>{NONWS}) "
+    rf"(?P<user_host>{HOSTNAME}) "
+    rf"(?P<tty>{NONWS}) "
+    rf"(?P<feature>{FEATURE_NAME}) "
+    rf"\(v(?P<version>{NONPAREN})\) "
+    rf"\((?P<license_host>{HOSTNAME})/"
+    rf"(?P<license_port>{INT}) "
+    rf"(?P<license_pid>{INT})\), "
+    r"start "
+    rf"(?P<weekday>{NONWS}) "
+    rf"(?P<date>{MMDD}) "
+    rf"(?P<time>{HHMM})$"
+)
+
+RX_FEATURE = re.compile(FEATURE_LINE)
+RX_USAGE_LINE_1 = re.compile(USAGE_LINE_1)
+RX_USAGE_LINE_2 = re.compile(USAGE_LINE_2)
+RX_USAGE_LINE_3 = re.compile(USAGE_LINE_3)
+RX_USAGE_LINE_4 = re.compile(USAGE_LINE_4)
+RX_USAGE_LINE_5 = re.compile(USAGE_LINE_5)
+USAGE_LINES = [RX_USAGE_LINE_1, RX_USAGE_LINE_2, RX_USAGE_LINE_3, RX_USAGE_LINE_4, RX_USAGE_LINE_5]
+
+
+def parse_feature_line(line: str) -> Optional[str]:
     """
-    Parse lines of the license output with regular expressions
+    Parse the feature line in the FlexLM output.
+    Data we need:
+    - ``feature``: license name
+    - ``total``: total amount of licenses
+    - ``used``: quantity of licenses being use
     """
-    parsed_data: dict = {"uses": [], "total": None}
-    for line in s.splitlines():
-        parsed = RX.match(line)
-        if parsed is None:
+    parsed_feature = RX_FEATURE.match(line)
+    if parsed_feature is None:
+        return None
+    feature_data = parsed_feature.groupdict()
+
+    return {
+        "feature": feature_data["feature"].lower(),
+        "total": int(feature_data["total"]),
+        "used": int(feature_data["used"]),
+    }
+
+
+def parse_usage_line(line: str) -> Optional[dict]:
+    """
+    Parse the usage line in the FlexLM output.
+    Data we need:
+    - ``user_name``: user who booked the license
+    - ``lead_host``: host using the license
+    - ``booked``: quantity of licenses being used
+
+    There can be multiple formats for the data line, so we need to check which one matches.
+    """
+
+    for RX in USAGE_LINES:
+        parsed_data = RX.match(line)
+        if parsed_data:
+            break
+
+    if parsed_data is None:
+        return None
+
+    data = parsed_data.groupdict()
+
+    return {
+        "user_name": data["user"].lower(),
+        "lead_host": data["user_host"],
+        "booked": int(data.get("tokens", 1)),
+    }
+
+
+def parse(server_output: str) -> dict:
+    """
+    Parse the FlexLM Output, using regext to match the lines we need:
+    - ``feature line``: info about the license
+    - ``data line``: info about the users using the license
+    """
+    parsed_data: dict = {}
+    uses = []
+
+    for line in server_output.splitlines():
+        parsed_feature = parse_feature_line(line)
+
+        if parsed_feature:
+            parsed_data = parsed_feature
             continue
 
-        if parsed.group("total"):
-            d = parsed.groupdict()
-            parsed_data["total"] = {
-                "total": int(d["total"]),
-                "used": int(d["used"]),
-                "feature": d["feature"].lower(),
-            }
-        if parsed.group("user"):
-            d = parsed.groupdict()
-            parsed_data["uses"].append(
-                {
-                    "user_name": d["user"],
-                    "lead_host": d["user_host"],
-                    "booked": int(d["tokens"]),
-                }
-            )
+        parsed_data_line = parse_usage_line(line)
+
+        if parsed_data_line:
+            uses.append(parsed_data_line)
+
+    if parsed_data:
+        parsed_data["uses"] = uses
+
     return parsed_data

--- a/lm-agent/lm_agent/parsing/flexlm.py
+++ b/lm-agent/lm_agent/parsing/flexlm.py
@@ -126,7 +126,7 @@ def parse_feature_line(line: str) -> Optional[Dict]:
     Data we need:
     - ``feature``: license name
     - ``total``: total amount of licenses
-    - ``used``: quantity of licenses being use
+    - ``used``: quantity of licenses being used
     """
     parsed_feature = RX_FEATURE.match(line)
     if parsed_feature is None:
@@ -152,8 +152,7 @@ def parse_usage_line(line: str) -> Optional[Dict]:
     """
 
     for RX in USAGE_LINES:
-        parsed_data = RX.match(line)
-        if parsed_data:
+        if parsed_data := RX.match(line):
             break
 
     if parsed_data is None:

--- a/lm-agent/lm_agent/parsing/flexlm.py
+++ b/lm-agent/lm_agent/parsing/flexlm.py
@@ -2,7 +2,7 @@
 Parser for FlexLM
 """
 import re
-from typing import Optional
+from typing import Optional, Dict
 
 HOSTWORD = r"[a-zA-Z0-9-]+"
 HOSTNAME = rf"{HOSTWORD}(\.{HOSTWORD})*"
@@ -120,7 +120,7 @@ RX_USAGE_LINE_5 = re.compile(USAGE_LINE_5)
 USAGE_LINES = [RX_USAGE_LINE_1, RX_USAGE_LINE_2, RX_USAGE_LINE_3, RX_USAGE_LINE_4, RX_USAGE_LINE_5]
 
 
-def parse_feature_line(line: str) -> Optional[str]:
+def parse_feature_line(line: str) -> Optional[Dict]:
     """
     Parse the feature line in the FlexLM output.
     Data we need:
@@ -140,7 +140,7 @@ def parse_feature_line(line: str) -> Optional[str]:
     }
 
 
-def parse_usage_line(line: str) -> Optional[dict]:
+def parse_usage_line(line: str) -> Optional[Dict]:
     """
     Parse the usage line in the FlexLM output.
     Data we need:
@@ -168,7 +168,7 @@ def parse_usage_line(line: str) -> Optional[dict]:
     }
 
 
-def parse(server_output: str) -> dict:
+def parse(server_output: str) -> Dict:
     """
     Parse the FlexLM Output, using regext to match the lines we need:
     - ``feature line``: info about the license

--- a/lm-agent/lm_agent/parsing/lmx.py
+++ b/lm-agent/lm_agent/parsing/lmx.py
@@ -19,7 +19,7 @@ USAGE_LINE_1 = (
 USAGE_LINE_2 = (
     rf"^(?P<in_use>{INT}) license\(s\) "
     rf"used by (?P<user>\S+)@(?P<lead_host>{HOSTNAME})_\S+ "
-    rf"\[{INT}\.{INT}\.{INT}\.{INT}\]" 
+    rf"\[{INT}\.{INT}\.{INT}\.{INT}\]"
 )
 RX_FEATURE = re.compile(FEATURE_LINE)
 RX_IN_USE = re.compile(IN_USE_LINE)

--- a/lm-agent/lm_agent/parsing/lmx.py
+++ b/lm-agent/lm_agent/parsing/lmx.py
@@ -11,14 +11,21 @@ VERSION = rf"{INT}\.{INT}"
 
 FEATURE_LINE = rf"^Feature: (?P<feature>\w+) Version: (?P<version>{VERSION}) Vendor: (?P<vendor>\S+)$"
 IN_USE_LINE = rf"^(?P<in_use>{INT}) of (?P<total>{INT}) license\(s\) used(:)?$"
-USAGE_LINE = (
+USAGE_LINE_1 = (
     rf"^(?P<in_use>{INT}) license\(s\) "
     rf"used by (?P<user>\S+)@(?P<lead_host>{HOSTNAME}) "
     rf"\[{INT}\.{INT}\.{INT}\.{INT}\]"
 )
+USAGE_LINE_2 = (
+    rf"^(?P<in_use>{INT}) license\(s\) "
+    rf"used by (?P<user>\S+)@(?P<lead_host>{HOSTNAME})_\S+ "
+    rf"\[{INT}\.{INT}\.{INT}\.{INT}\]" 
+)
 RX_FEATURE = re.compile(FEATURE_LINE)
 RX_IN_USE = re.compile(IN_USE_LINE)
-RX_USAGE = re.compile(USAGE_LINE)
+RX_USAGE_1 = re.compile(USAGE_LINE_1)
+RX_USAGE_2 = re.compile(USAGE_LINE_2)
+USAGE_LINES = [RX_USAGE_1, RX_USAGE_2]
 
 
 def parse_feature_line(line: str) -> Optional[str]:
@@ -68,7 +75,11 @@ def parse_usage_line(line: str) -> Optional[dict]:
     Obs: this line also doesn't incluse the license name.
     The license in use is the last one parsed before this line.
     """
-    parsed_usage = RX_USAGE.match(line)
+    for RX in USAGE_LINES:
+        parsed_usage = RX.match(line)
+        if parsed_usage:
+            break
+
     if parsed_usage is None:
         return None
     usage_data = parsed_usage.groupdict()

--- a/lm-agent/lm_agent/parsing/olicense.py
+++ b/lm-agent/lm_agent/parsing/olicense.py
@@ -18,7 +18,7 @@ FEATURE_LINE = (
     rf"\s+(?P<expiration_date>{EXPIRATION_DATE});"
 )
 
-IN_USE_LINE = rf"^\s+(?P<in_use>{INT})\s+FloatsLockedBy:$"
+IN_USE_LINE = rf"^\s+(?P<in_use>{INT})\s+FloatsLockedBy"
 
 USAGE_LINE = rf"^\s+(?P<user>\S+)@(?P<lead_host>{HOSTNAME})\s+#(?P<booked>{INT})$"
 

--- a/lm-agent/lm_agent/server_interfaces/flexlm.py
+++ b/lm-agent/lm_agent/server_interfaces/flexlm.py
@@ -57,18 +57,15 @@ class FlexLMLicenseServer(LicenseServerInterface):
         parsed_output = self.parser(server_output)
 
         # raise exception if parser didn't output license information
-        if parsed_output.get("total") is None or any(
-            [
-                parsed_output.get("total", {}).get("used") is None,
-                parsed_output.get("total", {}).get("total") is None,
-            ]
+        if any(
+            [parsed_output is None, parsed_output.get("total") is None, parsed_output.get("used") is None]
         ):
             raise LicenseManagerBadServerOutput("Invalid data returned from parser.")
 
         report_item = LicenseReportItem(
             product_feature=product_feature,
-            used=parsed_output["total"]["used"],
-            total=parsed_output["total"]["total"],
+            used=parsed_output["used"],
+            total=parsed_output["total"],
         )
 
         return report_item

--- a/lm-agent/tests/conftest.py
+++ b/lm-agent/tests/conftest.py
@@ -1001,6 +1001,34 @@ def lmx_output():
         """
     )
 
+@fixture
+def lmx_output_2():
+    return dedent(
+        """
+        LM-X End-user Utility v3.32
+        Copyright (C) 2002-2010 X-Formation. All rights reserved.
+
+        ++++++++++++++++++++++++++++++++++++++++
+        LM-X License Server on 6300@licserv0003.scom:
+
+        Server version: v4.9.3 Uptime: 10 day(s) 16 hour(s) 54 min(s) 21 sec(s)
+        ----------------------------------------
+        Feature: FEMFAT_VISUALIZER Version: 2024.0 Vendor: abc
+        Start date: NONE Expire date: 2024-06-30
+        Key type: EXCLUSIVE License sharing: HOST USER VIRTUAL
+
+        2 of 2 license(s) used:
+
+        1 license(s) used by fdsva1@dcv046.com_ver2023 [10.123.321.20]
+            Login time: 2024-03-11 12:50   Checkout time: 2024-03-11 12:50 
+            Shared on username: fdsva1   Shared on hostname: dcv046.com_ver2023 
+
+        1 license(s) used by asdsc1@dcv048.com_ver2022a [10.123.321.10]
+            Login time: 2024-03-11 17:29   Checkout time: 2024-03-11 17:29 
+            Shared on username: asdsc1   Shared on hostname: dcv048.com_ver2022a 
+        """
+    )
+
 
 @fixture
 def lmx_output_no_licenses():

--- a/lm-agent/tests/conftest.py
+++ b/lm-agent/tests/conftest.py
@@ -485,7 +485,7 @@ def scontrol_show_lic_output_olicense():
 
 
 @fixture
-def lmstat_output_bad():
+def flexlm_output_bad():
     """Some unparseable lmstat output."""
     return dedent(
         """\
@@ -498,30 +498,80 @@ def lmstat_output_bad():
 
 
 @fixture
-def lmstat_output():
-    """Some lmstat output to parse."""
+def flexlm_output():
+    """Some FlexLM output to parse."""
     return dedent(
         """\
         lmstat - Copyright (c) 1989-2004 by Macrovision Corporation. All rights reserved.
         ...
-
         Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 93 licenses in use)
-
         ...
-
-
+            sdmfva myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), start Thu 10/29 8:09, 29 licenses
+            adfdna myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), start Thu 10/29 8:09, 27 licenses
+            sdmfva myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), start Thu 10/29 8:09, 37 licenses
         """
-        "           jbemfv myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
-        "start Thu 10/29 8:09, 29 licenses\n"
-        "           cdxfdn myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
-        "start Thu 10/29 8:09, 27 licenses\n"
-        "           jbemfv myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), "
-        "start Thu 10/29 8:09, 37 licenses\n"
     )
 
 
 @fixture
-def lmstat_output_no_licenses():
+def flexlm_output_2():
+    """Some FlexLM output to parse."""
+    return dedent(
+        """\
+        lmutil - Copyright (c) 1989-2012 Flexera Software LLC. All Rights Reserved.
+        ...
+        Users of TEST_FEATURE:  (Total of 42800 licenses issued;  Total of 1600 licenses in use)
+        ...
+            usbn12 p-c94.com /dev/tty feature=test_feature (v2023.0) (myserver.example.com/41020 10223), start Mon 3/11 13:16, 100 licenses
+            usbn12 p-c94.com /dev/tty feature=test_feature_2 (v2023.0) (myserver.example.com/41020 626), start Mon 3/11 13:16, 1400 licenses
+            usbn12 p-c94.com /dev/tty feature=test_feature_3 (v2023.0) (myserver.example.com/41020 10110), start Mon 3/11 13:16, 100 licenses
+        """
+    )
+
+
+@fixture
+def flexlm_output_3():
+    """Some FlexLM output to parse."""
+    return dedent(
+        """\
+        lmutil - Copyright (c) 1989-2012 Flexera Software LLC. All Rights Reserved.
+        ...
+        Users of ccmppower:  (Total of 40 licenses issued;  Total of 3 licenses in use)
+        ...
+        "ccmppower" v2025.09, vendor: abc
+        floating license
+            1nou7p dcv033.com /dev/tty (v2023.06) (myserver.example.com/27012 3457), start Mon 3/11 12:17
+
+        "ccmppower" v2024.09, vendor: abc
+        floating license
+
+            1nou7p n-c41.com /dev/tty (v2023.06) (myserver.example.com/27012 2541), start Mon 3/11 22:36
+            1nou7p nid001234 /dev/tty (v2022.10) (myserver.example.com/27012 3331), start Sun 3/10 10:41
+        """
+    )
+
+
+@fixture
+def flexlm_output_4():
+    """Some FlexLM output to parse."""
+    return dedent(
+        """\
+        lmutil - Copyright (c) 1989-2012 Flexera Software LLC. All Rights Reserved.
+        ...
+        Users of MSCONE:  (Total of 750 licenses issued;  Total of 18 licenses in use)
+        ...
+            ABCDKK ER0037 SESOR045 MSCONE:ADAMS_View (v2023.0331) (myserver.example.com/29065 2639), start Fri 3/8 13:25, 5 licenses
+            ABCDKK ER0037 SESOR045 MSCONE:ADAMS_Car_Plugin (v2023.0331) (myserver.example.com/29065 8195), start Fri 3/8 13:25
+            ABCDKK ER0037 SESOR045 MSCONE:ADAMS_View (v2023.0331) (myserver.example.com/29065 2474), start Fri 3/8 13:25, 5 licenses
+            ABCDKK ER0037 SESOR045 MSCONE:ADAMS_Car_Plugin (v2023.0331) (myserver.example.com/29065 4903), start Fri 3/8 13:25
+            ABCDKK ER0037 SESOR100 MSCONE:ADAMS_View (v2021.0630) (myserver.example.com/29065 11260), start Mon 3/11 10:49, 5 licenses
+            ABCDKK ER0037 SESOR100 MSCONE:ADAMS_Car_Plugin (v2021.0630) (myserver.example.com/29065 7727), start Mon 3/11 10:49
+        """
+    )
+
+
+@fixture
+def flexlm_output_no_licenses():
     """Some lmstat output with no licenses in use to parse."""
     return dedent(
         """\

--- a/lm-agent/tests/conftest.py
+++ b/lm-agent/tests/conftest.py
@@ -1001,6 +1001,7 @@ def lmx_output():
         """
     )
 
+
 @fixture
 def lmx_output_2():
     return dedent(

--- a/lm-agent/tests/parsing/test_flexlm.py
+++ b/lm-agent/tests/parsing/test_flexlm.py
@@ -6,7 +6,28 @@ from pytest import mark
 from lm_agent.parsing.flexlm import parse, parse_feature_line, parse_usage_line
 
 
-def test_parse_feature_line():
+@mark.parametrize(
+    "line,result",
+    [
+        (
+            "Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 93 licenses in use)",
+            {
+                "feature": "testfeature",
+                "total": 1000,
+                "used": 93,
+            },
+        ),
+        (
+            "not a feature line",
+            None,
+        ),
+        (
+            "",
+            None,
+        ),
+    ],
+)
+def test_parse_feature_line(line, result):
     """
     Does the regex for the feature line match the lines in the output?
 
@@ -15,18 +36,48 @@ def test_parse_feature_line():
     - total
     - used
     """
-    assert parse_feature_line(
-        "Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 93 licenses in use)"
-    ) == {
-        "feature": "testfeature",
-        "total": 1000,
-        "used": 93,
-    }
-    assert parse_feature_line("not a feature line") is None
-    assert parse_feature_line("") is None
+    assert parse_feature_line(line) == result
 
 
-def test_parse_usage_line():
+@mark.parametrize(
+    "line,result",
+    [
+        (
+            "    user1 myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), start Thu 10/29 8:09, 29 licenses",
+            {
+                "user_name": "user1",
+                "lead_host": "myserver.example.com",
+                "booked": 29,
+            },
+        ),
+        (
+            "    user2 another.server.com /dev/tty feature=feature (v2023.0) (another.server.com/41020 10223), start Mon 3/11 13:16, 100 licenses",
+            {
+                "user_name": "user2",
+                "lead_host": "another.server.com",
+                "booked": 100,
+            },
+        ),
+        (
+            "    user3 ER1234 SESOD5045 MSCONE:ADAMS_View (v2023.0331) (alternative.server.com/29065 2639), start Fri 3/8 13:25, 5 licenses",
+            {
+                "user_name": "user3",
+                "lead_host": "ER1234",
+                "booked": 5,
+            },
+        ),
+        (
+            "    user3 ER1234 SESOD5045 MSCONE:ADAMS_View (v2023.0331) (alternative.server.com/29065 2639), start Fri 3/8 13:25",
+            {
+                "user_name": "user3",
+                "lead_host": "ER1234",
+                "booked": 1,
+            },
+        ),
+        ("aaaaa", None),
+    ],
+)
+def test_parse_usage_line(line, result):
     """
     Does the regex for the usage line match the line in the output?
 
@@ -35,35 +86,7 @@ def test_parse_usage_line():
     - lead host
     - booked
     """
-    assert parse_usage_line(
-        "    user1 myserver.example.com /dev/tty (v62.2) (myserver.example.com/24200 12507), start Thu 10/29 8:09, 29 licenses"
-    ) == {
-        "user_name": "user1",
-        "lead_host": "myserver.example.com",
-        "booked": 29,
-    }
-    assert parse_usage_line(
-        "    user2 another.server.com /dev/tty feature=feature (v2023.0) (another.server.com/41020 10223), start Mon 3/11 13:16, 100 licenses"
-    ) == {
-        "user_name": "user2",
-        "lead_host": "another.server.com",
-        "booked": 100,
-    }
-    assert parse_usage_line(
-        "    user3 ER1234 SESOD5045 MSCONE:ADAMS_View (v2023.0331) (alternative.server.com/29065 2639), start Fri 3/8 13:25, 5 licenses"
-    ) == {
-        "user_name": "user3",
-        "lead_host": "ER1234",
-        "booked": 5,
-    }
-    assert parse_usage_line(
-        "    user3 ER1234 SESOD5045 MSCONE:ADAMS_View (v2023.0331) (alternative.server.com/29065 2639), start Fri 3/8 13:25"
-    ) == {
-        "user_name": "user3",
-        "lead_host": "ER1234",
-        "booked": 1,
-    }
-    assert parse_usage_line("aaaaa") is None
+    assert parse_usage_line(line) == result
 
 
 @mark.parametrize(

--- a/lm-agent/tests/parsing/test_lmx.py
+++ b/lm-agent/tests/parsing/test_lmx.py
@@ -2,6 +2,8 @@
 Test the LM-X parser
 """
 
+from pytest import mark
+
 from lm_agent.parsing.lmx import parse, parse_feature_line, parse_in_use_line, parse_usage_line
 
 
@@ -64,45 +66,78 @@ def test_parse_usage_line():
         "lead_host": "p-g2.maas.rnd.com",
         "booked": 15000,
     }
+    assert parse_usage_line("1 license(s) used by mbrzy5@dcv046.com_ver2023 [10.123.321.20]") == {
+        "user_name": "mbrzy5",
+        "lead_host": "dcv046.com",
+        "booked": 1,
+    }
+    assert parse_usage_line("1 license(s) used by k12dca@ms0904_ver5.4.1 [10.123.321.156]") == {
+        "user_name": "k12dca",
+        "lead_host": "ms0904",
+        "booked": 1,
+    }
     assert parse_usage_line("0 license(s) used by v-c54.aaa.aa") is None
     assert parse_usage_line("") is None
 
 
-def test_parse__correct_output(lmx_output):
+@mark.parametrize(
+    "fixture,result",
+    [
+        (
+            "lmx_output",
+            {
+                "catiav5reader": {"total": 3, "used": 0, "uses": []},
+                "globalzoneeu": {
+                    "total": 1000003,
+                    "used": 40000,
+                    "uses": [
+                        {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
+                        {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 25000},
+                    ],
+                },
+                "hwaifpbs": {"total": 2147483647, "used": 0, "uses": []},
+                "hwawpf": {"total": 2147483647, "used": 0, "uses": []},
+                "hwactivate": {"total": 2147483647, "used": 0, "uses": []},
+                "hwflux2d": {
+                    "total": 2147483647,
+                    "used": 30000,
+                    "uses": [
+                        {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
+                        {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
+                    ],
+                },
+                "hyperworks": {
+                    "total": 1000000,
+                    "used": 25000,
+                    "uses": [
+                        {"user_name": "sssaah", "lead_host": "RD0082406", "booked": 25000},
+                    ],
+                },
+            }
+        ),
+        (
+            "lmx_output_2",
+            {
+                "femfat_visualizer": {
+                    "total": 2,
+                    "used": 2,
+                    "uses": [
+                        {"booked": 1, "lead_host": "dcv046.com", "user_name": "fdsva1"},
+                        {"booked": 1, "lead_host": "dcv048.com", "user_name": "asdsc1"},
+                    ],
+                },
+            }
+        ),
+    ],
+)
+def test_parse__correct_output(request, fixture, result):
     """
     Does the parser return the correct data for this output?
     - lmx_output: expected output from the license server,
     which contain licenses and usage information.
     """
-    assert parse(lmx_output) == {
-        "catiav5reader": {"total": 3, "used": 0, "uses": []},
-        "globalzoneeu": {
-            "total": 1000003,
-            "used": 40000,
-            "uses": [
-                {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
-                {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 25000},
-            ],
-        },
-        "hwaifpbs": {"total": 2147483647, "used": 0, "uses": []},
-        "hwawpf": {"total": 2147483647, "used": 0, "uses": []},
-        "hwactivate": {"total": 2147483647, "used": 0, "uses": []},
-        "hwflux2d": {
-            "total": 2147483647,
-            "used": 30000,
-            "uses": [
-                {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
-                {"user_name": "VRAAFG", "lead_host": "RD0082879", "booked": 15000},
-            ],
-        },
-        "hyperworks": {
-            "total": 1000000,
-            "used": 25000,
-            "uses": [
-                {"user_name": "sssaah", "lead_host": "RD0082406", "booked": 25000},
-            ],
-        },
-    }
+    output = request.getfixturevalue(fixture)
+    assert parse(output) == result
 
 
 def test_parse__bad_output(lmx_output_bad):

--- a/lm-agent/tests/parsing/test_lmx.py
+++ b/lm-agent/tests/parsing/test_lmx.py
@@ -113,7 +113,7 @@ def test_parse_usage_line():
                         {"user_name": "sssaah", "lead_host": "RD0082406", "booked": 25000},
                     ],
                 },
-            }
+            },
         ),
         (
             "lmx_output_2",
@@ -126,7 +126,7 @@ def test_parse_usage_line():
                         {"booked": 1, "lead_host": "dcv048.com", "user_name": "asdsc1"},
                     ],
                 },
-            }
+            },
         ),
     ],
 )

--- a/lm-agent/tests/parsing/test_olicense.py
+++ b/lm-agent/tests/parsing/test_olicense.py
@@ -35,8 +35,10 @@ def test_parse_in_use_line():
     - in_use
     """
     assert parse_in_use_line("    2 FloatsLockedBy:") == 2
+    assert parse_in_use_line("    1 FloatsLockedBy 'unknown clients'") == 1
     assert parse_in_use_line("not a in use license") is None
     assert parse_in_use_line("") is None
+
 
 
 def test_parse_usage_line():

--- a/lm-agent/tests/parsing/test_olicense.py
+++ b/lm-agent/tests/parsing/test_olicense.py
@@ -40,7 +40,6 @@ def test_parse_in_use_line():
     assert parse_in_use_line("") is None
 
 
-
 def test_parse_usage_line():
     """
     Does the regex for the usage line match the line in the output?

--- a/lm-agent/tests/server_interfaces/test_flexlm.py
+++ b/lm-agent/tests/server_interfaces/test_flexlm.py
@@ -35,26 +35,26 @@ def test_get_flexlm_commands_list(flexlm_server: FlexLMLicenseServer):
 async def test_flexlm_get_output_from_server(
     run_command_mock: mock.MagicMock,
     flexlm_server: FlexLMLicenseServer,
-    lmstat_output: str,
+    flexlm_output: str,
 ):
     """
     Do the license server interface return the output from the license server?
     """
-    run_command_mock.return_value = lmstat_output
+    run_command_mock.return_value = flexlm_output
 
     output = await flexlm_server.get_output_from_server("testproduct.testfeature")
-    assert output == lmstat_output
+    assert output == flexlm_output
 
 
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server: FlexLMLicenseServer, lmstat_output: str
+    get_output_from_server_mock: mock.MagicMock, flexlm_server: FlexLMLicenseServer, flexlm_output: str
 ):
     """
     Do the FlexLM server interface generate a report item for the product?
     """
-    get_output_from_server_mock.return_value = lmstat_output
+    get_output_from_server_mock.return_value = flexlm_output
 
     assert await flexlm_server.get_report_item("testproduct.testfeature") == LicenseReportItem(
         product_feature="testproduct.testfeature",
@@ -71,12 +71,12 @@ async def test_flexlm_get_report_item(
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_output_from_server")
 async def test_flexlm_get_report_item_with_bad_output(
-    get_output_from_server_mock: mock.MagicMock, flexlm_server: FlexLMLicenseServer, lmstat_output_bad: str
+    get_output_from_server_mock: mock.MagicMock, flexlm_server: FlexLMLicenseServer, flexlm_output_bad: str
 ):
     """
     Do the FlexLM server interface raise an exception when the server returns an unparseable output?
     """
-    get_output_from_server_mock.return_value = lmstat_output_bad
+    get_output_from_server_mock.return_value = flexlm_output_bad
 
     with raises(LicenseManagerBadServerOutput):
         await flexlm_server.get_report_item("testproduct.testfeature")
@@ -87,12 +87,12 @@ async def test_flexlm_get_report_item_with_bad_output(
 async def test_flexlm_get_report_item_with_no_used_licenses(
     get_output_from_server_mock: mock.MagicMock,
     flexlm_server: FlexLMLicenseServer,
-    lmstat_output_no_licenses: str,
+    flexlm_output_no_licenses: str,
 ):
     """
     Do the FlexLM server interface generate a report item when no licenses are in use?
     """
-    get_output_from_server_mock.return_value = lmstat_output_no_licenses
+    get_output_from_server_mock.return_value = flexlm_output_no_licenses
 
     assert await flexlm_server.get_report_item("testproduct.testfeature") == LicenseReportItem(
         product_feature="testproduct.testfeature",

--- a/lm-agent/tests/test_license_report.py
+++ b/lm-agent/tests/test_license_report.py
@@ -17,7 +17,7 @@ from lm_agent.backend_utils.models import (
     "output,reconciliation",
     [
         (
-            "lmstat_output",
+            "flexlm_output",
             [
                 {
                     "product_feature": "testproduct.testfeature",


### PR DESCRIPTION
#### What
Fix the parsers for FlexLM, LM-X and OLicense license servers to get the correct usage information.

#### Why
There are multiple versions of the output from each of these license servers, which required modifications to be able to parse all of them.

`Task`: https://jira.scania.com/browse/ASP-4670

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
