### PR TITLE
Fix LS-Dyna parser issue

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
+* Fix LS-Dyna parser to parse the queue value when it's represented as a dash instead of a zero
 
 ## 3.1.0 -- 2024-01-24
 * Updated linter and checker to use ruff [ASP-4293]

--- a/lm-agent/lm_agent/parsing/lsdyna.py
+++ b/lm-agent/lm_agent/parsing/lsdyna.py
@@ -10,15 +10,15 @@ NONWS = r"\S+"
 INT = r"\d+"
 PROGRAM = r"[A-Z0-9\-_]+"
 EXPIRATION_DATE = r"((0[1-9]|1[012])[\/](0[1-9]|[12][0-9]|3[01])[\/](19|20)\d\d)"
-CPUS_USED = r"[\d|-]"
+INT_OR_DASH = r"[\d|-]"
 
 PROGRAM_LINE = (
     rf"(?P<program>{PROGRAM})\s+"
     rf"(?P<expiration_date>{EXPIRATION_DATE})\s+"
-    rf"(?P<used>{CPUS_USED})\s+ "
+    rf"(?P<used>{INT_OR_DASH})\s+ "
     rf"(?P<free>{INT})\s+ "
     rf"(?P<max>{INT})\s+\|\s+"
-    rf"(?P<queue>{INT})"
+    rf"(?P<queue>{INT_OR_DASH})"
 )
 
 USAGE_LINE = (

--- a/lm-agent/tests/parsing/test_lsdyna.py
+++ b/lm-agent/tests/parsing/test_lsdyna.py
@@ -33,6 +33,10 @@ def test_parse_program_line():
         "program": "ls-dyna_971",
         "total": 500,
     }
+    assert parse_program_line("MPPDYNA          06/30/2024          -     60   2420 |     -") == {
+        "program": "mppdyna",
+        "total": 2420,
+    }
     assert parse_program_line("not a program line") is None
     assert parse_program_line("MPPDYNA          12/30/2022          0") is None
     assert parse_program_line("") is None


### PR DESCRIPTION
#### What
Fix the LS-Dyna parser to ensure it's parsing the most recent version of the output from the license server.

#### Why
The parser was failing to parse when no licenses are queued because it's represented as a dash instead of a zero.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
