### PR TITLE
Update GitHub Actions to support patch releases

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -6,7 +6,7 @@ name: Prepare for release
 #   - Use Poetry to bump up the versions;
 #   - Create a new header for the new version at the changelogs;
 #   - Check if all sub-projects share the same version number;
-#   - Create a new branch named release/<new_version>;
+#   - Create a new branch named prepare-release/<new_version>;
 #   - Open a draft PR to the main branch, so all the changes above can be reviewed by the team before merging.
 
 on:
@@ -72,9 +72,8 @@ jobs:
         with:
           token: ${{ secrets.TOKEN }}
           commit-message: "Prepared release ${{ steps.agent-package.outputs.version }}"
-          branch: "release/${{ steps.agent-package.outputs.version }}"
+          branch: "prepare-release/${{ steps.agent-package.outputs.version }}"
           title: "Release ${{ steps.agent-package.outputs.version }}"
-          base: "main"
           draft: true
           delete-branch: true
           body: "Automated changes by [prepare_release](https://github.com/omnivector-solutions/license-manager/blob/main/.github/workflows/prepare_release.yaml) GitHub action."

--- a/.github/workflows/tag_on_merged_pull_request.yaml
+++ b/.github/workflows/tag_on_merged_pull_request.yaml
@@ -1,7 +1,7 @@
 name: Create tag when released is accepted
 
 # This action:
-#   - Is triggered when a release PR is accepted and merged into main;
+#   - Is triggered when a release PR is accepted and merged into a release branch;
 #   - Get the version number from the tag's name;
 #   - Create a new tag named according to the version number in the PR;
 #   - Push the new tag to GitHub.
@@ -10,11 +10,12 @@ on:
   pull_request:
     branches: 
       - main
+      - release/**
     types: [closed]
 
 jobs:
   create-tag:
-    if: (github.event.pull_request.merged && startsWith(github.head_ref, 'release/'))
+    if: (github.event.pull_request.merged && startsWith(github.head_ref, 'prepare-release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +27,7 @@ jobs:
         id: get-tag
         with:
           _input-text: ${{ github.head_ref }}
-          release/: ""
+          prepare-release/: ""
 
       - name: Show tag name
         run: echo ${{ steps.get-tag.outputs.result }}


### PR DESCRIPTION
#### What
Update the GitHub Actions to support creating a patch release correctly.

#### Why
To follow the new branching model, the patch release should be merged into the release branch.
This is not possible with the current GitHub Actions because it's creating the patch release branch from the main branch instead of the release branch.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
