### PR TITLE
Release 3.1.1

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
+
+
+## 3.1.1 -- 2024-03-26
 * Fix LS-Dyna parser to parse the queue value when it's represented as a dash instead of a zero
 
 ## 3.1.0 -- 2024-01-24

--- a/lm-agent/pyproject.toml
+++ b/lm-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "3.1.0"
+version = "3.1.1"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to `License Manager API`.
 
 ## Unreleased
 
+
+## 3.1.1 -- 2024-03-26
 ## 3.1.0 -- 2024-01-24
 * Update constraints to limit int fields to 2**31-1 [PENG-1438]
 * Change minimum Python version to 3.12 [ASP-4290]

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to `License Manager API`.
 
 
 ## 3.1.1 -- 2024-03-26
+* Bumped version to keep in sync with agent
+
 ## 3.1.0 -- 2024-01-24
 * Update constraints to limit int fields to 2**31-1 [PENG-1438]
 * Change minimum Python version to 3.12 [ASP-4290]

--- a/lm-api/pyproject.toml
+++ b/lm-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "3.1.0"
+version = "3.1.1"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-cli/CHANGELOG.md
+++ b/lm-cli/CHANGELOG.md
@@ -6,6 +6,8 @@ This file keeps track of all notable changes to `License Manager CLI`.
 
 
 ## 3.1.1 -- 2024-03-26
+* Bumped version to keep in sync with agent
+
 ## 3.1.0 -- 2024-01-24
 * Updated linter and checker to use ruff [ASP-4293]
 * Change minimum Python version to 3.12 [ASP-4295]

--- a/lm-cli/CHANGELOG.md
+++ b/lm-cli/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to `License Manager CLI`.
 
 ## Unreleased
 
+
+## 3.1.1 -- 2024-03-26
 ## 3.1.0 -- 2024-01-24
 * Updated linter and checker to use ruff [ASP-4293]
 * Change minimum Python version to 3.12 [ASP-4295]

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-cli"
-version = "3.1.0"
+version = "3.1.1"
 description = "License Manager CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
Automated changes by [prepare_release](https://github.com/omnivector-solutions/license-manager/blob/main/.github/workflows/prepare_release.yaml) GitHub action.