### PR TITLE
[ASP-5160] Fix UTF-8 decoding of license server outputs

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -5,7 +5,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 ## Unreleased
 * Improve FlexLM, LM-X and OLicense parsers to parse multiple versions of the license server output [ASP-4670]
 * Fix LS-Dyna parser to parse the queue value when it's represented as a dash instead of a zero
-
+* Fix bug with output parsing when there's non UTF-8 characters in the output [ASP-5160]
 
 ## 3.1.0 -- 2024-01-24
 * Updated linter and checker to use ruff [ASP-4293]

--- a/lm-agent/lm_agent/utils.py
+++ b/lm-agent/lm_agent/utils.py
@@ -22,7 +22,7 @@ async def run_command(command_line_parts: List[str]) -> str:
 
     # block until the command succeeds
     stdout, _ = await asyncio.wait_for(proc.communicate(), TOOL_TIMEOUT)
-    output = str(stdout, encoding=ENCODING)
+    output = str(stdout, encoding=ENCODING, errors="replace")
 
     if proc.returncode != 0:
         error_message = shlex.join(


### PR DESCRIPTION
#### What
Replace errors when UTF-8 can't decode a character.

#### Why
It was breaking the parser when there's non UTF-8 characters in the output.

`Task`: https://jira.scania.com/browse/ASP-5160

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
