### PR TITLE
[ASP-5048]  Fix lead host parsing when the job runs in multiple nodes

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
-
+* Fix bug in extraction of the lead host when the job runs in multiple nodes [ASP-5048]
 
 ## 3.2.0 -- 2024-04-29
 * Improve FlexLM, LM-X and OLicense parsers to parse multiple versions of the license server output [ASP-4670]

--- a/lm-agent/lm_agent/workload_managers/slurm/cmd_utils.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/cmd_utils.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Union
 
 from lm_agent.backend_utils.models import LicenseBooking
 from lm_agent.logs import logger
+from buzz import require_condition
 
 
 SCONTROL_PATH = "/usr/bin/scontrol"
@@ -166,7 +167,13 @@ async def get_lead_host(nodelist):
     stdout, _ = await asyncio.wait_for(proc.communicate(), CMD_TIMEOUT)
     output = str(stdout, encoding=ENCODING)
 
-    return output.split("\n")[0]
+    lead_host = output.split("\n")[0]
+
+    require_condition(
+        lead_host != "", "Could not get lead host from nodelist.", raise_exc_class=ScontrolRetrievalFailure
+    )
+
+    return lead_host
 
 
 async def get_cluster_name() -> str:

--- a/lm-agent/lm_agent/workload_managers/slurm/common.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/common.py
@@ -4,25 +4,23 @@ Common utilities for slurm commands.
 import os
 
 from lm_agent.logs import logger
-
-SCONTROL_PATH = "/usr/bin/scontrol"
-SACCTMGR_PATH = "/usr/bin/sacctmgr"
-SQUEUE_PATH = "/usr/bin/squeue"
-CMD_TIMEOUT = 5
-ENCODING = "UTF8"
+from lm_agent.workload_managers.slurm.cmd_utils import get_lead_host
 
 
-def get_job_context():
-    """Get and return variables from the job environment."""
+async def get_job_context():
+    """
+    Get and return variables from the job environment.
+    """
     ctxt = dict()
     try:
         ctxt = {
             "cluster_name": os.environ["SLURM_CLUSTER_NAME"],
             "job_id": os.environ["SLURM_JOB_ID"],
-            "lead_host": os.environ["SLURM_JOB_NODELIST"].split(",")[0],
+            "lead_host": await get_lead_host(os.environ["SLURM_JOB_NODELIST"]),
             "user_name": os.environ["SLURM_JOB_USER"],
             "job_licenses": os.environ.get("SLURM_JOB_LICENSES", ""),
         }
+
     except KeyError as e:
         # If not all keys could be assigned, then return non 0 exit status
         logger.error(

--- a/lm-agent/lm_agent/workload_managers/slurm/reservations.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/reservations.py
@@ -5,7 +5,7 @@ from lm_agent.config import settings
 from lm_agent.exceptions import CommandFailedToExecute
 from lm_agent.logs import logger
 from lm_agent.utils import run_command
-from lm_agent.workload_managers.slurm.common import SCONTROL_PATH
+from lm_agent.workload_managers.slurm.cmd_utils import SCONTROL_PATH
 
 
 async def scontrol_create_reservation(licenses: str, duration: str) -> bool:

--- a/lm-agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
@@ -16,7 +16,7 @@ from lm_agent.workload_managers.slurm.common import get_job_context
 async def epilog():
     # Initialize the logger
     init_logging("slurmctld-epilog")
-    job_context = get_job_context()
+    job_context = await get_job_context()
     job_id = job_context["job_id"]
     job_licenses = job_context["job_licenses"]
 

--- a/lm-agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
@@ -27,7 +27,7 @@ async def prolog():
     # Initialize the logger
     init_logging("slurmctld-prolog")
     # Acqure the job context
-    job_context = get_job_context()
+    job_context = await get_job_context()
     job_id = job_context.get("job_id", "")
     user_name = job_context.get("user_name")
     lead_host = job_context.get("lead_host")


### PR DESCRIPTION
#### What
Fix the extraction of the lead host when the job runs in multiple nodes.

#### Why
The nodelist was being splitted by `,`, but the nodelist comes inside square brackets, which was not returning the expected values.

Example: `node-[1,2,3]` was being parsed as `node-[1` instead of `node-1`

`Task`: https://jira.scania.com/browse/ASP-5048

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
