### PR TITLE
[ASP-4603] Report Cluster Status to API

### DIFF
--- a/lm-agent/lm_agent/backend_utils/utils.py
+++ b/lm-agent/lm_agent/backend_utils/utils.py
@@ -134,6 +134,20 @@ async def check_backend_health():
         raise LicenseManagerBackendConnectionError("Could not connect to the backend health-check endpoint")
 
 
+async def report_cluster_status():
+    """
+    Report the cluster status to the backend.
+    """
+    interval = settings.STAT_INTERVAL
+
+    async with AsyncBackendClient() as backend_client:
+        resp = await backend_client.put("/lm/cluster_statuses", params={"interval": interval})
+
+    LicenseManagerBackendConnectionError.require_condition(
+        resp.status_code == 202, f"Failed to report cluster status: {resp.text}"
+    )
+
+
 async def get_cluster_jobs_from_backend() -> List[JobSchema]:
     """
     Get all jobs for the cluster with its bookings from the backend.

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -94,6 +94,9 @@ class Settings(BaseSettings):
     # If set to `True`, reconcile will be triggered by Prolog/Epilog. Set to `False` to disable this.
     USE_RECONCILE_IN_PROLOG_EPILOG: bool = True
 
+    # Stat interval used to report the cluster status to the API
+    STAT_INTERVAL: int = 60
+
     class Config:
         env_prefix = "LM2_AGENT_"
         if DEFAULT_DOTENV_PATH.is_file():

--- a/lm-agent/lm_agent/reconcile.py
+++ b/lm-agent/lm_agent/reconcile.py
@@ -5,7 +5,7 @@ import typing
 
 import sentry_sdk
 
-from lm_agent.backend_utils.utils import check_backend_health
+from lm_agent.backend_utils.utils import check_backend_health, report_cluster_status
 from lm_agent.config import settings
 from lm_agent.logs import init_logging, logger
 from lm_agent.services.reconciliation import reconcile
@@ -32,6 +32,7 @@ async def run_reconcile():
     begin_logging()
     logger.info("Starting reconcile script")
     await check_backend_health()
+    await report_cluster_status()
     await reconcile()
     logger.info("Reconcile completed successfully")
 

--- a/lm-agent/tests/backend_utils/test_backend_utils.py
+++ b/lm-agent/tests/backend_utils/test_backend_utils.py
@@ -31,6 +31,7 @@ from lm_agent.backend_utils.utils import (
     make_booking_request,
     make_feature_update,
     remove_job_by_slurm_job_id,
+    report_cluster_status,
 )
 from lm_agent.config import settings
 from lm_agent.exceptions import LicenseManagerBackendConnectionError
@@ -202,6 +203,22 @@ async def test__get_license_manager_backend_version__raises_exception_on_non_two
     respx.get(f"{settings.BACKEND_BASE_URL}/lm/health").mock(return_value=Response(500))
     with raises(LicenseManagerBackendConnectionError, match="Could not connect"):
         await check_backend_health()
+
+
+@mark.asyncio
+@pytest.mark.respx(base_url="http://backend")
+async def test__report_cluster_status__success_on_202(respx_mock):
+    respx_mock.put("/lm/cluster_statuses?interval=60").mock(return_value=Response(202))
+    await report_cluster_status()
+
+
+@mark.asyncio
+@pytest.mark.respx(base_url="http://backend")
+async def test__report_cluster_status__raises_exception_on_non_202(respx_mock):
+    respx_mock.put("/lm/cluster_statuses?interval=60").mock(return_value=Response(400))
+
+    with raises(LicenseManagerBackendConnectionError, match="Failed to report cluster status"):
+        await report_cluster_status()
 
 
 @mark.asyncio


### PR DESCRIPTION
#### What
Add a function to report the cluster status to the reconcile script.
Also add a new env var `STAT_INTERVAL` to set the interval of the timed reconciiation.
This env var will be set up by the License Manager Agent Charm and will be kept in sync with the stat interval of the timer that triggers the reconciliation.

#### Why
To have a way of tracking the latest update from each cluster.

`Task`: https://jira.scania.com/browse/ASP-4603

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
