### PR TITLE
PENG-2231 remove any audience setup from the API settings

### DIFF
--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -10,6 +10,8 @@ This file keeps track of all notable changes to `License Manager API`.
 * Upgrade py-buzz to *^4.1.0*
 * Upgrade Pydantic to *^2.8.2* [[PENG-2280](https://sharing.clickup.com/t/h/c/18022949/PENG-2280/YUSOZKBIF96CZJ0)]
 * Add *pydantic-settings* as a dependency
+* Remove the audience setting [[PENG-2231](https://sharing.clickup.com/t/h/c/18022949/PENG-2231/T3PXA6KD1EH124G)]
+
 
 ## 3.3.0 -- 2024-05-30
 * Add new endpoints to manage the cluster reports from the agent [ASP-4601]

--- a/lm-api/docker-compose.yaml
+++ b/lm-api/docker-compose.yaml
@@ -17,7 +17,6 @@ services:
       DATABASE_NAME: ${DATABASE_NAME:-compose-db-name}
       DATABASE_PORT: 5432
       ARMASEC_DOMAIN: ${ARMASEC_DOMAIN}
-      ARMASEC_AUDIENCE: ${ARMASEC_AUDIENCE}
       ARMASEC_DEBUG: ${ARMASEC_DEBUG:-false}
       LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
     ports:
@@ -35,7 +34,6 @@ services:
       TEST_DATABASE_NAME: test-db-name
       TEST_DATABASE_PORT: 5432
       ARMASEC_DOMAIN: armasec.dev
-      ARMASEC_AUDIENCE: https://armasec.dev
       LOG_LEVEL: DEBUG
       DEPLOY_ENV: TEST
     command: poetry run pytest -s
@@ -55,7 +53,6 @@ services:
       DATABASE_PSWD: ${DATABASE_PSWD:-compose-db-pswd}
       DATABASE_NAME: ${DATABASE_NAME:-compose-db-name}
       ARMASEC_DOMAIN: armasec.dev
-      ARMASEC_AUDIENCE: https://armasec.dev
       LOG_LEVEL: DEBUG
     command: "poetry run python -m alembic -c alembic/alembic.ini upgrade head"
     depends_on:

--- a/lm-api/lm_api/config.py
+++ b/lm-api/lm_api/config.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field, HttpUrl
+from pydantic import Field
 
 from lm_api.constants import LogLevelEnum
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -48,10 +48,8 @@ class Settings(BaseSettings):
 
     # Security Settings. For details, see https://github.com/omnivector-solutions/armsec
     ARMASEC_DOMAIN: str
-    ARMASEC_AUDIENCE: Optional[HttpUrl]
     ARMASEC_DEBUG: bool = Field(False)
     ARMASEC_ADMIN_DOMAIN: Optional[str] = None
-    ARMASEC_ADMIN_AUDIENCE: Optional[HttpUrl] = None
     ARMASEC_ADMIN_MATCH_KEY: Optional[str] = None
     ARMASEC_ADMIN_MATCH_VALUE: Optional[str] = None
     model_config = SettingsConfigDict(env_file=".env")

--- a/lm-api/lm_api/security.py
+++ b/lm-api/lm_api/security.py
@@ -21,14 +21,12 @@ def get_domain_configs() -> typing.List[DomainConfig]:
     domain_configs = [
         DomainConfig(
             domain=settings.ARMASEC_DOMAIN,
-            audience=str(settings.ARMASEC_AUDIENCE),
             debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
         )
     ]
     if all(
         [
             settings.ARMASEC_ADMIN_DOMAIN,
-            settings.ARMASEC_ADMIN_AUDIENCE,
             settings.ARMASEC_ADMIN_MATCH_KEY,
             settings.ARMASEC_ADMIN_MATCH_VALUE,
         ]
@@ -36,7 +34,6 @@ def get_domain_configs() -> typing.List[DomainConfig]:
         domain_configs.append(
             DomainConfig(
                 domain=settings.ARMASEC_ADMIN_DOMAIN,
-                audience=str(settings.ARMASEC_ADMIN_AUDIENCE),
                 match_keys={settings.ARMASEC_ADMIN_MATCH_KEY: settings.ARMASEC_ADMIN_MATCH_VALUE},
                 debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
             )

--- a/lm-api/tests/test_security.py
+++ b/lm-api/tests/test_security.py
@@ -6,20 +6,17 @@ from lm_api.security import IdentityPayload, get_domain_configs
 def test_get_domain_configs__loads_only_base_settings(tweak_settings):
     with tweak_settings(
         ARMASEC_DOMAIN="foo.io",
-        ARMASEC_AUDIENCE="https://bar.dev",
     ):
         domain_configs = get_domain_configs()
 
     assert len(domain_configs) == 1
     first_config = domain_configs.pop()
     assert first_config.domain == "foo.io"
-    assert first_config.audience == "https://bar.dev"
 
 
 def test_get_domain_configs__loads_admin_settings_if_all_are_present(tweak_settings):
     with tweak_settings(
         ARMASEC_DOMAIN="foo.io",
-        ARMASEC_AUDIENCE="https://bar.dev",
         ARMASEC_ADMIN_DOMAIN="admin.io",
     ):
         domain_configs = get_domain_configs()
@@ -27,13 +24,10 @@ def test_get_domain_configs__loads_admin_settings_if_all_are_present(tweak_setti
     assert len(domain_configs) == 1
     first_config = domain_configs.pop()
     assert first_config.domain == "foo.io"
-    assert first_config.audience == "https://bar.dev"
 
     with tweak_settings(
         ARMASEC_DOMAIN="foo.io",
-        ARMASEC_AUDIENCE="https://bar.dev",
         ARMASEC_ADMIN_DOMAIN="admin.io",
-        ARMASEC_ADMIN_AUDIENCE="https://admin.dev",
         ARMASEC_ADMIN_MATCH_KEY="foo",
         ARMASEC_ADMIN_MATCH_VALUE="bar",
     ):
@@ -42,9 +36,7 @@ def test_get_domain_configs__loads_admin_settings_if_all_are_present(tweak_setti
     assert len(domain_configs) == 2
     (first_config, second_config) = domain_configs
     assert first_config.domain == "foo.io"
-    assert first_config.audience == "https://bar.dev"
     assert second_config.domain == "admin.io"
-    assert second_config.audience == "https://admin.dev"
     assert second_config.match_keys == dict(foo="bar")
 
 


### PR DESCRIPTION
#### What
This PR simply removes any audience setup from the API

#### Why
The audience setting is no longer used by any means

`Task`: https://sharing.clickup.com/t/h/c/18022949/PENG-2231/T3PXA6KD1EH124G

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
