### PR TITLE
Fix plural parsing on FlexLM parser

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -4,7 +4,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
 * Add env var to set wheter the agent should use HTTP or HTTPS to communicate with the OIDC provider
-
+* Fix FlexLM parser to parse an output with only one license checked out
 
 ## 3.3.0 -- 2024-05-30
 * Fix bug in extraction of the lead host when the job runs in multiple nodes [ASP-5048]

--- a/lm-agent/lm_agent/parsing/flexlm.py
+++ b/lm-agent/lm_agent/parsing/flexlm.py
@@ -24,7 +24,7 @@ FEATURE_LINE = (
     rf"(?P<total>{INT}) "
     r"licenses issued;  Total of "
     rf"(?P<used>{INT}) "
-    rf"licenses in use\)$"
+    rf"license(?P<plural>s)? in use\)$"
 )
 
 USAGE_LINE_1 = (

--- a/lm-agent/tests/conftest.py
+++ b/lm-agent/tests/conftest.py
@@ -670,6 +670,20 @@ def flexlm_output_4():
 
 
 @fixture
+def flexlm_output_5():
+    """Some FlexLM output to parse."""
+    return dedent(
+        """\
+        Flexible License Manager status on Wed 7/3/2024 14:36
+        ...
+        Users of ADAMSTK_GG_Solver:  (Total of 6 licenses issued;  Total of 1 license in use)
+        ...
+            fjan1a dcv055.com /dev/pts/0 (v2023.0331) (myserver.example.com/29065 7549), start Wed 7/3 11:03
+        """
+    )
+
+
+@fixture
 def flexlm_output_no_licenses():
     """Some lmstat output with no licenses in use to parse."""
     return dedent(

--- a/lm-agent/tests/parsing/test_flexlm.py
+++ b/lm-agent/tests/parsing/test_flexlm.py
@@ -20,6 +20,14 @@ from lm_agent.server_interfaces.license_server_interface import LicenseUsesItem
             },
         ),
         (
+            "Users of TESTFEATURE:  (Total of 1000 licenses issued;  Total of 1 license in use)",
+            {
+                "feature": "testfeature",
+                "total": 1000,
+                "used": 1,
+            },
+        ),
+        (
             "not a feature line",
             None,
         ),
@@ -152,6 +160,17 @@ def test_parse_usage_line(line, result):
                     LicenseUsesItem(booked=1, lead_host="ER0037", username="abcdkk"),
                     LicenseUsesItem(booked=5, lead_host="ER0037", username="abcdkk"),
                     LicenseUsesItem(booked=1, lead_host="ER0037", username="abcdkk"),
+                ],
+            },
+        ),
+        (
+            "flexlm_output_5",
+            {
+                "feature": "adamstk_gg_solver",
+                "total": 6,
+                "used": 1,
+                "uses": [
+                    LicenseUsesItem(booked=1, lead_host="dcv055.com", username="fjan1a"),
                 ],
             },
         ),


### PR DESCRIPTION
#### What
Fix the feature line parsing in FlexLM parser to account for the plural.

#### Why
When there's only one license checked-out, the output changes from `n licenses` to `1 license`, which was breaking the parser.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
