### PR TITLE
Add env var to set HTTPS on Armasec

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
+* Add env var to set wheter the agent should use HTTP or HTTPS to communicate with the OIDC provider
 
 
 ## 3.3.0 -- 2024-05-30

--- a/lm-agent/lm_agent/backend_utils/utils.py
+++ b/lm-agent/lm_agent/backend_utils/utils.py
@@ -87,7 +87,8 @@ def acquire_token() -> str:
             client_secret=settings.OIDC_CLIENT_SECRET,
             grant_type="client_credentials",
         )
-        oidc_url = f"https://{settings.OIDC_DOMAIN}/protocol/openid-connect/token"
+        protocol = "https" if settings.OIDC_USE_HTTPS else "http"
+        oidc_url = f"{protocol}://{settings.OIDC_DOMAIN}/protocol/openid-connect/token"
         logger.debug(f"Posting OIDC request to {oidc_url}")
         response = httpx.post(oidc_url, data=oidc_body)
         LicenseManagerAuthTokenError.require_condition(

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -87,6 +87,7 @@ class Settings(BaseSettings):
     OIDC_AUDIENCE: str
     OIDC_CLIENT_ID: str
     OIDC_CLIENT_SECRET: str
+    OIDC_USE_HTTPS: bool = True
 
     # Token cache directory
     CACHE_DIR: Path = DEFAULT_CACHE_DIR

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -11,6 +11,7 @@ This file keeps track of all notable changes to `License Manager API`.
 * Upgrade Pydantic to *^2.8.2* [[PENG-2280](https://sharing.clickup.com/t/h/c/18022949/PENG-2280/YUSOZKBIF96CZJ0)]
 * Add *pydantic-settings* as a dependency
 * Remove the audience setting [[PENG-2231](https://sharing.clickup.com/t/h/c/18022949/PENG-2231/T3PXA6KD1EH124G)]
+* Add env var to set whether Armasec should use HTTPS or HTTP
 
 
 ## 3.3.0 -- 2024-05-30

--- a/lm-api/lm_api/config.py
+++ b/lm-api/lm_api/config.py
@@ -52,6 +52,7 @@ class Settings(BaseSettings):
     ARMASEC_ADMIN_DOMAIN: Optional[str] = None
     ARMASEC_ADMIN_MATCH_KEY: Optional[str] = None
     ARMASEC_ADMIN_MATCH_VALUE: Optional[str] = None
+    ARMASEC_USE_HTTPS: bool = Field(True)
     model_config = SettingsConfigDict(env_file=".env")
 
 

--- a/lm-api/lm_api/security.py
+++ b/lm-api/lm_api/security.py
@@ -22,6 +22,7 @@ def get_domain_configs() -> typing.List[DomainConfig]:
         DomainConfig(
             domain=settings.ARMASEC_DOMAIN,
             debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
+            use_https=settings.ARMASEC_USE_HTTPS,
         )
     ]
     if all(
@@ -36,6 +37,7 @@ def get_domain_configs() -> typing.List[DomainConfig]:
                 domain=settings.ARMASEC_ADMIN_DOMAIN,
                 match_keys={settings.ARMASEC_ADMIN_MATCH_KEY: settings.ARMASEC_ADMIN_MATCH_VALUE},
                 debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
+                use_https=settings.ARMASEC_USE_HTTPS,
             )
         )
     return domain_configs


### PR DESCRIPTION
#### What
Add an env var to set whether Armasec should use HTTPS or HTTP.

#### Why
While working on adding the lm-composed subproject, it was failing due to the default value being HTTPS and Keycloak was running on HTTP.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
