### PR TITLE
[ASP-5025] Refactor of License Manager Simulator to fix FK issue

### DIFF
--- a/lm-simulator/CHANGELOG.md
+++ b/lm-simulator/CHANGELOG.md
@@ -6,6 +6,9 @@ This file keeps track of all notable changes to license-manager-simulator
 * Migrated the project to the main license-manager repository
 * Upgrade FastAPI to *^0.111.0*
 * Upgrade Pydantic to *^2.8.2*
+* Added cascade delete to remove Licenses In Use when the License is deleted
+* Refactored database module to use AsyncSesssion
+
 
 ## 0.3.0 -- 2022-11-16
 * Fixed lm-sim ip in setup scripts to use the new subapp endpoint

--- a/lm-simulator/CHANGELOG.md
+++ b/lm-simulator/CHANGELOG.md
@@ -8,7 +8,7 @@ This file keeps track of all notable changes to license-manager-simulator
 * Upgrade Pydantic to *^2.8.2*
 * Added cascade delete to remove Licenses In Use when the License is deleted
 * Refactored database module to use AsyncSesssion
-
+* Updated job application example
 
 ## 0.3.0 -- 2022-11-16
 * Fixed lm-sim ip in setup scripts to use the new subapp endpoint

--- a/lm-simulator/Dockerfile
+++ b/lm-simulator/Dockerfile
@@ -1,14 +1,18 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8-slim
+FROM python:3.12-slim-bullseye
 
-ENV MODULE_NAME=lm_simulator.main
+WORKDIR /app
 
 RUN apt update && apt install -y curl libpq-dev gcc
 
-RUN pip install poetry && \
-    poetry config virtualenvs.create false
-
 COPY ./pyproject.toml ./poetry.lock* /app/
 
-RUN poetry install --no-root --only main
+RUN pip install poetry \
+    && poetry config virtualenvs.in-project true \
+    && poetry install --no-root --no-dev \
+    && rm -rf "$POETRY_CACHE_DIR"
+
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY ./lm_simulator /app/lm_simulator
+
+CMD ["uvicorn", "lm_simulator.main:app", "--host", "0.0.0.0", "--port", "80", "--loop", "asyncio"]

--- a/lm-simulator/Dockerfile-ci
+++ b/lm-simulator/Dockerfile-ci
@@ -1,0 +1,16 @@
+FROM python:3.12-slim-bullseye
+
+WORKDIR /app
+
+RUN apt update && apt install -y curl libpq-dev gcc
+
+COPY ./pyproject.toml ./poetry.lock* /app/
+
+RUN pip install poetry \
+    && poetry config virtualenvs.in-project true \
+    && poetry install --no-root \
+    && rm -rf "$POETRY_CACHE_DIR"
+
+COPY ./lm_simulator /app/lm_simulator
+
+CMD ["uvicorn", "lm_simulator.main:app", "--host", "0.0.0.0", "--port", "80", "--loop", "asyncio"]

--- a/lm-simulator/Makefile
+++ b/lm-simulator/Makefile
@@ -1,47 +1,51 @@
-# TARGETS
+# SETTINGS
+# Use one shell for all commands in a target recipe
+SHELL:=/bin/bash
+.DEFAULT_GOAL:=help
+ROOT_DIR:=$(shell dirname $(shell pwd))
+PACKAGE_NAME:=lm_simulator
+
+.PHONY: install
 install:
 	poetry install
 
-test: install
-	poetry run pytest
+.PHONY: test
+test:
+	docker-compose up --build unittest
+	docker-compose run --rm unittest
 
+.PHONY: lint
 lint: install
 	poetry run flake8 lm_simulator tests --max-line-length=110
 	poetry run isort --check lm_simulator tests
 	poetry run black --check lm_simulator tests
 
+.PHONY: format
 format: install
 	poetry run black lm_simulator tests
 	poetry run isort lm_simulator tests
 
+.PHONY: qa
 qa: test lint
+	echo "All quality checks pass!"
 
+.PHONY: local
 local: install
 	docker-compose up --build lm-simulator
 
+.PHONY: setup
 setup:
 	./scripts/create-dev-setup.sh $(lm_sim_ip)
 
+.PHONY: clean
 clean: clean-eggs clean-build
 	@find . -iname '*.pyc' -delete
 	@find . -iname '*.pyo' -delete
 	@find . -iname '*~' -delete
 	@find . -iname '*.swp' -delete
 	@find . -iname '__pycache__' -delete
-
-clean-eggs:
 	@find . -name '*.egg' -print0|xargs -0 rm -rf --
 	@rm -rf .eggs/
-
-clean-build:
 	@rm -fr build/
 	@rm -fr dist/
 	@rm -fr *.egg-info
-
-# SETTINGS
-# Use one shell for all commands in a target recipe
-.ONESHELL:
-# Set default goal
-.DEFAULT_GOAL := help
-# Use bash shell in Make instead of sh 
-SHELL := /bin/bash

--- a/lm-simulator/docker-compose.yaml
+++ b/lm-simulator/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       POSTGRES_DB: local-db
       POSTGRES_USER: local-user
       POSTGRES_PASSWORD: local-pswd
-    ports: ["5432:5432"]
+    ports: ["5434:5432"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
@@ -21,7 +21,7 @@ services:
       POSTGRES_DB: test-db
       POSTGRES_USER: test-user
       POSTGRES_PASSWORD: test-pswd
-    ports: ["5433:5432"]
+    ports: ["5435:5432"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]

--- a/lm-simulator/docker-compose.yaml
+++ b/lm-simulator/docker-compose.yaml
@@ -4,13 +4,16 @@ services:
   postgres-back:
     image: postgres:14.1
     environment:
-      POSTGRES_PASSWORD: 123
+      POSTGRES_DB: local-db
+      POSTGRES_USER: local-user
+      POSTGRES_PASSWORD: local-pswd
+    ports: ["5432:5432"]
+    restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "postgres", "-h", "localhost"]
-      interval: 5s
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
       timeout: 5s
       retries: 5
-    user: postgres
 
   lm-simulator:
     build:
@@ -20,7 +23,11 @@ services:
       postgres-back:
         condition: service_healthy
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:123@postgres-back:5432/postgres}
-    ports:
-      - "8000:8000"
+      DATABASE_HOST: postgres-back
+      DATABASE_USER: local-user
+      DATABASE_PSWD: local-pswd
+      DATABASE_NAME: local-db
+      DATABASE_PORT: 5432
+
+    ports: ["8000:8000"]
     command: uvicorn lm_simulator.main:app --reload --workers 1 --host 0.0.0.0 --port 8000

--- a/lm-simulator/docker-compose.yaml
+++ b/lm-simulator/docker-compose.yaml
@@ -42,7 +42,6 @@ services:
       DATABASE_PSWD: local-pswd
       DATABASE_NAME: local-db
       DATABASE_PORT: 5432
-
     ports: ["8000:8000"]
     command: uvicorn lm_simulator.main:app --reload --workers 1 --host 0.0.0.0 --port 8000
 

--- a/lm-simulator/docker-compose.yaml
+++ b/lm-simulator/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
 
-  postgres-back:
+  db:
     image: postgres:14.1
     environment:
       POSTGRES_DB: local-db
@@ -15,15 +15,29 @@ services:
       timeout: 5s
       retries: 5
 
+  unittest-db:
+    image: postgres:14.1
+    environment:
+      POSTGRES_DB: test-db
+      POSTGRES_USER: test-user
+      POSTGRES_PASSWORD: test-pswd
+    ports: ["5433:5432"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   lm-simulator:
     build:
       context: .
       dockerfile: ./Dockerfile
     depends_on:
-      postgres-back:
+      db:
         condition: service_healthy
     environment:
-      DATABASE_HOST: postgres-back
+      DATABASE_HOST: db
       DATABASE_USER: local-user
       DATABASE_PSWD: local-pswd
       DATABASE_NAME: local-db
@@ -31,3 +45,20 @@ services:
 
     ports: ["8000:8000"]
     command: uvicorn lm_simulator.main:app --reload --workers 1 --host 0.0.0.0 --port 8000
+
+  unittest:
+    build:
+      context: .
+      dockerfile: ./Dockerfile-ci
+    environment:
+      TEST_DATABASE_HOST: unittest-db
+      TEST_DATABASE_USER: test-user
+      TEST_DATABASE_PSWD: test-pswd
+      TEST_DATABASE_NAME: test-db
+      TEST_DATABASE_PORT: 5432
+    command: poetry run pytest -s
+    depends_on:
+      unittest-db:
+        condition: service_healthy
+    volumes:
+      - ./tests:/app/tests

--- a/lm-simulator/job/application.sh
+++ b/lm-simulator/job/application.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-# You must modify this value to reflect the ip address and port that the
+# You must modify this value to reflect the IP address and port that the
 # license-manager-simulator is listening on in your environment.
 #
 # The format of the value is: `http://<ip-address>:<port>`
 URL="http://localhost:8000"
 
-# number of licenses: from the CLI or 42
-if [ -z $1 ]; then
-	X=42
+# Number of licenses: from the CLI or default to 42
+if [ -z "$1" ]; then
+    X=42
 else
-	X=$1
+    X=$1
 fi
 
 payload="{\"quantity\": "$X", \
@@ -20,24 +20,28 @@ payload="{\"quantity\": "$X", \
           \"license_name\": \"test_feature\"}"
 
 echo "Requesting $X licenses for user $USER"
-status=$(curl -s -o /dev/null -w '%{http_code}' \
-	      -X 'POST' \
-	      -H 'Content-Type: application/json' \
-	      -d "$payload" \
-	      "$URL"/lm-sim/licenses-in-use/)
-if [ "$status" = "201" ]; then
-	echo "There are enought licenses available, lets run (sleep) the job"
-	sleep $((RANDOM % 100 + 100))
+response=$(curl -s -w 'HTTPSTATUS:%{http_code}' \
+              -X 'POST' \
+              -H 'Content-Type: application/json' \
+              -d "$payload" \
+              "$URL"/lm-sim/licenses-in-use)
+
+response_status=$(echo "$response" | sed -e 's/.*HTTPSTATUS://')
+response_body=$(echo "$response" | sed -e 's/HTTPSTATUS:.*//')
+
+if [ "$response_status" = "201" ]; then
+    echo "There are enough licenses available, let's run (sleep) the job"
+    sleep $((RANDOM % 100 + 100))
 else
-	echo "There are not enough licenses, let's crash the job"
-	tail /NOT_ENOUGH_LICENSES
+    echo "There are not enough licenses, let's crash the job"
+    tail /NOT_ENOUGH_LICENSES
 fi
 
-echo "Puting the licenses back"
+license_in_use_id=$(echo "$response_body" | grep -o '"id":[0-9]*' | awk -F: '{print $2}')
+
+echo "Putting the licenses back"
 curl -s -o /dev/null \
      -X DELETE \
-     -H 'Content-Type: application/json' \
-     -d "$payload" \
-     "$URL"/lm-sim/licenses-in-use/
+     "$URL/lm-sim/licenses-in-use/$license_in_use_id"
 
 echo "Job done"

--- a/lm-simulator/lm_simulator/config.py
+++ b/lm-simulator/lm_simulator/config.py
@@ -8,6 +8,12 @@ class Settings(BaseSettings):
     DATABASE_NAME: str = "local-db"
     DATABASE_PORT: int = 5432
 
+    TEST_DATABASE_HOST: str = "localhost"
+    TEST_DATABASE_USER: str = "test-db-user"
+    TEST_DATABASE_PSWD: str = "test-db-pswd"
+    TEST_DATABASE_NAME: str = "test-db-name"
+    TEST_DATABASE_PORT: int = 5433
+
     model_config = SettingsConfigDict(env_file=".env")
 
 

--- a/lm-simulator/lm_simulator/config.py
+++ b/lm-simulator/lm_simulator/config.py
@@ -1,11 +1,12 @@
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-_DB_RX = r"^(sqlite|postgresql)://.+$"
 
 
 class Settings(BaseSettings):
-    DATABASE_URL: str = Field("sqlite:///./sqlite.db?check_same_thread=false", pattern=_DB_RX)
+    DATABASE_HOST: str = "localhost"
+    DATABASE_USER: str = "local-user"
+    DATABASE_PSWD: str = "local-pswd"
+    DATABASE_NAME: str = "local-db"
+    DATABASE_PORT: int = 5432
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/lm-simulator/lm_simulator/crud.py
+++ b/lm-simulator/lm_simulator/crud.py
@@ -24,7 +24,7 @@ async def add_license(session: Session, license: LicenseCreate) -> LicenseRow:
         ),
     ):
         session.add(db_license)
-        await session.commit()
+        await session.flush()
         await session.refresh(db_license)
 
         return LicenseRow.model_validate(db_license, from_attributes=True)
@@ -66,7 +66,7 @@ async def remove_license(session: Session, license_name: str):
         ),
     ):
         await session.delete(db_license)
-        await session.commit()
+        await session.flush()
 
 
 async def add_license_in_use(session: Session, license_in_use: LicenseInUseCreate) -> LicenseInUseRow:
@@ -107,7 +107,7 @@ async def add_license_in_use(session: Session, license_in_use: LicenseInUseCreat
         ),
     ):
         session.add(db_license_in_use)
-        await session.commit()
+        await session.flush()
         await session.refresh(db_license_in_use)
 
         return LicenseInUseRow.model_validate(db_license_in_use)
@@ -152,4 +152,4 @@ async def remove_license_in_use(
         ),
     ):
         await session.delete(db_license_in_use)
-        await session.commit()
+        await session.flush()

--- a/lm-simulator/lm_simulator/database.py
+++ b/lm-simulator/lm_simulator/database.py
@@ -1,10 +1,32 @@
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from yarl import URL
 
 from lm_simulator.config import settings
+from lm_simulator.models import Base
 
-engine = create_engine(settings.DATABASE_URL)
-session = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+engine = create_async_engine(
+    str(
+        URL.build(
+            scheme="postgresql+asyncpg",
+            user=settings.DATABASE_USER,
+            password=settings.DATABASE_PSWD,
+            host=settings.DATABASE_HOST,
+            port=settings.DATABASE_PORT,
+            path=f"/{settings.DATABASE_NAME}",
+        )
+    )
+)
 
-Base = declarative_base()
+async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def init_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_maker() as session:
+        yield session

--- a/lm-simulator/lm_simulator/database.py
+++ b/lm-simulator/lm_simulator/database.py
@@ -29,4 +29,11 @@ async def init_db():
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_maker() as session:
-        yield session
+        try:
+            yield session
+            await session.commit()
+        except Exception as e:
+            await session.rollback()
+            raise e
+        finally:
+            await session.close()

--- a/lm-simulator/lm_simulator/main.py
+++ b/lm-simulator/lm_simulator/main.py
@@ -3,7 +3,6 @@ from typing import List
 
 from fastapi import Depends, FastAPI, Response, status
 from fastapi.middleware.cors import CORSMiddleware
-from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lm_simulator.crud import (
@@ -45,7 +44,6 @@ async def health():
 )
 async def create_license(license: LicenseCreate, session: AsyncSession = Depends(get_session)):
     license = await add_license(session=session, license=license)
-    logger.debug(f"Created license: {license}")
     return license
 
 

--- a/lm-simulator/lm_simulator/schemas.py
+++ b/lm-simulator/lm_simulator/schemas.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict
 
 
 class LicenseInUseCreate(BaseModel):
@@ -23,11 +21,6 @@ class LicenseCreate(BaseModel):
 
 class LicenseRow(LicenseCreate):
     in_use: int = 0
-    licenses_in_use: List[LicenseInUseRow] = []
+    licenses_in_use: list[LicenseInUseRow] = []
 
     model_config = ConfigDict(from_attributes=True)
-
-    @model_validator(mode="after")
-    def calculate_in_use(self):
-        self.in_use = sum(license_in_use.quantity for license_in_use in self.licenses_in_use)
-        return self

--- a/lm-simulator/poetry.lock
+++ b/lm-simulator/poetry.lock
@@ -34,6 +34,60 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.23)"]
 
 [[package]]
+name = "asyncpg"
+version = "0.28.0"
+description = "An asyncio PostgreSQL driver"
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "asyncpg-0.28.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a6d1b954d2b296292ddff4e0060f494bb4270d87fb3655dd23c5c6096d16d83"},
+    {file = "asyncpg-0.28.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0740f836985fd2bd73dca42c50c6074d1d61376e134d7ad3ad7566c4f79f8184"},
+    {file = "asyncpg-0.28.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e907cf620a819fab1737f2dd90c0f185e2a796f139ac7de6aa3212a8af96c050"},
+    {file = "asyncpg-0.28.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86b339984d55e8202e0c4b252e9573e26e5afa05617ed02252544f7b3e6de3e9"},
+    {file = "asyncpg-0.28.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0c402745185414e4c204a02daca3d22d732b37359db4d2e705172324e2d94e85"},
+    {file = "asyncpg-0.28.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c88eef5e096296626e9688f00ab627231f709d0e7e3fb84bb4413dff81d996d7"},
+    {file = "asyncpg-0.28.0-cp310-cp310-win32.whl", hash = "sha256:90a7bae882a9e65a9e448fdad3e090c2609bb4637d2a9c90bfdcebbfc334bf89"},
+    {file = "asyncpg-0.28.0-cp310-cp310-win_amd64.whl", hash = "sha256:76aacdcd5e2e9999e83c8fbcb748208b60925cc714a578925adcb446d709016c"},
+    {file = "asyncpg-0.28.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a0e08fe2c9b3618459caaef35979d45f4e4f8d4f79490c9fa3367251366af207"},
+    {file = "asyncpg-0.28.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b24e521f6060ff5d35f761a623b0042c84b9c9b9fb82786aadca95a9cb4a893b"},
+    {file = "asyncpg-0.28.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99417210461a41891c4ff301490a8713d1ca99b694fef05dabd7139f9d64bd6c"},
+    {file = "asyncpg-0.28.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f029c5adf08c47b10bcdc857001bbef551ae51c57b3110964844a9d79ca0f267"},
+    {file = "asyncpg-0.28.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ad1d6abf6c2f5152f46fff06b0e74f25800ce8ec6c80967f0bc789974de3c652"},
+    {file = "asyncpg-0.28.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d7fa81ada2807bc50fea1dc741b26a4e99258825ba55913b0ddbf199a10d69d8"},
+    {file = "asyncpg-0.28.0-cp311-cp311-win32.whl", hash = "sha256:f33c5685e97821533df3ada9384e7784bd1e7865d2b22f153f2e4bd4a083e102"},
+    {file = "asyncpg-0.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:5e7337c98fb493079d686a4a6965e8bcb059b8e1b8ec42106322fc6c1c889bb0"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1c56092465e718a9fdcc726cc3d9dcf3a692e4834031c9a9f871d92a75d20d48"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4acd6830a7da0eb4426249d71353e8895b350daae2380cb26d11e0d4a01c5472"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63861bb4a540fa033a56db3bb58b0c128c56fad5d24e6d0a8c37cb29b17c1c7d"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a93a94ae777c70772073d0512f21c74ac82a8a49be3a1d982e3f259ab5f27307"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d14681110e51a9bc9c065c4e7944e8139076a778e56d6f6a306a26e740ed86d2"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-win32.whl", hash = "sha256:8aec08e7310f9ab322925ae5c768532e1d78cfb6440f63c078b8392a38aa636a"},
+    {file = "asyncpg-0.28.0-cp37-cp37m-win_amd64.whl", hash = "sha256:319f5fa1ab0432bc91fb39b3960b0d591e6b5c7844dafc92c79e3f1bff96abef"},
+    {file = "asyncpg-0.28.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b337ededaabc91c26bf577bfcd19b5508d879c0ad009722be5bb0a9dd30b85a0"},
+    {file = "asyncpg-0.28.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4d32b680a9b16d2957a0a3cc6b7fa39068baba8e6b728f2e0a148a67644578f4"},
+    {file = "asyncpg-0.28.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4f62f04cdf38441a70f279505ef3b4eadf64479b17e707c950515846a2df197"},
+    {file = "asyncpg-0.28.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f20cac332c2576c79c2e8e6464791c1f1628416d1115935a34ddd7121bfc6a4"},
+    {file = "asyncpg-0.28.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:59f9712ce01e146ff71d95d561fb68bd2d588a35a187116ef05028675462d5ed"},
+    {file = "asyncpg-0.28.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fc9e9f9ff1aa0eddcc3247a180ac9e9b51a62311e988809ac6152e8fb8097756"},
+    {file = "asyncpg-0.28.0-cp38-cp38-win32.whl", hash = "sha256:9e721dccd3838fcff66da98709ed884df1e30a95f6ba19f595a3706b4bc757e3"},
+    {file = "asyncpg-0.28.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ba7d06a0bea539e0487234511d4adf81dc8762249858ed2a580534e1720db00"},
+    {file = "asyncpg-0.28.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d009b08602b8b18edef3a731f2ce6d3f57d8dac2a0a4140367e194eabd3de457"},
+    {file = "asyncpg-0.28.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ec46a58d81446d580fb21b376ec6baecab7288ce5a578943e2fc7ab73bf7eb39"},
+    {file = "asyncpg-0.28.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b48ceed606cce9e64fd5480a9b0b9a95cea2b798bb95129687abd8599c8b019"},
+    {file = "asyncpg-0.28.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8858f713810f4fe67876728680f42e93b7e7d5c7b61cf2118ef9153ec16b9423"},
+    {file = "asyncpg-0.28.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5e18438a0730d1c0c1715016eacda6e9a505fc5aa931b37c97d928d44941b4bf"},
+    {file = "asyncpg-0.28.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e9c433f6fcdd61c21a715ee9128a3ca48be8ac16fa07be69262f016bb0f4dbd2"},
+    {file = "asyncpg-0.28.0-cp39-cp39-win32.whl", hash = "sha256:41e97248d9076bc8e4849da9e33e051be7ba37cd507cbd51dfe4b2d99c70e3dc"},
+    {file = "asyncpg-0.28.0-cp39-cp39-win_amd64.whl", hash = "sha256:3ed77f00c6aacfe9d79e9eff9e21729ce92a4b38e80ea99a58ed382f42ebd55b"},
+    {file = "asyncpg-0.28.0.tar.gz", hash = "sha256:7252cdc3acb2f52feaa3664280d3bcd78a46bd6c10bfd681acfffefa1120e278"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=5.3.0,<5.4.0)", "sphinx-rtd-theme (>=1.2.2)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
+test = ["flake8 (>=5.0,<6.0)", "uvloop (>=0.15.3)"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.1"
 description = "Atomic file writes."
@@ -768,10 +822,157 @@ files = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.0.5"
+description = "multidict implementation"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "multidict-6.0.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:228b644ae063c10e7f324ab1ab6b548bdf6f8b47f3ec234fef1093bc2735e5f9"},
+    {file = "multidict-6.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:896ebdcf62683551312c30e20614305f53125750803b614e9e6ce74a96232604"},
+    {file = "multidict-6.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:411bf8515f3be9813d06004cac41ccf7d1cd46dfe233705933dd163b60e37600"},
+    {file = "multidict-6.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d147090048129ce3c453f0292e7697d333db95e52616b3793922945804a433c"},
+    {file = "multidict-6.0.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:215ed703caf15f578dca76ee6f6b21b7603791ae090fbf1ef9d865571039ade5"},
+    {file = "multidict-6.0.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c6390cf87ff6234643428991b7359b5f59cc15155695deb4eda5c777d2b880f"},
+    {file = "multidict-6.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21fd81c4ebdb4f214161be351eb5bcf385426bf023041da2fd9e60681f3cebae"},
+    {file = "multidict-6.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3cc2ad10255f903656017363cd59436f2111443a76f996584d1077e43ee51182"},
+    {file = "multidict-6.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6939c95381e003f54cd4c5516740faba40cf5ad3eeff460c3ad1d3e0ea2549bf"},
+    {file = "multidict-6.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:220dd781e3f7af2c2c1053da9fa96d9cf3072ca58f057f4c5adaaa1cab8fc442"},
+    {file = "multidict-6.0.5-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:766c8f7511df26d9f11cd3a8be623e59cca73d44643abab3f8c8c07620524e4a"},
+    {file = "multidict-6.0.5-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:fe5d7785250541f7f5019ab9cba2c71169dc7d74d0f45253f8313f436458a4ef"},
+    {file = "multidict-6.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1c1496e73051918fcd4f58ff2e0f2f3066d1c76a0c6aeffd9b45d53243702cc"},
+    {file = "multidict-6.0.5-cp310-cp310-win32.whl", hash = "sha256:7afcdd1fc07befad18ec4523a782cde4e93e0a2bf71239894b8d61ee578c1319"},
+    {file = "multidict-6.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:99f60d34c048c5c2fabc766108c103612344c46e35d4ed9ae0673d33c8fb26e8"},
+    {file = "multidict-6.0.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f285e862d2f153a70586579c15c44656f888806ed0e5b56b64489afe4a2dbfba"},
+    {file = "multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e"},
+    {file = "multidict-6.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd"},
+    {file = "multidict-6.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7be7047bd08accdb7487737631d25735c9a04327911de89ff1b26b81745bd4e3"},
+    {file = "multidict-6.0.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de170c7b4fe6859beb8926e84f7d7d6c693dfe8e27372ce3b76f01c46e489fcf"},
+    {file = "multidict-6.0.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04bde7a7b3de05732a4eb39c94574db1ec99abb56162d6c520ad26f83267de29"},
+    {file = "multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85f67aed7bb647f93e7520633d8f51d3cbc6ab96957c71272b286b2f30dc70ed"},
+    {file = "multidict-6.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:425bf820055005bfc8aa9a0b99ccb52cc2f4070153e34b701acc98d201693733"},
+    {file = "multidict-6.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d3eb1ceec286eba8220c26f3b0096cf189aea7057b6e7b7a2e60ed36b373b77f"},
+    {file = "multidict-6.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7901c05ead4b3fb75113fb1dd33eb1253c6d3ee37ce93305acd9d38e0b5f21a4"},
+    {file = "multidict-6.0.5-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:e0e79d91e71b9867c73323a3444724d496c037e578a0e1755ae159ba14f4f3d1"},
+    {file = "multidict-6.0.5-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:29bfeb0dff5cb5fdab2023a7a9947b3b4af63e9c47cae2a10ad58394b517fddc"},
+    {file = "multidict-6.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e030047e85cbcedbfc073f71836d62dd5dadfbe7531cae27789ff66bc551bd5e"},
+    {file = "multidict-6.0.5-cp311-cp311-win32.whl", hash = "sha256:2f4848aa3baa109e6ab81fe2006c77ed4d3cd1e0ac2c1fbddb7b1277c168788c"},
+    {file = "multidict-6.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:2faa5ae9376faba05f630d7e5e6be05be22913782b927b19d12b8145968a85ea"},
+    {file = "multidict-6.0.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:51d035609b86722963404f711db441cf7134f1889107fb171a970c9701f92e1e"},
+    {file = "multidict-6.0.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cbebcd5bcaf1eaf302617c114aa67569dd3f090dd0ce8ba9e35e9985b41ac35b"},
+    {file = "multidict-6.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2ffc42c922dbfddb4a4c3b438eb056828719f07608af27d163191cb3e3aa6cc5"},
+    {file = "multidict-6.0.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ceb3b7e6a0135e092de86110c5a74e46bda4bd4fbfeeb3a3bcec79c0f861e450"},
+    {file = "multidict-6.0.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79660376075cfd4b2c80f295528aa6beb2058fd289f4c9252f986751a4cd0496"},
+    {file = "multidict-6.0.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e4428b29611e989719874670fd152b6625500ad6c686d464e99f5aaeeaca175a"},
+    {file = "multidict-6.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d84a5c3a5f7ce6db1f999fb9438f686bc2e09d38143f2d93d8406ed2dd6b9226"},
+    {file = "multidict-6.0.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76c0de87358b192de7ea9649beb392f107dcad9ad27276324c24c91774ca5271"},
+    {file = "multidict-6.0.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:79a6d2ba910adb2cbafc95dad936f8b9386e77c84c35bc0add315b856d7c3abb"},
+    {file = "multidict-6.0.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:92d16a3e275e38293623ebf639c471d3e03bb20b8ebb845237e0d3664914caef"},
+    {file = "multidict-6.0.5-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:fb616be3538599e797a2017cccca78e354c767165e8858ab5116813146041a24"},
+    {file = "multidict-6.0.5-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:14c2976aa9038c2629efa2c148022ed5eb4cb939e15ec7aace7ca932f48f9ba6"},
+    {file = "multidict-6.0.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:435a0984199d81ca178b9ae2c26ec3d49692d20ee29bc4c11a2a8d4514c67eda"},
+    {file = "multidict-6.0.5-cp312-cp312-win32.whl", hash = "sha256:9fe7b0653ba3d9d65cbe7698cca585bf0f8c83dbbcc710db9c90f478e175f2d5"},
+    {file = "multidict-6.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:01265f5e40f5a17f8241d52656ed27192be03bfa8764d88e8220141d1e4b3556"},
+    {file = "multidict-6.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:19fe01cea168585ba0f678cad6f58133db2aa14eccaf22f88e4a6dccadfad8b3"},
+    {file = "multidict-6.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bf7a982604375a8d49b6cc1b781c1747f243d91b81035a9b43a2126c04766f5"},
+    {file = "multidict-6.0.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:107c0cdefe028703fb5dafe640a409cb146d44a6ae201e55b35a4af8e95457dd"},
+    {file = "multidict-6.0.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:403c0911cd5d5791605808b942c88a8155c2592e05332d2bf78f18697a5fa15e"},
+    {file = "multidict-6.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aeaf541ddbad8311a87dd695ed9642401131ea39ad7bc8cf3ef3967fd093b626"},
+    {file = "multidict-6.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4972624066095e52b569e02b5ca97dbd7a7ddd4294bf4e7247d52635630dd83"},
+    {file = "multidict-6.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d946b0a9eb8aaa590df1fe082cee553ceab173e6cb5b03239716338629c50c7a"},
+    {file = "multidict-6.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b55358304d7a73d7bdf5de62494aaf70bd33015831ffd98bc498b433dfe5b10c"},
+    {file = "multidict-6.0.5-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:a3145cb08d8625b2d3fee1b2d596a8766352979c9bffe5d7833e0503d0f0b5e5"},
+    {file = "multidict-6.0.5-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:d65f25da8e248202bd47445cec78e0025c0fe7582b23ec69c3b27a640dd7a8e3"},
+    {file = "multidict-6.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c9bf56195c6bbd293340ea82eafd0071cb3d450c703d2c93afb89f93b8386ccc"},
+    {file = "multidict-6.0.5-cp37-cp37m-win32.whl", hash = "sha256:69db76c09796b313331bb7048229e3bee7928eb62bab5e071e9f7fcc4879caee"},
+    {file = "multidict-6.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:fce28b3c8a81b6b36dfac9feb1de115bab619b3c13905b419ec71d03a3fc1423"},
+    {file = "multidict-6.0.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:76f067f5121dcecf0d63a67f29080b26c43c71a98b10c701b0677e4a065fbd54"},
+    {file = "multidict-6.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b82cc8ace10ab5bd93235dfaab2021c70637005e1ac787031f4d1da63d493c1d"},
+    {file = "multidict-6.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5cb241881eefd96b46f89b1a056187ea8e9ba14ab88ba632e68d7a2ecb7aadf7"},
+    {file = "multidict-6.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8e94e6912639a02ce173341ff62cc1201232ab86b8a8fcc05572741a5dc7d93"},
+    {file = "multidict-6.0.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09a892e4a9fb47331da06948690ae38eaa2426de97b4ccbfafbdcbe5c8f37ff8"},
+    {file = "multidict-6.0.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:55205d03e8a598cfc688c71ca8ea5f66447164efff8869517f175ea632c7cb7b"},
+    {file = "multidict-6.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37b15024f864916b4951adb95d3a80c9431299080341ab9544ed148091b53f50"},
+    {file = "multidict-6.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2a1dee728b52b33eebff5072817176c172050d44d67befd681609b4746e1c2e"},
+    {file = "multidict-6.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:edd08e6f2f1a390bf137080507e44ccc086353c8e98c657e666c017718561b89"},
+    {file = "multidict-6.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:60d698e8179a42ec85172d12f50b1668254628425a6bd611aba022257cac1386"},
+    {file = "multidict-6.0.5-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3d25f19500588cbc47dc19081d78131c32637c25804df8414463ec908631e453"},
+    {file = "multidict-6.0.5-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:4cc0ef8b962ac7a5e62b9e826bd0cd5040e7d401bc45a6835910ed699037a461"},
+    {file = "multidict-6.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:eca2e9d0cc5a889850e9bbd68e98314ada174ff6ccd1129500103df7a94a7a44"},
+    {file = "multidict-6.0.5-cp38-cp38-win32.whl", hash = "sha256:4a6a4f196f08c58c59e0b8ef8ec441d12aee4125a7d4f4fef000ccb22f8d7241"},
+    {file = "multidict-6.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:0275e35209c27a3f7951e1ce7aaf93ce0d163b28948444bec61dd7badc6d3f8c"},
+    {file = "multidict-6.0.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e7be68734bd8c9a513f2b0cfd508802d6609da068f40dc57d4e3494cefc92929"},
+    {file = "multidict-6.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1d9ea7a7e779d7a3561aade7d596649fbecfa5c08a7674b11b423783217933f9"},
+    {file = "multidict-6.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ea1456df2a27c73ce51120fa2f519f1bea2f4a03a917f4a43c8707cf4cbbae1a"},
+    {file = "multidict-6.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf590b134eb70629e350691ecca88eac3e3b8b3c86992042fb82e3cb1830d5e1"},
+    {file = "multidict-6.0.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5c0631926c4f58e9a5ccce555ad7747d9a9f8b10619621f22f9635f069f6233e"},
+    {file = "multidict-6.0.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dce1c6912ab9ff5f179eaf6efe7365c1f425ed690b03341911bf4939ef2f3046"},
+    {file = "multidict-6.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0868d64af83169e4d4152ec612637a543f7a336e4a307b119e98042e852ad9c"},
+    {file = "multidict-6.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:141b43360bfd3bdd75f15ed811850763555a251e38b2405967f8e25fb43f7d40"},
+    {file = "multidict-6.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7df704ca8cf4a073334e0427ae2345323613e4df18cc224f647f251e5e75a527"},
+    {file = "multidict-6.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6214c5a5571802c33f80e6c84713b2c79e024995b9c5897f794b43e714daeec9"},
+    {file = "multidict-6.0.5-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:cd6c8fca38178e12c00418de737aef1261576bd1b6e8c6134d3e729a4e858b38"},
+    {file = "multidict-6.0.5-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:e02021f87a5b6932fa6ce916ca004c4d441509d33bbdbeca70d05dff5e9d2479"},
+    {file = "multidict-6.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ebd8d160f91a764652d3e51ce0d2956b38efe37c9231cd82cfc0bed2e40b581c"},
+    {file = "multidict-6.0.5-cp39-cp39-win32.whl", hash = "sha256:04da1bb8c8dbadf2a18a452639771951c662c5ad03aefe4884775454be322c9b"},
+    {file = "multidict-6.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:d6f6d4f185481c9669b9447bf9d9cf3b95a0e9df9d169bbc17e363b7d5487755"},
+    {file = "multidict-6.0.5-py3-none-any.whl", hash = "sha256:0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7"},
+    {file = "multidict-6.0.5.tar.gz", hash = "sha256:f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da"},
+]
+
+[[package]]
+name = "mypy"
+version = "1.11.0"
+description = "Optional static typing for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a3824187c99b893f90c845bab405a585d1ced4ff55421fdf5c84cb7710995229"},
+    {file = "mypy-1.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:96f8dbc2c85046c81bcddc246232d500ad729cb720da4e20fce3b542cab91287"},
+    {file = "mypy-1.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a5d8d8dd8613a3e2be3eae829ee891b6b2de6302f24766ff06cb2875f5be9c6"},
+    {file = "mypy-1.11.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:72596a79bbfb195fd41405cffa18210af3811beb91ff946dbcb7368240eed6be"},
+    {file = "mypy-1.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:35ce88b8ed3a759634cb4eb646d002c4cef0a38f20565ee82b5023558eb90c00"},
+    {file = "mypy-1.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:98790025861cb2c3db8c2f5ad10fc8c336ed2a55f4daf1b8b3f877826b6ff2eb"},
+    {file = "mypy-1.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:25bcfa75b9b5a5f8d67147a54ea97ed63a653995a82798221cca2a315c0238c1"},
+    {file = "mypy-1.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bea2a0e71c2a375c9fa0ede3d98324214d67b3cbbfcbd55ac8f750f85a414e3"},
+    {file = "mypy-1.11.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2b3d36baac48e40e3064d2901f2fbd2a2d6880ec6ce6358825c85031d7c0d4d"},
+    {file = "mypy-1.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:d8e2e43977f0e09f149ea69fd0556623919f816764e26d74da0c8a7b48f3e18a"},
+    {file = "mypy-1.11.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1d44c1e44a8be986b54b09f15f2c1a66368eb43861b4e82573026e04c48a9e20"},
+    {file = "mypy-1.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cea3d0fb69637944dd321f41bc896e11d0fb0b0aa531d887a6da70f6e7473aba"},
+    {file = "mypy-1.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a83ec98ae12d51c252be61521aa5731f5512231d0b738b4cb2498344f0b840cd"},
+    {file = "mypy-1.11.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c7b73a856522417beb78e0fb6d33ef89474e7a622db2653bc1285af36e2e3e3d"},
+    {file = "mypy-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:f2268d9fcd9686b61ab64f077be7ffbc6fbcdfb4103e5dd0cc5eaab53a8886c2"},
+    {file = "mypy-1.11.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:940bfff7283c267ae6522ef926a7887305945f716a7704d3344d6d07f02df850"},
+    {file = "mypy-1.11.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:14f9294528b5f5cf96c721f231c9f5b2733164e02c1c018ed1a0eff8a18005ac"},
+    {file = "mypy-1.11.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7b54c27783991399046837df5c7c9d325d921394757d09dbcbf96aee4649fe9"},
+    {file = "mypy-1.11.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:65f190a6349dec29c8d1a1cd4aa71284177aee5949e0502e6379b42873eddbe7"},
+    {file = "mypy-1.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:dbe286303241fea8c2ea5466f6e0e6a046a135a7e7609167b07fd4e7baf151bf"},
+    {file = "mypy-1.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:104e9c1620c2675420abd1f6c44bab7dd33cc85aea751c985006e83dcd001095"},
+    {file = "mypy-1.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f006e955718ecd8d159cee9932b64fba8f86ee6f7728ca3ac66c3a54b0062abe"},
+    {file = "mypy-1.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:becc9111ca572b04e7e77131bc708480cc88a911adf3d0239f974c034b78085c"},
+    {file = "mypy-1.11.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6801319fe76c3f3a3833f2b5af7bd2c17bb93c00026a2a1b924e6762f5b19e13"},
+    {file = "mypy-1.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:c1a184c64521dc549324ec6ef7cbaa6b351912be9cb5edb803c2808a0d7e85ac"},
+    {file = "mypy-1.11.0-py3-none-any.whl", hash = "sha256:56913ec8c7638b0091ef4da6fcc9136896914a9d60d54670a75880c3e5b99ace"},
+    {file = "mypy-1.11.0.tar.gz", hash = "sha256:93743608c7348772fdc717af4aeee1997293a1ad04bc0ea6efa15bf65385c538"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -869,6 +1070,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+
+[[package]]
+name = "py-buzz"
+version = "4.1.0"
+description = "\"That's not flying, it's falling with style\": Exceptions with extras"
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "py_buzz-4.1.0-py3-none-any.whl", hash = "sha256:77dc0dc9c9923b6f8079dc2e2c3b4fbebd2308acaca1500f8eda2711cd308f97"},
+    {file = "py_buzz-4.1.0.tar.gz", hash = "sha256:ac11dba4922b2af114126044597d2fcd15e8c6a74368bed91f3c6732c8f09812"},
 ]
 
 [[package]]
@@ -1012,7 +1225,7 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 name = "pydantic-settings"
 version = "2.3.4"
 description = "Settings management using Pydantic"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -1304,82 +1517,91 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.52"
+version = "2.0.31"
 description = "Database Abstraction Library"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.7"
 files = [
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:f68016f9a5713684c1507cc37133c28035f29925c75c0df2f9d0f7571e23720a"},
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24bb0f81fbbb13d737b7f76d1821ec0b117ce8cbb8ee5e8641ad2de41aa916d3"},
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e93983cc0d2edae253b3f2141b0a3fb07e41c76cd79c2ad743fc27eb79c3f6db"},
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:84e10772cfc333eb08d0b7ef808cd76e4a9a30a725fb62a0495877a57ee41d81"},
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:427988398d2902de042093d17f2b9619a5ebc605bf6372f7d70e29bde6736842"},
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-win32.whl", hash = "sha256:1296f2cdd6db09b98ceb3c93025f0da4835303b8ac46c15c2136e27ee4d18d94"},
-    {file = "SQLAlchemy-1.4.52-cp310-cp310-win_amd64.whl", hash = "sha256:80e7f697bccc56ac6eac9e2df5c98b47de57e7006d2e46e1a3c17c546254f6ef"},
-    {file = "SQLAlchemy-1.4.52-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2f251af4c75a675ea42766880ff430ac33291c8d0057acca79710f9e5a77383d"},
-    {file = "SQLAlchemy-1.4.52-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb8f9e4c4718f111d7b530c4e6fb4d28f9f110eb82e7961412955b3875b66de0"},
-    {file = "SQLAlchemy-1.4.52-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afb1672b57f58c0318ad2cff80b384e816735ffc7e848d8aa51e0b0fc2f4b7bb"},
-    {file = "SQLAlchemy-1.4.52-cp311-cp311-win32.whl", hash = "sha256:6e41cb5cda641f3754568d2ed8962f772a7f2b59403b95c60c89f3e0bd25f15e"},
-    {file = "SQLAlchemy-1.4.52-cp311-cp311-win_amd64.whl", hash = "sha256:5bed4f8c3b69779de9d99eb03fd9ab67a850d74ab0243d1be9d4080e77b6af12"},
-    {file = "SQLAlchemy-1.4.52-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:49e3772eb3380ac88d35495843daf3c03f094b713e66c7d017e322144a5c6b7c"},
-    {file = "SQLAlchemy-1.4.52-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:618827c1a1c243d2540314c6e100aee7af09a709bd005bae971686fab6723554"},
-    {file = "SQLAlchemy-1.4.52-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de9acf369aaadb71a725b7e83a5ef40ca3de1cf4cdc93fa847df6b12d3cd924b"},
-    {file = "SQLAlchemy-1.4.52-cp312-cp312-win32.whl", hash = "sha256:763bd97c4ebc74136ecf3526b34808c58945023a59927b416acebcd68d1fc126"},
-    {file = "SQLAlchemy-1.4.52-cp312-cp312-win_amd64.whl", hash = "sha256:f12aaf94f4d9679ca475975578739e12cc5b461172e04d66f7a3c39dd14ffc64"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:853fcfd1f54224ea7aabcf34b227d2b64a08cbac116ecf376907968b29b8e763"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f98dbb8fcc6d1c03ae8ec735d3c62110949a3b8bc6e215053aa27096857afb45"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e135fff2e84103bc15c07edd8569612ce317d64bdb391f49ce57124a73f45c5"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5b5de6af8852500d01398f5047d62ca3431d1e29a331d0b56c3e14cb03f8094c"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3491c85df263a5c2157c594f54a1a9c72265b75d3777e61ee13c556d9e43ffc9"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-win32.whl", hash = "sha256:427c282dd0deba1f07bcbf499cbcc9fe9a626743f5d4989bfdfd3ed3513003dd"},
-    {file = "SQLAlchemy-1.4.52-cp36-cp36m-win_amd64.whl", hash = "sha256:ca5ce82b11731492204cff8845c5e8ca1a4bd1ade85e3b8fcf86e7601bfc6a39"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:29d4247313abb2015f8979137fe65f4eaceead5247d39603cc4b4a610936cd2b"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a752bff4796bf22803d052d4841ebc3c55c26fb65551f2c96e90ac7c62be763a"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7ea11727feb2861deaa293c7971a4df57ef1c90e42cb53f0da40c3468388000"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d913f8953e098ca931ad7f58797f91deed26b435ec3756478b75c608aa80d139"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a251146b921725547ea1735b060a11e1be705017b568c9f8067ca61e6ef85f20"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-win32.whl", hash = "sha256:1f8e1c6a6b7f8e9407ad9afc0ea41c1f65225ce505b79bc0342159de9c890782"},
-    {file = "SQLAlchemy-1.4.52-cp37-cp37m-win_amd64.whl", hash = "sha256:346ed50cb2c30f5d7a03d888e25744154ceac6f0e6e1ab3bc7b5b77138d37710"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:4dae6001457d4497736e3bc422165f107ecdd70b0d651fab7f731276e8b9e12d"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5d2e08d79f5bf250afb4a61426b41026e448da446b55e4770c2afdc1e200fce"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bbce5dd7c7735e01d24f5a60177f3e589078f83c8a29e124a6521b76d825b85"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bdb7b4d889631a3b2a81a3347c4c3f031812eb4adeaa3ee4e6b0d028ad1852b5"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c294ae4e6bbd060dd79e2bd5bba8b6274d08ffd65b58d106394cb6abbf35cf45"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-win32.whl", hash = "sha256:bcdfb4b47fe04967669874fb1ce782a006756fdbebe7263f6a000e1db969120e"},
-    {file = "SQLAlchemy-1.4.52-cp38-cp38-win_amd64.whl", hash = "sha256:7d0dbc56cb6af5088f3658982d3d8c1d6a82691f31f7b0da682c7b98fa914e91"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:a551d5f3dc63f096ed41775ceec72fdf91462bb95abdc179010dc95a93957800"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ab773f9ad848118df7a9bbabca53e3f1002387cdbb6ee81693db808b82aaab0"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2de46f5d5396d5331127cfa71f837cca945f9a2b04f7cb5a01949cf676db7d1"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7027be7930a90d18a386b25ee8af30514c61f3852c7268899f23fdfbd3107181"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99224d621affbb3c1a4f72b631f8393045f4ce647dd3262f12fe3576918f8bf3"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-win32.whl", hash = "sha256:c124912fd4e1bb9d1e7dc193ed482a9f812769cb1e69363ab68e01801e859821"},
-    {file = "SQLAlchemy-1.4.52-cp39-cp39-win_amd64.whl", hash = "sha256:2c286fab42e49db23c46ab02479f328b8bdb837d3e281cae546cc4085c83b680"},
-    {file = "SQLAlchemy-1.4.52.tar.gz", hash = "sha256:80e63bbdc5217dad3485059bdf6f65a7d43f33c8bde619df5c220edf03d87296"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f2a213c1b699d3f5768a7272de720387ae0122f1becf0901ed6eaa1abd1baf6c"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9fea3d0884e82d1e33226935dac990b967bef21315cbcc894605db3441347443"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3ad7f221d8a69d32d197e5968d798217a4feebe30144986af71ada8c548e9fa"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f2bee229715b6366f86a95d497c347c22ddffa2c7c96143b59a2aa5cc9eebbc"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cd5b94d4819c0c89280b7c6109c7b788a576084bf0a480ae17c227b0bc41e109"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:750900a471d39a7eeba57580b11983030517a1f512c2cb287d5ad0fcf3aebd58"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-win32.whl", hash = "sha256:7bd112be780928c7f493c1a192cd8c5fc2a2a7b52b790bc5a84203fb4381c6be"},
+    {file = "SQLAlchemy-2.0.31-cp310-cp310-win_amd64.whl", hash = "sha256:5a48ac4d359f058474fadc2115f78a5cdac9988d4f99eae44917f36aa1476327"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f68470edd70c3ac3b6cd5c2a22a8daf18415203ca1b036aaeb9b0fb6f54e8298"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e2c38c2a4c5c634fe6c3c58a789712719fa1bf9b9d6ff5ebfce9a9e5b89c1ca"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd15026f77420eb2b324dcb93551ad9c5f22fab2c150c286ef1dc1160f110203"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2196208432deebdfe3b22185d46b08f00ac9d7b01284e168c212919891289396"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:352b2770097f41bff6029b280c0e03b217c2dcaddc40726f8f53ed58d8a85da4"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56d51ae825d20d604583f82c9527d285e9e6d14f9a5516463d9705dab20c3740"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-win32.whl", hash = "sha256:6e2622844551945db81c26a02f27d94145b561f9d4b0c39ce7bfd2fda5776dac"},
+    {file = "SQLAlchemy-2.0.31-cp311-cp311-win_amd64.whl", hash = "sha256:ccaf1b0c90435b6e430f5dd30a5aede4764942a695552eb3a4ab74ed63c5b8d3"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3b74570d99126992d4b0f91fb87c586a574a5872651185de8297c6f90055ae42"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f77c4f042ad493cb8595e2f503c7a4fe44cd7bd59c7582fd6d78d7e7b8ec52c"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd1591329333daf94467e699e11015d9c944f44c94d2091f4ac493ced0119449"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74afabeeff415e35525bf7a4ecdab015f00e06456166a2eba7590e49f8db940e"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b9c01990d9015df2c6f818aa8f4297d42ee71c9502026bb074e713d496e26b67"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:66f63278db425838b3c2b1c596654b31939427016ba030e951b292e32b99553e"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-win32.whl", hash = "sha256:0b0f658414ee4e4b8cbcd4a9bb0fd743c5eeb81fc858ca517217a8013d282c96"},
+    {file = "SQLAlchemy-2.0.31-cp312-cp312-win_amd64.whl", hash = "sha256:fa4b1af3e619b5b0b435e333f3967612db06351217c58bfb50cee5f003db2a5a"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f43e93057cf52a227eda401251c72b6fbe4756f35fa6bfebb5d73b86881e59b0"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d337bf94052856d1b330d5fcad44582a30c532a2463776e1651bd3294ee7e58b"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c06fb43a51ccdff3b4006aafee9fcf15f63f23c580675f7734245ceb6b6a9e05"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:b6e22630e89f0e8c12332b2b4c282cb01cf4da0d26795b7eae16702a608e7ca1"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:79a40771363c5e9f3a77f0e28b3302801db08040928146e6808b5b7a40749c88"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-win32.whl", hash = "sha256:501ff052229cb79dd4c49c402f6cb03b5a40ae4771efc8bb2bfac9f6c3d3508f"},
+    {file = "SQLAlchemy-2.0.31-cp37-cp37m-win_amd64.whl", hash = "sha256:597fec37c382a5442ffd471f66ce12d07d91b281fd474289356b1a0041bdf31d"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:dc6d69f8829712a4fd799d2ac8d79bdeff651c2301b081fd5d3fe697bd5b4ab9"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:23b9fbb2f5dd9e630db70fbe47d963c7779e9c81830869bd7d137c2dc1ad05fb"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a21c97efcbb9f255d5c12a96ae14da873233597dfd00a3a0c4ce5b3e5e79704"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26a6a9837589c42b16693cf7bf836f5d42218f44d198f9343dd71d3164ceeeac"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:dc251477eae03c20fae8db9c1c23ea2ebc47331bcd73927cdcaecd02af98d3c3"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:2fd17e3bb8058359fa61248c52c7b09a97cf3c820e54207a50af529876451808"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-win32.whl", hash = "sha256:c76c81c52e1e08f12f4b6a07af2b96b9b15ea67ccdd40ae17019f1c373faa227"},
+    {file = "SQLAlchemy-2.0.31-cp38-cp38-win_amd64.whl", hash = "sha256:4b600e9a212ed59355813becbcf282cfda5c93678e15c25a0ef896b354423238"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b6cf796d9fcc9b37011d3f9936189b3c8074a02a4ed0c0fbbc126772c31a6d4"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:78fe11dbe37d92667c2c6e74379f75746dc947ee505555a0197cfba9a6d4f1a4"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fc47dc6185a83c8100b37acda27658fe4dbd33b7d5e7324111f6521008ab4fe"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a41514c1a779e2aa9a19f67aaadeb5cbddf0b2b508843fcd7bafdf4c6864005"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:afb6dde6c11ea4525318e279cd93c8734b795ac8bb5dda0eedd9ebaca7fa23f1"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3f9faef422cfbb8fd53716cd14ba95e2ef655400235c3dfad1b5f467ba179c8c"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-win32.whl", hash = "sha256:fc6b14e8602f59c6ba893980bea96571dd0ed83d8ebb9c4479d9ed5425d562e9"},
+    {file = "SQLAlchemy-2.0.31-cp39-cp39-win_amd64.whl", hash = "sha256:3cb8a66b167b033ec72c3812ffc8441d4e9f5f78f5e31e54dcd4c90a4ca5bebc"},
+    {file = "SQLAlchemy-2.0.31-py3-none-any.whl", hash = "sha256:69f3e3c08867a8e4856e92d7afb618b95cdee18e0bc1647b77599722c9a28911"},
+    {file = "SQLAlchemy-2.0.31.tar.gz", hash = "sha256:b607489dd4a54de56984a0c7656247504bd5523d9d0ba799aef59d4add009484"},
 ]
 
 [package.dependencies]
-greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and platform_machine == \"aarch64\" or python_version >= \"3\" and platform_machine == \"ppc64le\" or python_version >= \"3\" and platform_machine == \"x86_64\" or python_version >= \"3\" and platform_machine == \"amd64\" or python_version >= \"3\" and platform_machine == \"AMD64\" or python_version >= \"3\" and platform_machine == \"win32\" or python_version >= \"3\" and platform_machine == \"WIN32\""}
+greenlet = {version = "!=0.4.17", markers = "python_version < \"3.13\" and platform_machine == \"aarch64\" or python_version < \"3.13\" and platform_machine == \"ppc64le\" or python_version < \"3.13\" and platform_machine == \"x86_64\" or python_version < \"3.13\" and platform_machine == \"amd64\" or python_version < \"3.13\" and platform_machine == \"AMD64\" or python_version < \"3.13\" and platform_machine == \"win32\" or python_version < \"3.13\" and platform_machine == \"WIN32\""}
+mypy = {version = ">=0.910", optional = true, markers = "extra == \"mypy\""}
+typing-extensions = ">=4.6.0"
 
 [package.extras]
 aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
+aioodbc = ["aioodbc", "greenlet (!=0.4.17)"]
 aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
-asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
-mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
 mssql = ["pyodbc"]
 mssql-pymssql = ["pymssql"]
 mssql-pyodbc = ["pyodbc"]
-mypy = ["mypy (>=0.910)", "sqlalchemy2-stubs"]
-mysql = ["mysqlclient (>=1.4.0)", "mysqlclient (>=1.4.0,<2)"]
+mypy = ["mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx_oracle (>=7)", "cx_oracle (>=7,<8)"]
+oracle = ["cx_oracle (>=8)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
-postgresql-pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
 postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
-pymysql = ["pymysql", "pymysql (<1)"]
+postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
+pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
@@ -1462,14 +1684,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.30.1"
+version = "0.30.3"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "uvicorn-0.30.1-py3-none-any.whl", hash = "sha256:cd17daa7f3b9d7a24de3617820e634d0933b69eed8e33a516071174427238c81"},
-    {file = "uvicorn-0.30.1.tar.gz", hash = "sha256:d46cd8e0fd80240baffbcd9ec1012a712938754afcf81bce56c024c1656aece8"},
+    {file = "uvicorn-0.30.3-py3-none-any.whl", hash = "sha256:94a3608da0e530cea8f69683aa4126364ac18e3826b6630d1a65f4638aade503"},
+    {file = "uvicorn-0.30.3.tar.gz", hash = "sha256:0d114d0831ff1adbf231d358cbf42f17333413042552a624ea6a9b4c33dcfd81"},
 ]
 
 [package.dependencies]
@@ -1701,7 +1923,111 @@ files = [
     {file = "websockets-12.0.tar.gz", hash = "sha256:81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b"},
 ]
 
+[[package]]
+name = "yarl"
+version = "1.9.4"
+description = "Yet another URL library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"},
+    {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a3a6ed1d525bfb91b3fc9b690c5a21bb52de28c018530ad85093cc488bee2dd2"},
+    {file = "yarl-1.9.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c38c9ddb6103ceae4e4498f9c08fac9b590c5c71b0370f98714768e22ac6fa66"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9e09c9d74f4566e905a0b8fa668c58109f7624db96a2171f21747abc7524234"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b8477c1ee4bd47c57d49621a062121c3023609f7a13b8a46953eb6c9716ca392"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5ff2c858f5f6a42c2a8e751100f237c5e869cbde669a724f2062d4c4ef93551"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:357495293086c5b6d34ca9616a43d329317feab7917518bc97a08f9e55648455"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54525ae423d7b7a8ee81ba189f131054defdb122cde31ff17477951464c1691c"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:801e9264d19643548651b9db361ce3287176671fb0117f96b5ac0ee1c3530d53"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e516dc8baf7b380e6c1c26792610230f37147bb754d6426462ab115a02944385"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:7d5aaac37d19b2904bb9dfe12cdb08c8443e7ba7d2852894ad448d4b8f442863"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:54beabb809ffcacbd9d28ac57b0db46e42a6e341a030293fb3185c409e626b8b"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bac8d525a8dbc2a1507ec731d2867025d11ceadcb4dd421423a5d42c56818541"},
+    {file = "yarl-1.9.4-cp310-cp310-win32.whl", hash = "sha256:7855426dfbddac81896b6e533ebefc0af2f132d4a47340cee6d22cac7190022d"},
+    {file = "yarl-1.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:848cd2a1df56ddbffeb375535fb62c9d1645dde33ca4d51341378b3f5954429b"},
+    {file = "yarl-1.9.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:35a2b9396879ce32754bd457d31a51ff0a9d426fd9e0e3c33394bf4b9036b099"},
+    {file = "yarl-1.9.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c7d56b293cc071e82532f70adcbd8b61909eec973ae9d2d1f9b233f3d943f2c"},
+    {file = "yarl-1.9.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d8a1c6c0be645c745a081c192e747c5de06e944a0d21245f4cf7c05e457c36e0"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b3c1ffe10069f655ea2d731808e76e0f452fc6c749bea04781daf18e6039525"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:549d19c84c55d11687ddbd47eeb348a89df9cb30e1993f1b128f4685cd0ebbf8"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7409f968456111140c1c95301cadf071bd30a81cbd7ab829169fb9e3d72eae9"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e23a6d84d9d1738dbc6e38167776107e63307dfc8ad108e580548d1f2c587f42"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8b889777de69897406c9fb0b76cdf2fd0f31267861ae7501d93003d55f54fbe"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4e9035df8d0880b2f1c7f5031f33f69e071dfe72ee9310cfc76f7b605958ceb9"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:c0ec0ed476f77db9fb29bca17f0a8fcc7bc97ad4c6c1d8959c507decb22e8572"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:ee04010f26d5102399bd17f8df8bc38dc7ccd7701dc77f4a68c5b8d733406958"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:49a180c2e0743d5d6e0b4d1a9e5f633c62eca3f8a86ba5dd3c471060e352ca98"},
+    {file = "yarl-1.9.4-cp311-cp311-win32.whl", hash = "sha256:81eb57278deb6098a5b62e88ad8281b2ba09f2f1147c4767522353eaa6260b31"},
+    {file = "yarl-1.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:d1d2532b340b692880261c15aee4dc94dd22ca5d61b9db9a8a361953d36410b1"},
+    {file = "yarl-1.9.4-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0d2454f0aef65ea81037759be5ca9947539667eecebca092733b2eb43c965a81"},
+    {file = "yarl-1.9.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:44d8ffbb9c06e5a7f529f38f53eda23e50d1ed33c6c869e01481d3fafa6b8142"},
+    {file = "yarl-1.9.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aaaea1e536f98754a6e5c56091baa1b6ce2f2700cc4a00b0d49eca8dea471074"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3777ce5536d17989c91696db1d459574e9a9bd37660ea7ee4d3344579bb6f129"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9fc5fc1eeb029757349ad26bbc5880557389a03fa6ada41703db5e068881e5f2"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea65804b5dc88dacd4a40279af0cdadcfe74b3e5b4c897aa0d81cf86927fee78"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa102d6d280a5455ad6a0f9e6d769989638718e938a6a0a2ff3f4a7ff8c62cc4"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09efe4615ada057ba2d30df871d2f668af661e971dfeedf0c159927d48bbeff0"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:6f5cb257bc2ec58f437da2b37a8cd48f666db96d47b8a3115c29f316313654ff"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:992f18e0ea248ee03b5a6e8b3b4738850ae7dbb172cc41c966462801cbf62cf7"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:0e9d124c191d5b881060a9e5060627694c3bdd1fe24c5eecc8d5d7d0eb6faabc"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3986b6f41ad22988e53d5778f91855dc0399b043fc8946d4f2e68af22ee9ff10"},
+    {file = "yarl-1.9.4-cp312-cp312-win32.whl", hash = "sha256:4b21516d181cd77ebd06ce160ef8cc2a5e9ad35fb1c5930882baff5ac865eee7"},
+    {file = "yarl-1.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984"},
+    {file = "yarl-1.9.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:63b20738b5aac74e239622d2fe30df4fca4942a86e31bf47a81a0e94c14df94f"},
+    {file = "yarl-1.9.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7d7f7de27b8944f1fee2c26a88b4dabc2409d2fea7a9ed3df79b67277644e17"},
+    {file = "yarl-1.9.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c74018551e31269d56fab81a728f683667e7c28c04e807ba08f8c9e3bba32f14"},
+    {file = "yarl-1.9.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca06675212f94e7a610e85ca36948bb8fc023e458dd6c63ef71abfd482481aa5"},
+    {file = "yarl-1.9.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aef935237d60a51a62b86249839b51345f47564208c6ee615ed2a40878dccdd"},
+    {file = "yarl-1.9.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2b134fd795e2322b7684155b7855cc99409d10b2e408056db2b93b51a52accc7"},
+    {file = "yarl-1.9.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d25039a474c4c72a5ad4b52495056f843a7ff07b632c1b92ea9043a3d9950f6e"},
+    {file = "yarl-1.9.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f7d6b36dd2e029b6bcb8a13cf19664c7b8e19ab3a58e0fefbb5b8461447ed5ec"},
+    {file = "yarl-1.9.4-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:957b4774373cf6f709359e5c8c4a0af9f6d7875db657adb0feaf8d6cb3c3964c"},
+    {file = "yarl-1.9.4-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:d7eeb6d22331e2fd42fce928a81c697c9ee2d51400bd1a28803965883e13cead"},
+    {file = "yarl-1.9.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:6a962e04b8f91f8c4e5917e518d17958e3bdee71fd1d8b88cdce74dd0ebbf434"},
+    {file = "yarl-1.9.4-cp37-cp37m-win32.whl", hash = "sha256:f3bc6af6e2b8f92eced34ef6a96ffb248e863af20ef4fde9448cc8c9b858b749"},
+    {file = "yarl-1.9.4-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4d7a90a92e528aadf4965d685c17dacff3df282db1121136c382dc0b6014d2"},
+    {file = "yarl-1.9.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ec61d826d80fc293ed46c9dd26995921e3a82146feacd952ef0757236fc137be"},
+    {file = "yarl-1.9.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8be9e837ea9113676e5754b43b940b50cce76d9ed7d2461df1af39a8ee674d9f"},
+    {file = "yarl-1.9.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bef596fdaa8f26e3d66af846bbe77057237cb6e8efff8cd7cc8dff9a62278bbf"},
+    {file = "yarl-1.9.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d47552b6e52c3319fede1b60b3de120fe83bde9b7bddad11a69fb0af7db32f1"},
+    {file = "yarl-1.9.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fc30f71689d7fc9168b92788abc977dc8cefa806909565fc2951d02f6b7d57"},
+    {file = "yarl-1.9.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4aa9741085f635934f3a2583e16fcf62ba835719a8b2b28fb2917bb0537c1dfa"},
+    {file = "yarl-1.9.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:206a55215e6d05dbc6c98ce598a59e6fbd0c493e2de4ea6cc2f4934d5a18d130"},
+    {file = "yarl-1.9.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07574b007ee20e5c375a8fe4a0789fad26db905f9813be0f9fef5a68080de559"},
+    {file = "yarl-1.9.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5a2e2433eb9344a163aced6a5f6c9222c0786e5a9e9cac2c89f0b28433f56e23"},
+    {file = "yarl-1.9.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6ad6d10ed9b67a382b45f29ea028f92d25bc0bc1daf6c5b801b90b5aa70fb9ec"},
+    {file = "yarl-1.9.4-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:6fe79f998a4052d79e1c30eeb7d6c1c1056ad33300f682465e1b4e9b5a188b78"},
+    {file = "yarl-1.9.4-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:a825ec844298c791fd28ed14ed1bffc56a98d15b8c58a20e0e08c1f5f2bea1be"},
+    {file = "yarl-1.9.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8619d6915b3b0b34420cf9b2bb6d81ef59d984cb0fde7544e9ece32b4b3043c3"},
+    {file = "yarl-1.9.4-cp38-cp38-win32.whl", hash = "sha256:686a0c2f85f83463272ddffd4deb5e591c98aac1897d65e92319f729c320eece"},
+    {file = "yarl-1.9.4-cp38-cp38-win_amd64.whl", hash = "sha256:a00862fb23195b6b8322f7d781b0dc1d82cb3bcac346d1e38689370cc1cc398b"},
+    {file = "yarl-1.9.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:604f31d97fa493083ea21bd9b92c419012531c4e17ea6da0f65cacdcf5d0bd27"},
+    {file = "yarl-1.9.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8a854227cf581330ffa2c4824d96e52ee621dd571078a252c25e3a3b3d94a1b1"},
+    {file = "yarl-1.9.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ba6f52cbc7809cd8d74604cce9c14868306ae4aa0282016b641c661f981a6e91"},
+    {file = "yarl-1.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6327976c7c2f4ee6816eff196e25385ccc02cb81427952414a64811037bbc8b"},
+    {file = "yarl-1.9.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8397a3817d7dcdd14bb266283cd1d6fc7264a48c186b986f32e86d86d35fbac5"},
+    {file = "yarl-1.9.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e0381b4ce23ff92f8170080c97678040fc5b08da85e9e292292aba67fdac6c34"},
+    {file = "yarl-1.9.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23d32a2594cb5d565d358a92e151315d1b2268bc10f4610d098f96b147370136"},
+    {file = "yarl-1.9.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ddb2a5c08a4eaaba605340fdee8fc08e406c56617566d9643ad8bf6852778fc7"},
+    {file = "yarl-1.9.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:26a1dc6285e03f3cc9e839a2da83bcbf31dcb0d004c72d0730e755b33466c30e"},
+    {file = "yarl-1.9.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:18580f672e44ce1238b82f7fb87d727c4a131f3a9d33a5e0e82b793362bf18b4"},
+    {file = "yarl-1.9.4-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:29e0f83f37610f173eb7e7b5562dd71467993495e568e708d99e9d1944f561ec"},
+    {file = "yarl-1.9.4-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:1f23e4fe1e8794f74b6027d7cf19dc25f8b63af1483d91d595d4a07eca1fb26c"},
+    {file = "yarl-1.9.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:db8e58b9d79200c76956cefd14d5c90af54416ff5353c5bfd7cbe58818e26ef0"},
+    {file = "yarl-1.9.4-cp39-cp39-win32.whl", hash = "sha256:c7224cab95645c7ab53791022ae77a4509472613e839dab722a72abe5a684575"},
+    {file = "yarl-1.9.4-cp39-cp39-win_amd64.whl", hash = "sha256:824d6c50492add5da9374875ce72db7a0733b29c2394890aef23d533106e2b15"},
+    {file = "yarl-1.9.4-py3-none-any.whl", hash = "sha256:928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad"},
+    {file = "yarl-1.9.4.tar.gz", hash = "sha256:566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf"},
+]
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "ab2735104a0c8b91bc8da31a7c088fe484419962bd45e0407f7a6237c46617dd"
+content-hash = "b763ae34e362f916903c148d58d10e4ee2f11a4c318453cebba71d0cfa8bf2d8"

--- a/lm-simulator/pyproject.toml
+++ b/lm-simulator/pyproject.toml
@@ -35,11 +35,11 @@ python-dotenv = "^1.0.1"
 [tool.pytest.ini_options]
 addopts = "-v --random-order --cov=lm_simulator --cov-report=term-missing --cov-fail-under=85"
 env = [
-    "DATABASE_HOST: postgres-test",
-    "DATABASE_USER: test-user",
-    "DATABASE_PSWD: test-pswd",
-    "DATABASE_NAME: test-db",
-    "DATABASE_PORT: 5433"
+    "TEST_DATABASE_HOST: test-db",
+    "TEST_DATABASE_USER: test-user",
+    "TEST_DATABASE_PSWD: test-pswd",
+    "TEST_DATABASE_NAME: test-db",
+    "TEST_DATABASE_PORT: 5432"
 ]
 
 [tool.black]

--- a/lm-simulator/pyproject.toml
+++ b/lm-simulator/pyproject.toml
@@ -9,10 +9,15 @@ packages = [{ include = "lm_simulator" }]
 [tool.poetry.dependencies]
 python = "^3.12"
 fastapi = "^0.111.0"
-SQLAlchemy = "^1.4.23"
+pydantic = "^2.8.2"
+pydantic-settings = "^2.3.4"
+SQLAlchemy = {extras = ["mypy"], version = "^2.0.22"}
 uvicorn = "^0.30.1"
 requests = "^2.27.1"
 psycopg2 = "2.9.5"
+yarl = "^1.9.2"
+asyncpg = "^0.28"
+py-buzz = "^4.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
@@ -26,12 +31,15 @@ isort = "^5.9.3"
 requests = "^2.26.0"
 Jinja2 = "^3.0.1"
 python-dotenv = "^1.0.1"
-pydantic-settings = "^2.3.4"
 
 [tool.pytest.ini_options]
 addopts = "-v --random-order --cov=lm_simulator --cov-report=term-missing --cov-fail-under=85"
 env = [
-    "DATABASE_URL = sqlite:///./sqlite-testing.db",
+    "DATABASE_HOST: postgres-test",
+    "DATABASE_USER: test-user",
+    "DATABASE_PSWD: test-pswd",
+    "DATABASE_NAME: test-db",
+    "DATABASE_PORT: 5433"
 ]
 
 [tool.black]

--- a/lm-simulator/tests/conftest.py
+++ b/lm-simulator/tests/conftest.py
@@ -3,8 +3,7 @@ from typing import List
 
 from httpx import AsyncClient
 from pytest import fixture
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from yarl import URL
 
 from lm_simulator.config import settings
@@ -62,9 +61,9 @@ async def engine():
 async def synth_session(engine):
     async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
     async with async_session_maker() as session:
-        transaction = await session.begin_nested()
+        await session.begin_nested()
         yield session
-        await transaction.rollback()
+        await session.rollback()
         await session.close()
 
 
@@ -79,7 +78,7 @@ async def backend_client(synth_session):
 
 
 @fixture
-async def insert_objects(synth_session):
+def insert_objects(synth_session):
     """
     Fixture to insert objects into the database.
     """
@@ -102,7 +101,7 @@ async def insert_objects(synth_session):
 
 
 @fixture
-async def read_objects(synth_session):
+def read_objects(synth_session):
     """
     Fixture to read objects from the database.
     """
@@ -117,7 +116,7 @@ async def read_objects(synth_session):
 
 
 @fixture
-async def read_object(synth_session):
+def read_object(synth_session):
     """
     Fixture to read a single object from the database.
     """
@@ -132,7 +131,7 @@ async def read_object(synth_session):
 
 
 @fixture
-async def delete_objects(synth_session):
+def delete_objects(synth_session):
     """
     Fixture to delete objects from the database.
     """
@@ -142,72 +141,6 @@ async def delete_objects(synth_session):
         await synth_session.flush()
 
     return _helper
-
-
-@fixture
-async def create_licenses(insert_objects):
-    licenses_to_add = [
-        {
-            "name": "test_license1",
-            "total": 1000,
-        },
-        {
-            "name": "test_license2",
-            "total": 2000,
-        },
-    ]
-
-    inserted_licenses = await insert_objects(licenses_to_add, License)
-    return inserted_licenses
-
-
-@fixture
-async def create_one_license(insert_objects):
-    license_to_add = [
-        {
-            "name": "test_license",
-            "total": 1000,
-        }
-    ]
-
-    inserted_license = await insert_objects(license_to_add, License)
-    return inserted_license
-
-
-@fixture
-async def create_one_license_in_use(insert_objects):
-    license_in_use_to_add = [
-        {
-            "quantity": 100,
-            "user_name": "user1",
-            "lead_host": "host1",
-            "license_name": "test_license",
-        }
-    ]
-
-    inserted_license_in_use = await insert_objects(license_in_use_to_add, LicenseInUse)
-    return inserted_license_in_use
-
-
-@fixture
-async def create_licenses_in_use(insert_objects, create_licenses):
-    licenses_in_use_to_add = [
-        {
-            "quantity": 100,
-            "user_name": "user1",
-            "lead_host": "host1",
-            "license_name": "test_license1",
-        },
-        {
-            "quantity": 200,
-            "user_name": "user2",
-            "lead_host": "host2",
-            "license_name": "test_license2",
-        },
-    ]
-
-    inserted_licenses_in_use = await insert_objects(licenses_in_use_to_add, LicenseInUse)
-    return inserted_licenses_in_use
 
 
 @fixture

--- a/lm-simulator/tests/conftest.py
+++ b/lm-simulator/tests/conftest.py
@@ -1,65 +1,248 @@
-import os
-import re
+import asyncio
+from typing import List
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest import fixture
-from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session
+from yarl import URL
 
 from lm_simulator.config import settings
-from lm_simulator.database import Base
-from lm_simulator.main import get_db, subapp
+from lm_simulator.database import Base, get_session
+from lm_simulator.main import subapp
+from lm_simulator.models import License, LicenseInUse
 from lm_simulator.schemas import LicenseCreate, LicenseInUseCreate
 
 
-@fixture(scope="session", autouse=True)
-def enforce_testing_database():
-    match = re.match(r"sqlite:///(.*-testing\.db)", settings.DATABASE_URL)
-    if not match:
-        raise Exception(f"URL for database is invalid for testing: {settings.DATABASE_URL}")
-    testing_db_file = match.group(1)
-    yield
-    os.remove(testing_db_file)
-
-
 @fixture(scope="session")
-def engine():
-    return create_engine(settings.DATABASE_URL, connect_args={"check_same_thread": False})
+def event_loop():
+    """
+    Create an instance of the default event loop for each test case.
+
+    This fixture is used to run each test in a different async loop. Running all
+    in the same loop causes errors with SQLAlchemy. See the following two issues:
+
+    1. https://github.com/tiangolo/fastapi/issues/5692
+    2. https://github.com/encode/starlette/issues/1315
+
+    [Reference](https://tonybaloney.github.io/posts/async-test-patterns-for-pytest-and-unittest.html)
+    """
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
 
 
-@fixture(scope="session")
-def tables(engine):
-    Base.metadata.create_all(bind=engine)
-    yield
+@fixture(autouse=True, scope="session")
+async def engine():
+    """
+    Provide a fixture to prepare the test database.
+    """
+    engine = create_async_engine(
+        str(
+            URL.build(
+                scheme="postgresql+asyncpg",
+                user=settings.TEST_DATABASE_USER,
+                password=settings.TEST_DATABASE_PSWD,
+                host=settings.TEST_DATABASE_HOST,
+                port=settings.TEST_DATABASE_PORT,
+                path=f"/{settings.TEST_DATABASE_NAME}",
+            )
+        )
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield engine
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
 
 
-@fixture
-def session(engine, tables):
-    connection = engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection, future=True)
-
-    yield session
-
-    session.close()
-    transaction.rollback()
-    connection.close()
-
-
-@fixture
-def client(session):
-    def override_get_db():
+@fixture(scope="function")
+async def synth_session(engine):
+    async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with async_session_maker() as session:
+        transaction = await session.begin_nested()
         yield session
+        await transaction.rollback()
+        await session.close()
 
-    subapp.dependency_overrides[get_db] = override_get_db
-    yield TestClient(subapp)
+
+@fixture
+async def backend_client(synth_session):
+    def override_get_session():
+        yield synth_session
+
+    subapp.dependency_overrides[get_session] = override_get_session
+    async with AsyncClient(app=subapp, base_url="http://test") as client:
+        yield client
+
+
+@fixture
+async def insert_objects(synth_session):
+    """
+    Fixture to insert objects into the database.
+    """
+
+    async def _helper(
+        objects: List[Base],
+        table: Base,
+    ):
+        db_objects = [table(**obj.model_dump()) for obj in objects]
+
+        for obj in db_objects:
+            synth_session.add(obj)
+
+        await synth_session.flush()
+
+        await asyncio.gather(synth_session.refresh(obj) for obj in db_objects if obj)
+        return db_objects
+
+    return _helper
+
+
+@fixture
+async def read_objects(synth_session):
+    """
+    Fixture to read objects from the database.
+    """
+
+    async def _helper(stmt):
+        fetched = (await synth_session.execute(stmt)).scalars().all()
+
+        await asyncio.gather(synth_session.refresh(obj) for obj in fetched if obj)
+        return fetched
+
+    return _helper
+
+
+@fixture
+async def read_object(synth_session):
+    """
+    Fixture to read a single object from the database.
+    """
+
+    async def _helper(stmt):
+        fetched = (await synth_session.execute(stmt)).scalar()
+
+        await synth_session.refresh(fetched)
+        return fetched
+
+    return _helper
+
+
+@fixture
+async def delete_objects(synth_session):
+    """
+    Fixture to delete objects from the database.
+    """
+
+    async def _helper(object):
+        await synth_session.delete(object)
+        await synth_session.flush()
+
+    return _helper
+
+
+@fixture
+async def create_licenses(insert_objects):
+    licenses_to_add = [
+        {
+            "name": "test_license1",
+            "total": 1000,
+        },
+        {
+            "name": "test_license2",
+            "total": 2000,
+        },
+    ]
+
+    inserted_licenses = await insert_objects(licenses_to_add, License)
+    return inserted_licenses
+
+
+@fixture
+async def create_one_license(insert_objects):
+    license_to_add = [
+        {
+            "name": "test_license",
+            "total": 1000,
+        }
+    ]
+
+    inserted_license = await insert_objects(license_to_add, License)
+    return inserted_license
+
+
+@fixture
+async def create_one_license_in_use(insert_objects):
+    license_in_use_to_add = [
+        {
+            "quantity": 100,
+            "user_name": "user1",
+            "lead_host": "host1",
+            "license_name": "test_license",
+        }
+    ]
+
+    inserted_license_in_use = await insert_objects(license_in_use_to_add, LicenseInUse)
+    return inserted_license_in_use
+
+
+@fixture
+async def create_licenses_in_use(insert_objects, create_licenses):
+    licenses_in_use_to_add = [
+        {
+            "quantity": 100,
+            "user_name": "user1",
+            "lead_host": "host1",
+            "license_name": "test_license1",
+        },
+        {
+            "quantity": 200,
+            "user_name": "user2",
+            "lead_host": "host2",
+            "license_name": "test_license2",
+        },
+    ]
+
+    inserted_licenses_in_use = await insert_objects(licenses_in_use_to_add, LicenseInUse)
+    return inserted_licenses_in_use
 
 
 @fixture
 def one_license():
-    return LicenseCreate(name="test_name", total=100)
+    return LicenseCreate(name="test_license", total=1000)
+
+
+@fixture
+def licenses():
+    return [
+        LicenseCreate(name="test_license1", total=1000),
+        LicenseCreate(name="test_license2", total=2000),
+    ]
 
 
 @fixture
 def one_license_in_use():
-    return LicenseInUseCreate(quantity=10, user_name="user1", lead_host="host1", license_name="test_name")
+    return LicenseInUseCreate(quantity=100, user_name="user1", lead_host="host1", license_name="test_license")
+
+
+@fixture
+def one_license_in_use__not_enough():
+    return LicenseInUseCreate(
+        quantity=1500, user_name="user1", lead_host="host1", license_name="test_license"
+    )
+
+
+@fixture
+def one_license_in_use__not_found():
+    return LicenseInUseCreate(quantity=100, user_name="user1", lead_host="host1", license_name="not_found")
+
+
+@fixture
+def licenses_in_use():
+    return [
+        LicenseInUseCreate(quantity=100, user_name="user1", lead_host="host1", license_name="test_license1"),
+        LicenseInUseCreate(quantity=200, user_name="user2", lead_host="host2", license_name="test_license2"),
+    ]

--- a/lm-simulator/tests/test_crud.py
+++ b/lm-simulator/tests/test_crud.py
@@ -163,12 +163,12 @@ async def test__remove_license_in_use__success(
     one_license, one_license_in_use, insert_objects, read_objects, synth_session
 ):
     await insert_objects([one_license], License)
-    await insert_objects([one_license_in_use], LicenseInUse)
+    inserted = await insert_objects([one_license_in_use], LicenseInUse)
 
     licenses_in_use_in_db = await read_objects(LicenseInUse)
     assert len(licenses_in_use_in_db) == 1
 
-    await remove_license_in_use(synth_session, licenses_in_use_in_db[0].id)
+    await remove_license_in_use(synth_session, inserted[0].id)
 
     licenses_in_use_in_db_after_delete = await read_objects(LicenseInUse)
     assert len(licenses_in_use_in_db_after_delete) == 0
@@ -182,7 +182,7 @@ async def test__remove_license_in_use__fail_with_not_found(
     await insert_objects([one_license_in_use], LicenseInUse)
 
     with pytest.raises(HTTPException) as exc_info:
-        await remove_license_in_use(synth_session, 2)
+        await remove_license_in_use(synth_session, 0)
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
     assert exc_info.value.detail == "License In Use not found"

--- a/lm-simulator/tests/test_crud.py
+++ b/lm-simulator/tests/test_crud.py
@@ -36,8 +36,8 @@ async def test__add_license__fail_with_duplicate(one_license, synth_session):
         await add_license(synth_session, one_license)
 
     assert exc_info.type == HTTPException
-    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert exc_info.value.detail == "Can't create License, check the input data"
+    assert exc_info.value.status_code == status.HTTP_409_CONFLICT
+    assert exc_info.value.detail == "License already exists"
 
 
 @mark.asyncio

--- a/lm-simulator/tests/test_crud.py
+++ b/lm-simulator/tests/test_crud.py
@@ -1,235 +1,222 @@
 import pytest
-from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException, status
+from pytest import mark
 
-from lm_simulator import crud
+from lm_simulator.crud import (
+    add_license,
+    add_license_in_use,
+    list_licenses,
+    list_licenses_in_use,
+    remove_license,
+    remove_license_in_use,
+)
 from lm_simulator.models import License, LicenseInUse
-from lm_simulator.schemas import LicenseInUseCreate, LicenseRow
+from lm_simulator.schemas import LicenseRow
 
 
-def test_create_license(one_license, session):
-    created_license = crud.create_license(session, one_license)
-    assert created_license.id
+@mark.asyncio
+async def test__add_license__success(one_license, read_objects, synth_session):
+    created_license = await add_license(synth_session, one_license)
+
     assert created_license.name == one_license.name
     assert created_license.total == one_license.total
 
-    licenses_in_db = session.execute(select(License)).scalars().all()
+    licenses_in_db = await read_objects(License)
+
     assert len(licenses_in_db) == 1
-    assert licenses_in_db[0].id == created_license.id
-    assert licenses_in_db[0].name == one_license.name
-    assert licenses_in_db[0].total == one_license.total
+
+    assert licenses_in_db[0].name == created_license.name
+    assert licenses_in_db[0].total == created_license.total
 
 
-# ignoring warning about double rollback
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_create_license_duplicate(one_license, session):
-    """Test that an exception is thrown if a duplicate license entry is created."""
-    crud.create_license(session, one_license)
-    with pytest.raises(IntegrityError):
-        crud.create_license(session, one_license)
+@mark.asyncio
+async def test__add_license__fail_with_duplicate(one_license, synth_session):
+    with pytest.raises(HTTPException) as exc_info:
+        await add_license(synth_session, one_license)
+
+    assert exc_info.type == HTTPException
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "Can't create License, check the input data"
 
 
-def test_get_licenses_empty(session):
-    licenses = crud.get_licenses(session)
+@mark.asyncio
+async def test__list_licenses__empty(synth_session):
+    licenses = await list_licenses(synth_session)
     assert len(licenses) == 0
 
 
-def test_get_licenses(session):
-    session.add(License(id=1, name="name1", total=10))
-    session.add(License(id=2, name="name2", total=10))
-    session.commit()
+@mark.asyncio
+async def test__list_licenses__success(licenses, insert_objects, synth_session):
+    await insert_objects(licenses, License)
 
-    licenses_response = crud.get_licenses(session)
-    assert len(licenses_response) == 2
-    assert licenses_response[0].id == 1
-    assert licenses_response[0].name == "name1"
-    assert licenses_response[0].total == 10
-    assert licenses_response[1].id == 2
-    assert licenses_response[1].name == "name2"
-    assert licenses_response[1].total == 10
+    licenses_in_db = await list_licenses(synth_session)
+
+    assert len(licenses_in_db) == 2
+
+    assert licenses_in_db[0].name == licenses.name
+    assert licenses_in_db[0].total == licenses.total
+
+    assert licenses_in_db[1].name == licenses.name
+    assert licenses_in_db[1].total == licenses.total
 
 
-def test_delete_license(session, one_license):
-    session.add(License(**one_license.dict()))
-    session.commit()
+@mark.asyncio
+async def test__remove_license__success(one_license, insert_objects, read_objects, synth_session):
+    await insert_objects([one_license], License)
 
-    licenses_in_db = session.execute(select(License)).scalars().all()
+    licenses_in_db = await read_objects(License)
     assert len(licenses_in_db) == 1
-    crud.delete_license(session, one_license.name)
-    licenses_in_db_after_delete = session.execute(select(License)).scalars().all()
+
+    await remove_license(synth_session, one_license.name)
+
+    licenses_in_db_after_delete = await read_objects(License)
     assert len(licenses_in_db_after_delete) == 0
 
 
-def test_delete_license_not_found(session, one_license):
-    session.add(License(**one_license.dict()))
-    session.commit()
+@mark.asyncio
+async def test__remove_license__fail_with_not_found(one_license, insert_objects, synth_session):
+    await insert_objects([one_license], License)
 
-    with pytest.raises(crud.LicenseNotFound):
-        crud.delete_license(
-            session,
-            "non-existing-license",
-        )
-    licenses_in_db = session.execute(select(License)).scalars().all()
+    with pytest.raises(HTTPException) as exc_info:
+        await remove_license(synth_session, "non-existing-license")
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == "License not found"
+
+
+@mark.asyncio
+async def test__add_license_in_use__success(
+    one_license, one_license_in_use, insert_objects, read_objects, synth_session
+):
+    await insert_objects([one_license], License)
+
+    await add_license_in_use(synth_session, one_license_in_use)
+
+    licenses_in_use_in_db = await read_objects(LicenseInUse)
+    assert len(licenses_in_use_in_db) == 1
+
+    assert licenses_in_use_in_db[0].id
+    assert licenses_in_use_in_db[0].quantity == one_license_in_use.quantity
+    assert licenses_in_use_in_db[0].user_name == one_license_in_use.user_name
+    assert licenses_in_use_in_db[0].lead_host == one_license_in_use.lead_host
+    assert licenses_in_use_in_db[0].license_name == one_license_in_use.license_name
+
+
+@mark.asyncio
+async def test__add_license_in_use__fail_with_not_enough_licenses(
+    one_license, one_license_in_use__not_enough, insert_objects, synth_session
+):
+    await insert_objects([one_license], License)
+    await insert_objects([one_license_in_use__not_enough], LicenseInUse)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await add_license_in_use(synth_session, one_license_in_use__not_enough)
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "Not enough licenses"
+
+
+@mark.asyncio
+async def test__add_license_in_use__fail_with_license_not_found(
+    one_license, one_license_in_use__not_found, insert_objects, synth_session
+):
+    await insert_objects([one_license], LicenseInUse)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await add_license_in_use(synth_session, one_license_in_use__not_found)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == "License not found"
+
+
+@mark.asyncio
+async def test__list_licenses_in_use__empty(synth_session):
+    licenses_in_use = await list_licenses_in_use(synth_session)
+    assert len(licenses_in_use) == 0
+
+
+@mark.asyncio
+async def test__list_licenses_in_use__success(licenses, licenses_in_use, insert_objects, synth_session):
+    await insert_objects(licenses, License)
+    await insert_objects(licenses_in_use, LicenseInUse)
+
+    licenses_in_use_in_db = await list_licenses_in_use(synth_session)
+
+    assert len(licenses_in_use_in_db) == 2
+
+    assert licenses_in_use_in_db[0].id == 1
+    assert licenses_in_use_in_db[0].quantity == licenses_in_use[0].quantity
+    assert licenses_in_use_in_db[0].user_name == licenses_in_use[0].user_name
+    assert licenses_in_use_in_db[0].lead_host == licenses_in_use[0].lead_host
+    assert licenses_in_use_in_db[0].license_name == licenses_in_use[0].license_name
+
+    assert licenses_in_use_in_db[1].id == 2
+    assert licenses_in_use_in_db[1].quantity == licenses_in_use[1].quantity
+    assert licenses_in_use_in_db[1].user_name == licenses_in_use[1].user_name
+    assert licenses_in_use_in_db[1].lead_host == licenses_in_use[1].lead_host
+    assert licenses_in_use_in_db[1].license_name == licenses_in_use[1].license_name
+
+
+@mark.asyncio
+async def test__remove_license_in_use__success(
+    one_license, one_license_in_use, insert_objects, read_objects, synth_session
+):
+    await insert_objects([one_license], License)
+    await insert_objects([one_license_in_use], LicenseInUse)
+
+    licenses_in_use_in_db = await read_objects(LicenseInUse)
+    assert len(licenses_in_use_in_db) == 1
+
+    await remove_license_in_use(synth_session, licenses_in_use_in_db[0].id)
+
+    licenses_in_use_in_db_after_delete = await read_objects(LicenseInUse)
+    assert len(licenses_in_use_in_db_after_delete) == 0
+
+
+@mark.asyncio
+async def test__remove_license_in_use__fail_with_not_found(
+    one_license, one_license_in_use, insert_objects, synth_session
+):
+    await insert_objects([one_license], License)
+    await insert_objects([one_license_in_use], LicenseInUse)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await remove_license_in_use(synth_session, 2)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == "License In Use not found"
+
+
+@mark.asyncio
+async def test__add_license_in_use__correctly_updates_license_in_use(
+    one_license, one_license_in_use, insert_objects, read_objects, synth_session
+):
+    await insert_objects([one_license], License)
+
+    licenses_in_db = await read_objects(License)
     assert len(licenses_in_db) == 1
+    assert LicenseRow.model_validate(licenses_in_db[0]).in_use == 0
+
+    await add_license_in_use(synth_session, one_license_in_use)
+
+    licenses_in_use_in_db = await read_objects(LicenseInUse)
+    assert len(licenses_in_use_in_db) == 1
+    assert LicenseRow.model_validate(licenses_in_db[0]).in_use == one_license_in_use.quantity
 
 
-def test_get_licenses_in_use(session, one_license, one_license_in_use):
-    session.add(License(**one_license.dict()))
-    session.add(LicenseInUse(**one_license_in_use.dict(), id=1))
-    session.commit()
+@mark.asyncio
+async def test__remove_license_in_use__correctly_updates_license_in_use(
+    one_license, one_license_in_use, insert_objects, read_objects, synth_session
+):
+    await insert_objects([one_license], License)
+    await insert_objects([one_license_in_use], LicenseInUse)
 
-    licenses_in_use = crud.get_licenses_in_use(session)
-    assert len(licenses_in_use) == 1
-    assert licenses_in_use[0].id == 1
-    assert licenses_in_use[0].quantity == one_license_in_use.quantity
-    assert licenses_in_use[0].user_name == one_license_in_use.user_name
-    assert licenses_in_use[0].lead_host == one_license_in_use.lead_host
-    assert licenses_in_use[0].license_name == one_license_in_use.license_name
+    licenses_in_db = await read_objects(License)
+    assert len(licenses_in_db) == 1
+    assert LicenseRow.model_validate(licenses_in_db[0]).in_use == one_license_in_use.quantity
 
+    remove_license_in_use(synth_session, 1)
 
-def test_get_licenses_in_use_empty(session):
-    licenses_in_use = crud.get_licenses_in_use(session)
-    assert len(licenses_in_use) == 0
-
-
-def test_get_licenses_in_use_from_name(session, one_license, one_license_in_use):
-    session.add(License(**one_license.dict()))
-    session.add(LicenseInUse(**one_license_in_use.dict(), id=1))
-    session.commit()
-
-    licenses_in_use = crud.get_licenses_in_use_from_name(session, one_license.name)
-    assert len(licenses_in_use) == 1
-    assert licenses_in_use[0].id == 1
-    assert licenses_in_use[0].quantity == one_license_in_use.quantity
-    assert licenses_in_use[0].user_name == one_license_in_use.user_name
-    assert licenses_in_use[0].lead_host == one_license_in_use.lead_host
-    assert licenses_in_use[0].license_name == one_license_in_use.license_name
-
-
-def test_get_licenses_in_use_from_name_empty(session):
-    licenses_in_use = crud.get_licenses_in_use_from_name(session, "name")
-    assert len(licenses_in_use) == 0
-
-
-def test_create_license_in_use(session, one_license_in_use):
-    session.add(License(id=1, name="test_name", total=10))
-    session.commit()
-
-    created_license_in_use = crud.create_license_in_use(session, one_license_in_use)
-    assert created_license_in_use.id
-    assert created_license_in_use.quantity == one_license_in_use.quantity
-    assert created_license_in_use.user_name == one_license_in_use.user_name
-    assert created_license_in_use.lead_host == one_license_in_use.lead_host
-    assert created_license_in_use.license_name == one_license_in_use.license_name
-
-    license_in_use_in_db = session.execute(select(LicenseInUse)).scalars().all()
-    assert len(license_in_use_in_db) == 1
-    assert license_in_use_in_db[0].id == created_license_in_use.id
-    assert license_in_use_in_db[0].quantity == one_license_in_use.quantity
-    assert license_in_use_in_db[0].user_name == one_license_in_use.user_name
-    assert license_in_use_in_db[0].lead_host == one_license_in_use.lead_host
-    assert license_in_use_in_db[0].license_name == one_license_in_use.license_name
-
-
-def test_create_license_in_use_correctly_updates_license_in_use(session):
-    session.add(License(id=1, name="test_name", total=30))
-    session.commit()
-
-    crud.create_license_in_use(
-        session,
-        LicenseInUseCreate(
-            quantity=10,
-            user_name="user1",
-            lead_host="host1",
-            license_name="test_name",
-        ),
-    )
-    crud.create_license_in_use(
-        session,
-        LicenseInUseCreate(
-            quantity=20,
-            user_name="user1",
-            lead_host="host1",
-            license_name="test_name",
-        ),
-    )
-    licenses_in_db = session.execute(select(License)).scalars().all()
-    assert LicenseRow.from_orm(licenses_in_db[0]).in_use == 30
-
-
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_create_license_in_use_duplicate(session, one_license_in_use):
-    """Test that an exception is thrown if a duplicate in use license entry is created."""
-    session.add(License(id=1, name="test_name", total=100))
-    session.commit()
-
-    crud.create_license_in_use(session, one_license_in_use)
-    with pytest.raises(IntegrityError):
-        crud.create_license_in_use(session, one_license_in_use)
-
-
-def test_create_license_in_use_not_available(session, one_license_in_use):
-    session.add(License(id=1, name="test_name", total=0))
-    session.commit()
-
-    with pytest.raises(crud.NotEnoughLicenses):
-        crud.create_license_in_use(session, one_license_in_use)
-
-
-def test_create_license_in_use_empty(session, one_license_in_use):
-    with pytest.raises(crud.LicenseNotFound):
-        crud.create_license_in_use(session, one_license_in_use)
-
-
-def test_delete_license_in_use(session, one_license, one_license_in_use):
-    session.add(License(**one_license.dict()))
-    session.add(LicenseInUse(**one_license_in_use.dict(), id=1))
-    session.commit()
-
-    license_in_use_in_db = session.execute(select(LicenseInUse)).scalars().all()
-    assert len(license_in_use_in_db) == 1
-
-    crud.delete_license_in_use(
-        session,
-        one_license_in_use.lead_host,
-        one_license_in_use.user_name,
-        one_license_in_use.quantity,
-        one_license_in_use.license_name,
-    )
-    license_in_use_in_db_after_delete = session.execute(select(LicenseInUse)).scalars().all()
-    assert len(license_in_use_in_db_after_delete) == 0
-
-
-def test_delete_license_in_use_not_found(session, one_license, one_license_in_use):
-    session.add(License(**one_license.dict()))
-    session.add(LicenseInUse(**one_license_in_use.dict(), id=1))
-    session.commit()
-
-    with pytest.raises(crud.LicenseNotFound):
-        crud.delete_license_in_use(
-            session,
-            "wrong_lead_host",
-            one_license_in_use.user_name,
-            one_license_in_use.quantity,
-            one_license_in_use.license_name,
-        )
-    license_in_use_in_db = session.execute(select(LicenseInUse)).scalars().all()
-    assert len(license_in_use_in_db) == 1
-
-
-def test_delete_license_in_use_correctly_updates_license_in_use(session, one_license_in_use):
-    session.add(License(id=1, name="test_name", total=30))
-    session.add(LicenseInUse(**one_license_in_use.dict(), id=1))
-    session.commit()
-    licenses_in_db = session.execute(select(License)).scalars().all()
-    assert LicenseRow.from_orm(licenses_in_db[0]).in_use == one_license_in_use.quantity
-    crud.delete_license_in_use(
-        session,
-        one_license_in_use.lead_host,
-        one_license_in_use.user_name,
-        one_license_in_use.quantity,
-        one_license_in_use.license_name,
-    )
-
-    licenses_in_db = session.execute(select(License)).scalars().all()
-    assert LicenseRow.from_orm(licenses_in_db[0]).in_use == 0
+    licenses_in_db_after_delete = await read_objects(License)
+    assert len(licenses_in_db_after_delete) == 1
+    assert LicenseRow.model_validate(licenses_in_db_after_delete[0]).in_use == 0

--- a/lm-simulator/tests/test_crud.py
+++ b/lm-simulator/tests/test_crud.py
@@ -33,6 +33,7 @@ async def test__add_license__success(one_license, read_objects, synth_session):
 async def test__add_license__fail_with_duplicate(one_license, synth_session):
     with pytest.raises(HTTPException) as exc_info:
         await add_license(synth_session, one_license)
+        await add_license(synth_session, one_license)
 
     assert exc_info.type == HTTPException
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
@@ -120,7 +121,7 @@ async def test__add_license_in_use__fail_with_not_enough_licenses(
 async def test__add_license_in_use__fail_with_license_not_found(
     one_license, one_license_in_use__not_found, insert_objects, synth_session
 ):
-    await insert_objects([one_license], LicenseInUse)
+    await insert_objects([one_license], License)
 
     with pytest.raises(HTTPException) as exc_info:
         await add_license_in_use(synth_session, one_license_in_use__not_found)

--- a/lm-simulator/tests/test_crud.py
+++ b/lm-simulator/tests/test_crud.py
@@ -54,11 +54,11 @@ async def test__list_licenses__success(licenses, insert_objects, synth_session):
 
     assert len(licenses_in_db) == 2
 
-    assert licenses_in_db[0].name == licenses.name
-    assert licenses_in_db[0].total == licenses.total
+    assert licenses_in_db[0].name == licenses[0].name
+    assert licenses_in_db[0].total == licenses[0].total
 
-    assert licenses_in_db[1].name == licenses.name
-    assert licenses_in_db[1].total == licenses.total
+    assert licenses_in_db[1].name == licenses[1].name
+    assert licenses_in_db[1].total == licenses[1].total
 
 
 @mark.asyncio
@@ -139,23 +139,23 @@ async def test__list_licenses_in_use__empty(synth_session):
 @mark.asyncio
 async def test__list_licenses_in_use__success(licenses, licenses_in_use, insert_objects, synth_session):
     await insert_objects(licenses, License)
-    await insert_objects(licenses_in_use, LicenseInUse)
+    inserted = await insert_objects(licenses_in_use, LicenseInUse)
 
     licenses_in_use_in_db = await list_licenses_in_use(synth_session)
 
     assert len(licenses_in_use_in_db) == 2
 
-    assert licenses_in_use_in_db[0].id == 1
-    assert licenses_in_use_in_db[0].quantity == licenses_in_use[0].quantity
-    assert licenses_in_use_in_db[0].user_name == licenses_in_use[0].user_name
-    assert licenses_in_use_in_db[0].lead_host == licenses_in_use[0].lead_host
-    assert licenses_in_use_in_db[0].license_name == licenses_in_use[0].license_name
+    assert licenses_in_use_in_db[0].id == inserted[0].id
+    assert licenses_in_use_in_db[0].quantity == inserted[0].quantity
+    assert licenses_in_use_in_db[0].user_name == inserted[0].user_name
+    assert licenses_in_use_in_db[0].lead_host == inserted[0].lead_host
+    assert licenses_in_use_in_db[0].license_name == inserted[0].license_name
 
-    assert licenses_in_use_in_db[1].id == 2
-    assert licenses_in_use_in_db[1].quantity == licenses_in_use[1].quantity
-    assert licenses_in_use_in_db[1].user_name == licenses_in_use[1].user_name
-    assert licenses_in_use_in_db[1].lead_host == licenses_in_use[1].lead_host
-    assert licenses_in_use_in_db[1].license_name == licenses_in_use[1].license_name
+    assert licenses_in_use_in_db[1].id == inserted[1].id
+    assert licenses_in_use_in_db[1].quantity == inserted[1].quantity
+    assert licenses_in_use_in_db[1].user_name == inserted[1].user_name
+    assert licenses_in_use_in_db[1].lead_host == inserted[1].lead_host
+    assert licenses_in_use_in_db[1].license_name == inserted[1].license_name
 
 
 @mark.asyncio
@@ -200,9 +200,9 @@ async def test__add_license_in_use__correctly_updates_license_in_use(
 
     await add_license_in_use(synth_session, one_license_in_use)
 
-    licenses_in_use_in_db = await read_objects(LicenseInUse)
-    assert len(licenses_in_use_in_db) == 1
-    assert LicenseRow.model_validate(licenses_in_db[0]).in_use == one_license_in_use.quantity
+    licenses_in_db_after_add = await read_objects(License)
+    assert len(licenses_in_db_after_add) == 1
+    assert LicenseRow.model_validate(licenses_in_db_after_add[0]).in_use == one_license_in_use.quantity
 
 
 @mark.asyncio
@@ -210,13 +210,13 @@ async def test__remove_license_in_use__correctly_updates_license_in_use(
     one_license, one_license_in_use, insert_objects, read_objects, synth_session
 ):
     await insert_objects([one_license], License)
-    await insert_objects([one_license_in_use], LicenseInUse)
+    inserted = await insert_objects([one_license_in_use], LicenseInUse)
 
     licenses_in_db = await read_objects(License)
     assert len(licenses_in_db) == 1
     assert LicenseRow.model_validate(licenses_in_db[0]).in_use == one_license_in_use.quantity
 
-    remove_license_in_use(synth_session, 1)
+    await remove_license_in_use(synth_session, inserted[0].id)
 
     licenses_in_db_after_delete = await read_objects(License)
     assert len(licenses_in_db_after_delete) == 1

--- a/lm-simulator/tests/test_main.py
+++ b/lm-simulator/tests/test_main.py
@@ -46,7 +46,7 @@ async def test__create_license__fail_with_duplicate(backend_client, one_license,
         "/licenses",
         json=one_license.model_dump(),
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_409_CONFLICT
 
 
 @mark.asyncio

--- a/lm-simulator/tests/test_main.py
+++ b/lm-simulator/tests/test_main.py
@@ -1,259 +1,229 @@
-import pytest
 from fastapi import status
+from pytest import mark
 
 from lm_simulator.models import License, LicenseInUse
 
 
-def test_health_check(client):
-    """Test the health check route."""
-    response = client.get("/health")
+@mark.asyncio
+async def test__health_check(backend_client):
+    """
+    Test the health check route.
+    """
+    response = await backend_client.get("/health")
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_create_license(client):
-    """Test that the correct status code and response are returned on in use license creation."""
-    response = client.post(
-        "/licenses/",
-        json={"name": "test_name", "total": 100},
+@mark.asyncio
+async def test__create_license__success(backend_client, one_license):
+    """
+    Test that the correct status code and response are returned on in use license creation.
+    """
+    response = await backend_client.post(
+        "/licenses",
+        json=one_license.model_dump(),
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json() == {
-        "id": 1,
-        "name": "test_name",
-        "total": 100,
+        "name": one_license.name,
+        "total": one_license.total,
         "in_use": 0,
         "licenses_in_use": [],
     }
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_create_license_duplicate(client, session, one_license):
-    """Test that the correct response is returned when a duplicate license creation is attempted."""
-    session.add(License(**one_license.dict()))
-    session.commit()
-    response = client.post(
-        "/licenses/",
-        json={"name": "test_name", "total": 100},
+@mark.asyncio
+async def test__create_license__fail_with_duplicate(backend_client, one_license, insert_objects):
+    """
+    Test that the correct response is returned when a duplicate license creation is attempted.
+    """
+    await insert_objects([one_license], License)
+
+    response = backend_client.post(
+        "/licenses",
+        json=one_license.model_dump(),
     )
-    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_list_licenses(client, session):
-    session.add(License(name="l1", total=100, id=1))
-    session.add(License(name="l2", total=200, id=2))
-    session.add(License(name="l3", total=300, id=3))
-    session.commit()
-    response = client.get("/licenses/")
+@mark.asyncio
+async def test__list_licenses__empty(backend_client):
+    response = await backend_client.get("/licenses")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+
+
+@mark.asyncio
+async def test__list_licenses__success(backend_client, licenses, insert_objects):
+    """
+    Test that the correct response is returned when listing licenses.
+    """
+    await insert_objects(licenses, License)
+
+    response = await backend_client.get("/licenses")
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == [
         {
-            "id": 1,
-            "name": "l1",
-            "total": 100,
+            "name": licenses[0].name,
+            "total": licenses[0].total,
             "in_use": 0,
             "licenses_in_use": [],
         },
         {
-            "id": 2,
-            "name": "l2",
-            "total": 200,
-            "in_use": 0,
-            "licenses_in_use": [],
-        },
-        {
-            "id": 3,
-            "name": "l3",
-            "total": 300,
+            "name": licenses[1].name,
+            "total": licenses[1].total,
             "in_use": 0,
             "licenses_in_use": [],
         },
     ]
 
 
-def test_list_licenses_empty(client):
-    response = client.get("/licenses/")
+@mark.asyncio
+async def test__delete_license__success(backend_client, one_license, insert_objects):
+    """
+    Test that the correct response is returned when deleting a license.
+    """
+    await insert_objects([one_license], License)
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
+    response = await backend_client.delete(f"/licenses/{one_license.name}")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_list_licenses_in_use(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    session.add(
-        LicenseInUse(quantity=10, user_name="user1", lead_host="host1", license_name="test_name", id=1)
+@mark.asyncio
+async def test__delete_license__fail_with_not_found(backend_client):
+    """
+    Test that the correct response is returned when attempting to delete a non-existent license.
+    """
+    response = await backend_client.delete("/licenses/not-a-license")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@mark.asyncio
+async def test__create_license_in_use__success(
+    backend_client, one_license, one_license_in_use, insert_objects
+):
+    """
+    Test that the correct response is returned when creating a license in use.
+    """
+    await insert_objects([one_license], License)
+
+    response = await backend_client.post(
+        "/licenses-in-use",
+        json=one_license_in_use.model_dump(),
     )
-    session.add(
-        LicenseInUse(quantity=20, user_name="user1", lead_host="host1", license_name="test_name", id=2)
-    )
-    session.commit()
-    response = client.get("/licenses-in-use/")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == [
-        {
-            "id": 1,
-            "quantity": 10,
-            "user_name": "user1",
-            "lead_host": "host1",
-            "license_name": "test_name",
-        },
-        {
-            "id": 2,
-            "quantity": 20,
-            "user_name": "user1",
-            "lead_host": "host1",
-            "license_name": "test_name",
-        },
-    ]
-
-
-def test_list_licenses_in_use_from_name(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    session.add(
-        LicenseInUse(quantity=10, user_name="user1", lead_host="host1", license_name="test_name", id=1)
-    )
-    session.add(
-        LicenseInUse(quantity=20, user_name="user1", lead_host="host1", license_name="test_name", id=2)
-    )
-    session.commit()
-    response = client.get("/licenses-in-use/test_name")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == [
-        {
-            "id": 1,
-            "quantity": 10,
-            "user_name": "user1",
-            "lead_host": "host1",
-            "license_name": "test_name",
-        },
-        {
-            "id": 2,
-            "quantity": 20,
-            "user_name": "user1",
-            "lead_host": "host1",
-            "license_name": "test_name",
-        },
-    ]
-
-
-def test_list_licenses_in_use_from_name_no_match(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    session.add(
-        LicenseInUse(quantity=10, user_name="user1", lead_host="host1", license_name="test_name", id=1)
-    )
-    session.add(
-        LicenseInUse(quantity=20, user_name="user1", lead_host="host1", license_name="test_name", id=2)
-    )
-    session.commit()
-    response = client.get("/licenses-in-use/name_not_in_database")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
-
-
-def test_list_licenses_in_use_from_name_empty(client):
-    response = client.get("/licenses-in-use/test")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
-
-
-def test_list_licenses_in_use_empty(client):
-    response = client.get("/licenses-in-use/")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
-
-
-def test_create_license_in_use(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    response = client.post(
-        "/licenses-in-use/",
-        json={"license_name": "test_name", "quantity": 10, "user_name": "user1", "lead_host": "host1"},
-    )
     assert response.status_code == status.HTTP_201_CREATED
-    assert response.json() == {
-        "id": 1,
-        "quantity": 10,
-        "user_name": "user1",
-        "lead_host": "host1",
-        "license_name": "test_name",
-    }
+    assert response.json() == one_license_in_use.model_dump()
 
 
-def test_create_license_in_use_not_enough(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    response = client.post(
-        "/licenses-in-use/",
-        json={"license_name": "test_name", "quantity": 9999, "user_name": "user1", "lead_host": "host1"},
+@mark.asyncio
+async def test__create_license_in_use__fail_with_not_enough(backend_client, one_license, insert_objects):
+    """
+    Test that the correct response is returned when creating a license in use with not enough licenses.
+    """
+    await insert_objects([one_license], License)
+
+    response = await backend_client.post(
+        "/licenses-in-use",
+        json={
+            "license_name": one_license.name,
+            "quantity": 9999,
+            "user_name": "user1",
+            "lead_host": "host1",
+        },
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Not enough licenses available" in response.text
+    assert "Not enough licenses" in response.text
 
 
-def test_create_license_in_use_dont_exists(client):
-    response = client.post(
-        "/licenses-in-use/",
-        json={"license_name": "test_name", "quantity": 1, "user_name": "user1", "lead_host": "host1"},
+@mark.asyncio
+async def test__create_license_in_use__fail_with_license_not_found(
+    backend_client, one_license, insert_objects
+):
+    """
+    Test that the correct response is returned when creating a license in use with a non-existent license.
+    """
+    await insert_objects([one_license], License)
+
+    response = await backend_client.post(
+        "/licenses-in-use",
+        json={
+            "license_name": "not-a-license",
+            "quantity": 1,
+            "user_name": "user1",
+            "lead_host": "host1",
+        },
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert "doesn't exist" in response.text
 
 
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_create_license_in_use_duplicate(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    session.add(
-        LicenseInUse(quantity=10, user_name="user1", lead_host="host1", license_name="test_name", id=1)
-    )
-    session.commit()
-    response = client.post(
-        "/licenses-in-use/",
-        json={"license_name": "test_name", "quantity": 10, "user_name": "user1", "lead_host": "host1"},
-    )
-    assert response.status_code == status.HTTP_409_CONFLICT
-    assert "LicenseInUse already exists" in response.text
+@mark.asyncio
+async def test__list_licenses_in_use__empty(backend_client):
+    """
+    Test that the correct response is returned when listing licenses in use with no licenses in use.
+    """
+    response = await backend_client.get("/licenses-in-use")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
 
 
-def test_delete_license_in_use(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    session.add(
-        LicenseInUse(quantity=10, user_name="user1", lead_host="host1", license_name="test_name", id=1)
-    )
-    session.add(
-        LicenseInUse(quantity=20, user_name="user1", lead_host="host1", license_name="test_name", id=2)
-    )
-    session.commit()
+@mark.asyncio
+async def test__list_licenses_in_use__success(backend_client, licenses, licenses_in_use, insert_objects):
+    """
+    Test that the correct response is returned when listing licenses in use.
+    """
+    await insert_objects(licenses, License)
+    await insert_objects(licenses_in_use, LicenseInUse)
 
-    response = client.request(
-        "DELETE",
-        "/licenses-in-use/",
-        json={"license_name": "test_name", "quantity": 10, "user_name": "user1", "lead_host": "host1"},
-    )
+    response = await backend_client.get("/licenses-in-use")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [
+        {
+            "id": 1,
+            "quantity": licenses_in_use[0].quantity,
+            "user_name": licenses_in_use[0].user_name,
+            "lead_host": licenses_in_use[0].lead_host,
+            "license_name": licenses_in_use[0].license_name,
+        },
+        {
+            "id": 2,
+            "quantity": licenses_in_use[1].quantity,
+            "user_name": licenses_in_use[1].user_name,
+            "lead_host": licenses_in_use[1].lead_host,
+            "license_name": licenses_in_use[1].license_name,
+        },
+    ]
+
+
+@mark.asyncio
+async def test__delete_license_in_use__success(
+    backend_client, one_license, one_license_in_use, insert_objects
+):
+    """
+    Test that the correct response is returned when deleting a license in use.
+    """
+    await insert_objects([one_license], License)
+    inserted = await insert_objects([one_license_in_use], LicenseInUse)
+
+    response = await backend_client.delete(f"/licenses-in-use/{inserted.id}")
+
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_delete_license_in_use_not_found(client):
-    response = client.request(
-        "DELETE",
-        "/licenses-in-use/",
-        json={"license_name": "test_name", "quantity": 10, "user_name": "user1", "lead_host": "host1"},
-    )
+@mark.asyncio
+async def test__delete_license_in_use__fail_with_not_found(backend_client):
+    """
+    Test that the correct response is returned when attempting to delete a non-existent license in use.
+    """
+    response = await backend_client.delete("/licenses-in-use/999")
+
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert "License not found" in response.text
-
-
-def test_delete_license(client, session, one_license):
-    session.add(License(**one_license.dict()))
-    session.commit()
-
-    response = client.delete("/licenses/test_name")
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-
-def test_delete_license_not_found(client):
-    response = client.delete("/licenses/not-a-license")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert "License not found" in response.text
+    assert "License In Use not found" in response.text


### PR DESCRIPTION
#### What
Refact the License Manager Simulator:
* Changed the `engine` and `session` to be Async
* Fixed `models` to add cascade delete on the `LicenseInUse` (solving the FK issue)
* Updated `CRUD` module to use the new `session`
* Updated `main` module to remove trailing slash and use the new `CRUD` methods
* Updated unit tests and improved test coverage
* Updated test job application to use the new routes

#### Why
When deleting a `License`, the `LicenseInUse` related to it was kept in the database. It was not possible to delete these entries because the parent `License` was not available anymore.

`Task`: https://jira.scania.com/browse/ASP-5025

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
