### PR TITLE
Fix slurm_job_id type hint to str

### DIFF
--- a/lm-agent/lm_agent/backend_utils/models.py
+++ b/lm-agent/lm_agent/backend_utils/models.py
@@ -94,7 +94,7 @@ class LicenseBookingRequest(BaseModel):
     Structure to represent a list of license bookings.
     """
 
-    slurm_job_id: int
+    slurm_job_id: str
     username: str
     lead_host: str
     bookings: List[LicenseBooking] = []


### PR DESCRIPTION
#### What
Fix the type hint for the `slurm_job_id` in the `LicenseBookingRequest` model.

#### Why
It was causing issues in the local test environment.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
