### PR TITLE
Change docker-compose command

### DIFF
--- a/lm-api/Makefile
+++ b/lm-api/Makefile
@@ -11,8 +11,8 @@ install:
 
 .PHONY: test
 test:
-	docker-compose build unittest
-	docker-compose run --rm unittest
+	docker compose build unittest
+	docker compose run --rm unittest
 
 .PHONY: mypy
 mypy: install
@@ -42,7 +42,7 @@ publish:
 
 .PHONY: local
 local:
-	docker-compose up --build license-manager
+	docker compose up --build license-manager
 
 # To include a message with the generated migration, set the MESSAGE variable in the make command:
 #   $ make db-migration MESSAGE="this migration applies foo to bar"

--- a/lm-simulator/Makefile
+++ b/lm-simulator/Makefile
@@ -11,8 +11,8 @@ install:
 
 .PHONY: test
 test:
-	docker-compose up --build unittest
-	docker-compose run --rm unittest
+	docker compose up --build unittest
+	docker compose run --rm unittest
 
 .PHONY: lint
 lint: install
@@ -31,7 +31,7 @@ qa: test lint
 
 .PHONY: local
 local: install
-	docker-compose up --build lm-simulator
+	docker compose up --build lm-simulator
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
#### What
Change the `docker-compose` command to use `docker compose` from Docker.

#### Why
The Ubuntu image used in the GitHub Actions was updated and dropped the support for `docker-compose`.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
