### PR TITLE
Add lm-sim to prepare_release

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -62,8 +62,16 @@ jobs:
           echo "Poetry version is: $(poetry version --short)"
           echo "::set-output name=version::$(poetry version --short)"
 
+      - id: lm-sim-package
+        name: Bump version on the simulator
+        working-directory: lm-simulator
+        run: |
+          ../release-scripts/prepare-release.sh ${{ github.event.inputs.bump_rule }}
+          echo "Poetry version is: $(poetry version --short)"
+          echo "::set-output name=version::$(poetry version --short)"          
+
       - name: Fail if poetry packages version don't match
-        if: ${{ steps.agent-package.outputs.version != steps.backend-package.outputs.version != steps.lm-cli-package.outputs.version }}
+        if: ${{ steps.agent-package.outputs.version != steps.backend-package.outputs.version != steps.lm-cli-package.outputs.version != steps.lm-sim-package.outputs.version }}
         run: echo "Poetry packages version don't match!"
 
       - uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
#### What
Update the `prepare_release` GitHub Action to include the `lm-simulator` subproject.

#### Why
Since the project was added later, it was missing in the Action.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
