### PR TITLE
[ASP-4668] Add routes to Simulator API

### DIFF
--- a/lm-simulator/CHANGELOG.md
+++ b/lm-simulator/CHANGELOG.md
@@ -9,6 +9,8 @@ This file keeps track of all notable changes to license-manager-simulator
 * Added cascade delete to remove Licenses In Use when the License is deleted
 * Refactored database module to use AsyncSesssion
 * Converted job application example to Python
+* Add LicenseServerType column to License table
+* Add routes to filter by name and LicenseServerType
 
 ## 0.3.0 -- 2022-11-16
 * Fixed lm-sim ip in setup scripts to use the new subapp endpoint

--- a/lm-simulator/lm_simulator/constants.py
+++ b/lm-simulator/lm_simulator/constants.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class LicenseServerType(str, Enum):
+    """
+    Describe the supported license server types that may be used for fetching licenses from license servers.
+    """
+
+    FLEXLM = "flexlm"
+    RLM = "rlm"
+    LMX = "lmx"
+    LSDYNA = "lsdyna"
+    OLICENSE = "olicense"

--- a/lm-simulator/lm_simulator/crud.py
+++ b/lm-simulator/lm_simulator/crud.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from buzz import enforce_defined, handle_errors, require_condition
 from fastapi import HTTPException, status
@@ -60,7 +60,7 @@ async def list_licenses_by_server_type(session: Session, server_type: LicenseSer
     return [LicenseRow.model_validate(license) for license in db_licenses]
 
 
-async def read_license_by_name(session: Session, license_name: str) -> Optional[LicenseRow]:
+async def read_license_by_name(session: Session, license_name: str) -> LicenseRow:
     """
     Retrive the License in the database by name.
     """

--- a/lm-simulator/lm_simulator/crud.py
+++ b/lm-simulator/lm_simulator/crud.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import List, Optional
 
 from buzz import enforce_defined, handle_errors, require_condition
 from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from lm_simulator.constants import LicenseServerType
 from lm_simulator.models import License, LicenseInUse
 from lm_simulator.schemas import LicenseCreate, LicenseInUseCreate, LicenseInUseRow, LicenseRow
 
@@ -48,6 +49,33 @@ async def list_licenses(session: Session) -> List[LicenseRow]:
     query = await session.execute(select(License))
     db_licenses = query.scalars().all()
     return [LicenseRow.model_validate(license) for license in db_licenses]
+
+
+async def list_licenses_by_server_type(session: Session, server_type: LicenseServerType) -> List[LicenseRow]:
+    """
+    List all Licenses in the database by server type.
+    """
+    query = await session.execute(select(License).where(License.license_server_type == server_type))
+    db_licenses = query.scalars().all()
+    return [LicenseRow.model_validate(license) for license in db_licenses]
+
+
+async def read_license_by_name(session: Session, license_name: str) -> Optional[LicenseRow]:
+    """
+    Retrive the License in the database by name.
+    """
+    query = await session.execute(select(License).where(License.name == license_name))
+    db_license = enforce_defined(
+        query.scalar_one_or_none(),
+        "License not found",
+        raise_exc_class=HTTPException,
+        exc_builder=lambda exc_class, msg: exc_class(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="License not found",
+        ),
+    )
+
+    return LicenseRow.model_validate(db_license)
 
 
 async def remove_license(session: Session, license_name: str):

--- a/lm-simulator/lm_simulator/main.py
+++ b/lm-simulator/lm_simulator/main.py
@@ -5,11 +5,14 @@ from fastapi import Depends, FastAPI, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from lm_simulator.constants import LicenseServerType
 from lm_simulator.crud import (
     add_license,
     add_license_in_use,
     list_licenses,
+    list_licenses_by_server_type,
     list_licenses_in_use,
+    read_license_by_name,
     remove_license,
     remove_license_in_use,
 )
@@ -54,6 +57,28 @@ async def create_license(license: LicenseCreate, session: AsyncSession = Depends
 )
 async def get_licenses(session: AsyncSession = Depends(get_session)):
     licenses = await list_licenses(session=session)
+    return licenses
+
+
+@subapp.get(
+    "/licenses/{license_name}",
+    status_code=status.HTTP_200_OK,
+    response_model=LicenseRow,
+)
+async def get_license_by_name(license_name: str, session: AsyncSession = Depends(get_session)):
+    license = await read_license_by_name(session=session, license_name=license_name)
+    return license
+
+
+@subapp.get(
+    "/licenses/type/{server_type}",
+    status_code=status.HTTP_200_OK,
+    response_model=List[LicenseRow],
+)
+async def get_licenses_by_server_type(
+    server_type: LicenseServerType, session: AsyncSession = Depends(get_session)
+):
+    licenses = await list_licenses_by_server_type(session=session, server_type=server_type)
     return licenses
 
 

--- a/lm-simulator/lm_simulator/models.py
+++ b/lm-simulator/lm_simulator/models.py
@@ -17,6 +17,7 @@ class License(Base):
         lazy="selectin",
         cascade="all, delete-orphan",
     )
+    license_server_type: Mapped[str] = mapped_column(String, nullable=False)
 
     @property
     def in_use(self):

--- a/lm-simulator/lm_simulator/schemas.py
+++ b/lm-simulator/lm_simulator/schemas.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, ConfigDict
 
+from lm_simulator.constants import LicenseServerType
+
 
 class LicenseInUseCreate(BaseModel):
     quantity: int
@@ -17,6 +19,7 @@ class LicenseInUseRow(LicenseInUseCreate):
 class LicenseCreate(BaseModel):
     name: str
     total: int
+    license_server_type: LicenseServerType
 
 
 class LicenseRow(LicenseCreate):

--- a/lm-simulator/tests/conftest.py
+++ b/lm-simulator/tests/conftest.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from yarl import URL
 
 from lm_simulator.config import settings
+from lm_simulator.constants import LicenseServerType
 from lm_simulator.database import Base, get_session
 from lm_simulator.main import subapp
 from lm_simulator.schemas import LicenseCreate, LicenseInUseCreate
@@ -117,14 +118,14 @@ def read_objects(synth_session):
 
 @fixture
 def one_license():
-    return LicenseCreate(name="test_license", total=1000)
+    return LicenseCreate(name="test_license", total=1000, license_server_type=LicenseServerType.FLEXLM)
 
 
 @fixture
 def licenses():
     return [
-        LicenseCreate(name="test_license1", total=1000),
-        LicenseCreate(name="test_license2", total=2000),
+        LicenseCreate(name="test_license1", total=1000, license_server_type=LicenseServerType.FLEXLM),
+        LicenseCreate(name="test_license2", total=2000, license_server_type=LicenseServerType.FLEXLM),
     ]
 
 

--- a/lm-simulator/tests/test_main.py
+++ b/lm-simulator/tests/test_main.py
@@ -31,6 +31,7 @@ async def test__create_license__success(backend_client, one_license, read_object
         "name": licenses_in_db[0].name,
         "total": licenses_in_db[0].total,
         "in_use": 0,
+        "license_server_type": licenses_in_db[0].license_server_type,
         "licenses_in_use": [],
     }
 
@@ -51,6 +52,9 @@ async def test__create_license__fail_with_duplicate(backend_client, one_license,
 
 @mark.asyncio
 async def test__list_licenses__empty(backend_client):
+    """
+    Test that the correct response is returned when listing licenses with no licenses.
+    """
     response = await backend_client.get("/licenses")
 
     assert response.status_code == status.HTTP_200_OK
@@ -72,15 +76,85 @@ async def test__list_licenses__success(backend_client, licenses, insert_objects)
             "name": inserted[0].name,
             "total": inserted[0].total,
             "in_use": 0,
+            "license_server_type": inserted[0].license_server_type,
             "licenses_in_use": [],
         },
         {
             "name": inserted[1].name,
             "total": inserted[1].total,
             "in_use": 0,
+            "license_server_type": inserted[1].license_server_type,
             "licenses_in_use": [],
         },
     ]
+
+
+@mark.asyncio
+async def test__list_licenses_by_server_type__empty(backend_client):
+    """
+    Test that the correct response is returned when listing licenses by server type with no licenses.
+    """
+    response = await backend_client.get("/licenses/type/flexlm")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
+
+
+@mark.asyncio
+async def test__list_licenses_by_server_type__success(backend_client, licenses, insert_objects):
+    """
+    Test that the correct response is returned when listing licenses by server type.
+    """
+    await insert_objects(licenses, License)
+
+    response = await backend_client.get("/licenses/type/flexlm")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [
+        {
+            "name": licenses[0].name,
+            "total": licenses[0].total,
+            "in_use": 0,
+            "license_server_type": licenses[0].license_server_type,
+            "licenses_in_use": [],
+        },
+        {
+            "name": licenses[1].name,
+            "total": licenses[1].total,
+            "in_use": 0,
+            "license_server_type": licenses[1].license_server_type,
+            "licenses_in_use": [],
+        },
+    ]
+
+
+@mark.asyncio
+async def test__read_license_by_name__success(backend_client, one_license, insert_objects):
+    """
+    Test that the correct response is returned when reading a license.
+    """
+    await insert_objects([one_license], License)
+
+    response = await backend_client.get(f"/licenses/{one_license.name}")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "name": one_license.name,
+        "total": one_license.total,
+        "in_use": 0,
+        "license_server_type": one_license.license_server_type,
+        "licenses_in_use": [],
+    }
+
+
+@mark.asyncio
+async def test__read_license_by_name__fail_with_not_found(backend_client):
+    """
+    Test that the correct response is returned when attempting to read a non-existent license.
+    """
+    response = await backend_client.get("/licenses/not-a-license")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @mark.asyncio


### PR DESCRIPTION
#### What
Add a column for `License Server Type` in the License model.
Also add routes to filter by `License Server Type` and by license name.

#### Why
The scripts were filtering the licenses by name, expecting a license with a known name to distinguish the license server type. Now that the licenses in the database already have a type, it can be filtered in the API instead.


`Task`: https://jira.scania.com/browse/ASP-4668

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
