### PR TITLE
Remove OIDC_AUDIENCE setting from subprojects

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -233,7 +233,6 @@ license-manager-agent:
   lmxendutil-path: "/usr/local/bin/lmxendutil"
   olixtool-path: "/usr/local/bin/olixtool"
   oidc-domain: "your-oidc-domain"
-  oidc-audience: "your-oidc-audience"
   oidc-client-id: "your-oidc-client-id"
   oidc-client-secret: "your-oidc-client-secret"
   sentry-dsn: ""

--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
-
+* Remove OIDC_AUDIENCE setting
 
 ## 3.4.0 -- 2024-08-19
 * Add env var to set wheter the agent should use HTTP or HTTPS to communicate with the OIDC provider

--- a/lm-agent/lm_agent/backend_utils/utils.py
+++ b/lm-agent/lm_agent/backend_utils/utils.py
@@ -82,7 +82,6 @@ def acquire_token() -> str:
     if token is None:
         logger.debug("Attempting to acquire token from OIDC")
         oidc_body = dict(
-            audience=settings.OIDC_AUDIENCE,
             client_id=settings.OIDC_CLIENT_ID,
             client_secret=settings.OIDC_CLIENT_SECRET,
             grant_type="client_credentials",

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -71,7 +71,6 @@ class Settings(BaseSettings):
 
     # OIDC config for machine-to-machine security
     OIDC_DOMAIN: str
-    OIDC_AUDIENCE: str
     OIDC_CLIENT_ID: str
     OIDC_CLIENT_SECRET: str
     OIDC_USE_HTTPS: bool = True

--- a/lm-agent/pyproject.toml
+++ b/lm-agent/pyproject.toml
@@ -39,7 +39,6 @@ addopts = "--random-order --cov=lm_agent --cov-report=term-missing --cov-fail-un
 testpaths = ["tests"]
 env = [
     "LM2_AGENT_OIDC_DOMAIN = str",
-    "LM2_AGENT_OIDC_AUDIENCE = str",
     "LM2_AGENT_OIDC_CLIENT_ID = str",
     "LM2_AGENT_OIDC_CLIENT_SECRET = str",
     "LM2_AGENT_BACKEND_BASE_URL = http://backend",

--- a/lm-api/data_migration/migration_script.py
+++ b/lm-api/data_migration/migration_script.py
@@ -10,13 +10,12 @@ from data_migration.models import OldConfiguration
 load_dotenv()
 
 
-def acquire_token(oidc_domain, audience, client_id, client_secret) -> str:
+def acquire_token(oidc_domain, client_id, client_secret) -> str:
     """
     Retrieves a token from OIDC.
     """
     logger.debug("Attempting to acquire token from OIDC")
     oidc_body = dict(
-        audience=audience,
         client_id=client_id,
         client_secret=client_secret,
         grant_type="client_credentials",
@@ -178,14 +177,12 @@ def create_new_configurations(token: str, old_configurations: List[OldConfigurat
 def main():
     old_token = acquire_token(
         oidc_domain=os.environ.get("OLD_OIDC_DOMAIN"),
-        audience=os.environ.get("OLD_OIDC_AUDIENCE"),
         client_id=os.environ.get("OLD_OIDC_CLIENT_ID"),
         client_secret=os.environ.get("OLD_OIDC_CLIENT_SECRET"),
     )
 
     new_token = acquire_token(
         oidc_domain=os.environ.get("NEW_OIDC_DOMAIN"),
-        audience=os.environ.get("NEW_OIDC_AUDIENCE"),
         client_id=os.environ.get("NEW_OIDC_CLIENT_ID"),
         client_secret=os.environ.get("NEW_OIDC_CLIENT_SECRET"),
     )

--- a/lm-cli/CHANGELOG.md
+++ b/lm-cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager CLI`.
 
 ## Unreleased
-
+* Remove OIDC_AUDIENCE setting
 
 ## 3.4.0 -- 2024-08-19
 * Upgrade Pydantic to *^2.8.2*

--- a/lm-cli/lm_cli/auth.py
+++ b/lm-cli/lm_cli/auth.py
@@ -217,7 +217,6 @@ def refresh_access_token(ctx: LicenseManagerContext, token_set: TokenSet):
             response_model_cls=TokenSet,
             data=dict(
                 client_id=settings.OIDC_CLIENT_ID,
-                audience=settings.OIDC_AUDIENCE,
                 grant_type="refresh_token",
                 refresh_token=token_set.refresh_token,
             ),
@@ -251,7 +250,6 @@ def fetch_auth_tokens(ctx: LicenseManagerContext) -> TokenSet:
             data=dict(
                 client_id=settings.OIDC_CLIENT_ID,
                 grant_type="client_credentials",
-                audience=settings.OIDC_AUDIENCE,
             ),
         ),
     )

--- a/lm-cli/lm_cli/config.py
+++ b/lm-cli/lm_cli/config.py
@@ -38,7 +38,6 @@ class Settings(BaseSettings):
     # OIDC config for machine-to-machine security
     OIDC_DOMAIN: str
     OIDC_LOGIN_DOMAIN: Optional[str] = None
-    OIDC_AUDIENCE: str
     OIDC_CLIENT_ID: str
     OIDC_MAX_POLL_TIME: int = 5 * 60  # 5 Minutes
 

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -51,7 +51,6 @@ env = [
     "LM_API_ENDPOINT = https://dummy_api.com/lm/api/v1",
     "LM_DEBUG = false",
     "OIDC_DOMAIN = dummy_auth_domain.com",
-    "OIDC_AUDIENCE = https://dummy_auth_audience.com",
     "OIDC_CLIENT_ID = dummy_client_id",
     "IDENTITY_CLAIMS_KEY = email",
 ]

--- a/lm-test/README.md
+++ b/lm-test/README.md
@@ -31,7 +31,6 @@ You'll also need the `.env` file with the following values:
 LM_API_BASE_URL=http://127.0.0.1:7000
 LM_SIM_BASE_URL=http://127.0.0.1:7070
 OIDC_DOMAIN=<your-OIDC-domain>
-OIDC_AUDIENCE=<your-OIDC-audience>
 OIDC_CLIENT_ID=<cluster-client-id-in-OIDC>
 OIDC_CLIENT_SECRET=<client-secret-to-retrieve-OIDC-token>
 LM_SIM_PATH=<path-to-lm-sim-cloned-repo>

--- a/lm-test/lm_test/config.py
+++ b/lm-test/lm_test/config.py
@@ -20,7 +20,6 @@ class Settings(BaseSettings):
 
     # OIDC config for machine-to-machine security
     OIDC_DOMAIN: str
-    OIDC_AUDIENCE: str
     OIDC_CLIENT_ID: str
     OIDC_CLIENT_SECRET: str
 

--- a/lm-test/lm_test/utils.py
+++ b/lm-test/lm_test/utils.py
@@ -13,7 +13,6 @@ def acquire_token() -> str:
     Retrieves a token from OIDC based on the app settings.
     """
     oidc_body = dict(
-        audience=settings.OIDC_AUDIENCE,
         client_id=settings.OIDC_CLIENT_ID,
         client_secret=settings.OIDC_CLIENT_SECRET,
         grant_type="client_credentials",


### PR DESCRIPTION
#### What
Remove the `OIDC_AUDIENCE` setting from `lm-agent`, `lm-cli`, `lm-test` and `documentation`.

#### Why
The audience was removed from the API in #359, so it's not needed anymore.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
