### PR TITLE
Change .env prefix to LM_AGENT in lm-agent

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -4,7 +4,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
 * Remove OIDC_AUDIENCE setting
-* Remove LM2_AGENT prefix from settings
+* Change .env prefix to LM_AGENT in settings
 
 ## 3.4.0 -- 2024-08-19
 * Add env var to set wheter the agent should use HTTP or HTTPS to communicate with the OIDC provider

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -19,6 +19,9 @@ DEFAULT_BIN_PATH = Path(__file__).parent.parent / "bin"
 class Settings(BaseSettings):
     """
     App config.
+
+    If you are setting these in the environment, you must prefix "LM_AGENT_", e.g.
+    LM_AGENT_LOG_LEVEL=DEBUG
     """
 
     # Deployment environment
@@ -85,6 +88,7 @@ class Settings(BaseSettings):
     ENCODING: str = "utf-8"
 
     model_config = SettingsConfigDict(
+        env_prefix="LM_AGENT_",
         env_file=DEFAULT_DOTENV_PATH if DEFAULT_DOTENV_PATH.is_file() else Path(".env"),
     )
 

--- a/lm-agent/pyproject.toml
+++ b/lm-agent/pyproject.toml
@@ -38,16 +38,16 @@ minversion = "6.0"
 addopts = "--random-order --cov=lm_agent --cov-report=term-missing --cov-fail-under=70"
 testpaths = ["tests"]
 env = [
-    "OIDC_DOMAIN = str",
-    "OIDC_CLIENT_ID = str",
-    "OIDC_CLIENT_SECRET = str",
-    "BACKEND_BASE_URL = http://backend",
-    "LMUTIL_PATH = ./tests/mock_tools",
-    "RLMUTIL_PATH = ./tests/mock_tools",
-    "LSDYNA_PATH = ./tests/mock_tools",
-    "LMXENDUTIL_PATH = ./tests/mock_tools",
-    "OLIXTOOL_PATH = ./tests/mock_tools",
-    "LOG_LEVEL = DEBUG",
+    "LM_AGENT_OIDC_DOMAIN = str",
+    "LM_AGENT_OIDC_CLIENT_ID = str",
+    "LM_AGENT_OIDC_CLIENT_SECRET = str",
+    "LM_AGENT_BACKEND_BASE_URL = http://backend",
+    "LM_AGENT_LMUTIL_PATH = ./tests/mock_tools",
+    "LM_AGENT_RLMUTIL_PATH = ./tests/mock_tools",
+    "LM_AGENT_LSDYNA_PATH = ./tests/mock_tools",
+    "LM_AGENT_LMXENDUTIL_PATH = ./tests/mock_tools",
+    "LM_AGENT_OLIXTOOL_PATH = ./tests/mock_tools",
+    "LM_AGENT_LOG_LEVEL = DEBUG",
 ]
 
 [tool.ruff]

--- a/lm-agent/tests/test_settings.py
+++ b/lm-agent/tests/test_settings.py
@@ -14,7 +14,7 @@ def good_env():
     """
     A parseable environment
     """
-    env = {"BACKEND_BASE_URL": "http://hello/"}
+    env = {"LM_AGENT_BACKEND_BASE_URL": "http://hello/"}
     with patch.dict(os.environ, env) as e:
         yield e
 
@@ -24,7 +24,7 @@ def bad_env():
     """
     An unparseable environment
     """
-    env = {"BACKEND_BASE_URL": "not-a-url"}
+    env = {"LM_AGENT_BACKEND_BASE_URL": "not-a-url"}
     with patch.dict(os.environ, env) as e:
         yield e
 
@@ -34,7 +34,7 @@ def test_init_settings(good_env):
     Do we build a settings object from good input?
     """
     good = init_settings()
-    assert str(good.BACKEND_BASE_URL) == good_env["BACKEND_BASE_URL"]
+    assert str(good.BACKEND_BASE_URL) == good_env["LM_AGENT_BACKEND_BASE_URL"]
 
 
 def test_init_settings_bad(bad_env, caplog):


### PR DESCRIPTION
#### What
Change the `LM2_AGENT` prefix from agent's env vars to `LM_AGENT`.

#### Why
Since we're going to release version 4.0 of LM, it doesn't make sense to still have `LM2_AGENT` as prefix.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
