### PR TITLE
Fix prepare_release GitHub Action

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -79,13 +79,7 @@ jobs:
           echo "::set-output name=version::$(poetry version --short)" 
 
       - name: Fail if poetry packages version don't match
-        if: |
-          ${{ steps.agent-package.outputs.version != |
-              steps.backend-package.outputs.version != |
-              steps.lm-cli-package.outputs.version != |
-              steps.lm-sim-package.outputs.version != |
-              steps.lm-sim-api-package.outputs.version |
-          }}
+        if: ${{ steps.agent-package.outputs.version != steps.backend-package.outputs.version != steps.lm-cli-package.outputs.version != steps.lm-sim-package.outputs.version != steps.lm-sim-api-package.outputs.version }}
         run: echo "Poetry packages version don't match!"
 
       - uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
#### What
Fix the formatting in the `prepare_release` GitHub Action.

#### Why
It was not running with the command split in multiple lines.

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
