### PR TITLE
Attempt to fix the *Output metadata* action in the *build-publish* job.

### DIFF
--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Output metadata
         working-directory: ${{ matrix.sub_project }}
-        if: ${{ matrix.sub_project }} == "lm-agent"
+        if: matrix.sub_project == 'lm-agent'
         id: extract-metadata
         run: |
           VERSION=$(find ./dist -name '*.tar.gz' | sed 's/.\/dist\/license_manager_agent-\(.*\)\.tar\.gz/\1/')


### PR DESCRIPTION
#### What
This PR attempts to fix the behaviour of the *Output metadata* action in which it is expected to run only for the *lm-agent* sub project.

#### Why
Fix the CI

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
