### PR TITLE
[ASP-5024] Remove DomainConfig from Armasec

### DIFF
--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to `License Manager API`.
 
 ## Unreleased
 * Fix lifespan initialization in FastAPI app
+* Remove DomainConfig from Armasec client to pass the attributes directly
 
 ## 4.1.0 -- 2024-10-10
 * Add support to DSLS license server

--- a/lm-api/lm_api/security.py
+++ b/lm-api/lm_api/security.py
@@ -8,7 +8,6 @@ import typing
 from typing_extensions import Self
 
 from armasec import Armasec, TokenPayload
-from armasec.schemas import DomainConfig
 from armasec.token_security import PermissionMode
 from fastapi import Depends
 from loguru import logger
@@ -17,33 +16,11 @@ from pydantic import model_validator, EmailStr
 from lm_api.config import settings
 
 
-def get_domain_configs() -> typing.List[DomainConfig]:
-    domain_configs = [
-        DomainConfig(
-            domain=settings.ARMASEC_DOMAIN,
-            debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
-            use_https=settings.ARMASEC_USE_HTTPS,
-        )
-    ]
-    if all(
-        [
-            settings.ARMASEC_ADMIN_DOMAIN,
-            settings.ARMASEC_ADMIN_MATCH_KEY,
-            settings.ARMASEC_ADMIN_MATCH_VALUE,
-        ]
-    ):
-        domain_configs.append(
-            DomainConfig(
-                domain=settings.ARMASEC_ADMIN_DOMAIN,
-                match_keys={settings.ARMASEC_ADMIN_MATCH_KEY: settings.ARMASEC_ADMIN_MATCH_VALUE},
-                debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
-                use_https=settings.ARMASEC_USE_HTTPS,
-            )
-        )
-    return domain_configs
-
-
-guard = Armasec(domain_configs=get_domain_configs())
+guard = Armasec(
+    domain=settings.ARMASEC_DOMAIN,
+    debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
+    use_https=settings.ARMASEC_USE_HTTPS,
+)
 
 
 class IdentityPayload(TokenPayload):

--- a/lm-api/tests/test_security.py
+++ b/lm-api/tests/test_security.py
@@ -1,43 +1,6 @@
 import pytest
 
-from lm_api.security import IdentityPayload, get_domain_configs
-
-
-def test_get_domain_configs__loads_only_base_settings(tweak_settings):
-    with tweak_settings(
-        ARMASEC_DOMAIN="foo.io",
-    ):
-        domain_configs = get_domain_configs()
-
-    assert len(domain_configs) == 1
-    first_config = domain_configs.pop()
-    assert first_config.domain == "foo.io"
-
-
-def test_get_domain_configs__loads_admin_settings_if_all_are_present(tweak_settings):
-    with tweak_settings(
-        ARMASEC_DOMAIN="foo.io",
-        ARMASEC_ADMIN_DOMAIN="admin.io",
-    ):
-        domain_configs = get_domain_configs()
-
-    assert len(domain_configs) == 1
-    first_config = domain_configs.pop()
-    assert first_config.domain == "foo.io"
-
-    with tweak_settings(
-        ARMASEC_DOMAIN="foo.io",
-        ARMASEC_ADMIN_DOMAIN="admin.io",
-        ARMASEC_ADMIN_MATCH_KEY="foo",
-        ARMASEC_ADMIN_MATCH_VALUE="bar",
-    ):
-        domain_configs = get_domain_configs()
-
-    assert len(domain_configs) == 2
-    (first_config, second_config) = domain_configs
-    assert first_config.domain == "foo.io"
-    assert second_config.domain == "admin.io"
-    assert second_config.match_keys == dict(foo="bar")
+from lm_api.security import IdentityPayload
 
 
 def test_identity_payload__extracts_organization_id_successfully():


### PR DESCRIPTION
#### What
Change the `Armasec` client to receive the configuration attributes directly instead of using `DomainConfig`.

#### Why
During the work on [ASP-5024] it was noted that `Armasec` was not logging even with `ARMASEC_DEBUG` set to `True`.
It was due to the way the client was being constructed.

`Task`: https://jira.scania.com/browse/ASP-5024

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
