### PR TITLE
PENG-2499 Updated lm-agent to find .env file

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
 
+## 4.2.1 -- 2024-11-19
+* Updated Agent to find .env file [PENG-2499](https://sharing.clickup.com/t/h/c/18022949/PENG-2499/NJ7XCLHQ3O2MBAX)
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API
@@ -62,7 +64,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 * Fix bug when retrieving bookings for non existing job
 
 ## 3.0.5 -- 2023-08-29
-* Change payload for feature update to include the product name 
+* Change payload for feature update to include the product name
 
 ## 3.0.4 -- 2023-08-28
 * Improve function to get bookings sum from backend

--- a/lm-agent/pyproject.toml
+++ b/lm-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-agent"
-version = "4.2.0"
+version = "4.2.1"
 description = "Provides an agent for interacting with license manager"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -5,6 +5,9 @@ This file keeps track of all notable changes to `License Manager API`.
 ## Unreleased
 * Use `pydantic_extra_types.pendulum_dt` to parse the `last_reported` field in `ClusterStatusSchema`
 
+## 4.2.1 -- 2024-11-19
+* Bumped version to keep in sync with agent
+
 ## 4.2.0 -- 2024-11-18
 * Fix lifespan initialization in FastAPI app
 * Remove DomainConfig from Armasec client to pass the attributes directly

--- a/lm-api/pyproject.toml
+++ b/lm-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-backend"
-version = "4.2.0"
+version = "4.2.1"
 description = "Provides an API for managing license data"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-cli/CHANGELOG.md
+++ b/lm-cli/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to `License Manager CLI`.
 
 ## Unreleased
 
+## 4.2.1 -- 2024-11-19
+* Bumped version to keep in sync with agent
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-cli/pyproject.toml
+++ b/lm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-cli"
-version = "4.2.0"
+version = "4.2.1"
 description = "License Manager CLI Client"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/lm-simulator/CHANGELOG.md
+++ b/lm-simulator/CHANGELOG.md
@@ -4,6 +4,8 @@ This file keeps track of all notable changes to License Manager Simulator
 
 ## Unreleased
 
+## 4.2.1 -- 2024-11-19
+* Bumped version to keep in sync with agent
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-simulator/pyproject.toml
+++ b/lm-simulator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "license-manager-simulator"
-version = "4.2.0"
+version = "4.2.1"
 description = "The License Manager Simulator is an application that simulates output from 5 license servers for use in the development of applications which interface to the license servers."
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Updated lm-agent to look in multiple places for the `.env` file.

#### Why
The `.env` file is located in different places depending on whether we are in the prolog/epilog or the main agent process.

`Task`: https://app.clickup.com/t/18022949/PENG-2499

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
