### PR TITLE
Tucker/peng 2499  update lm agent to find dotenv file

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
-
+* Updated Agent to find .env file [PENG-2499](https://sharing.clickup.com/t/h/c/18022949/PENG-2499/NJ7XCLHQ3O2MBAX)
 
 ## 4.2.1 -- 2024-11-18
 * Bumped version to keep in sync with LM-API
@@ -65,7 +65,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 * Fix bug when retrieving bookings for non existing job
 
 ## 3.0.5 -- 2023-08-29
-* Change payload for feature update to include the product name 
+* Change payload for feature update to include the product name
 
 ## 3.0.4 -- 2023-08-28
 * Improve function to get bookings sum from backend

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager API`.
 
 ## Unreleased
-
+* Bumped version to keep in sync with agent
 
 ## 4.2.1 -- 2024-11-18
 * Use `pydantic_extra_types.pendulum_dt` to parse the `last_reported` field in `ClusterStatusSchema`

--- a/lm-cli/CHANGELOG.md
+++ b/lm-cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager CLI`.
 
 ## Unreleased
-
+* Bumped version to keep in sync with agent
 
 ## 4.2.1 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-simulator-api/CHANGELOG.md
+++ b/lm-simulator-api/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to License Manager Simulator API
 
 ## Unreleased
-
+* Bumped version to keep in sync with agent
 
 ## 4.2.1 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-simulator/CHANGELOG.md
+++ b/lm-simulator/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to License Manager Simulator
 
 ## Unreleased
-
+* Bumped version to keep in sync with agent
 
 ## 4.2.1 -- 2024-11-18
 * Bumped version to keep in sync with LM-API


### PR DESCRIPTION
#### What
Updated lm-agent to look in multiple places for the `.env` file.

#### Why
The `.env` file is located in different places depending on whether we are in the prolog/epilog or the main agent process.

`Task`: https://app.clickup.com/t/18022949/PENG-2499

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
