### PR TITLE
[ASP-5422] Fix bug on License Report feature checking

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -5,6 +5,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 ## Unreleased
 * Updated Agent to find .env file [PENG-2499](https://sharing.clickup.com/t/h/c/18022949/PENG-2499/NJ7XCLHQ3O2MBAX)
 * Fix DSLS parser to handle outputs with a warning line [ASP-5422]
+* Fix License Report module to generate the correct feature report when the get_report_item fails [ASP-5422]
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-agent/lm_agent/services/license_report.py
+++ b/lm-agent/lm_agent/services/license_report.py
@@ -94,7 +94,7 @@ async def report() -> typing.List[LicenseReportItem]:
             get_report_awaitables.append(
                 license_server_interface.get_report_item(feature_id, product_feature)
             )
-            product_features_awaited.append(feature_info)
+            product_features_awaited.append(feature_info_to_check)
 
     results: list[BaseException | LicenseReportItem] = await asyncio.gather(
         *get_report_awaitables, return_exceptions=True


### PR DESCRIPTION
#### What
Fix a typo in the `License Report` module where the licenses were getting the wrong name when the `get_report_item` function fails to get a report from the license server output.

#### Why
This was creating several license reports with the same feature name when the `get_report_item` raises an exception for more than one feature.
Consequently the `make_feature_update` HTTP request was returning `400` due to trying to update two features with the same name.
This error was discovered during the DSLS license server testing.

`Task`: https://jira.scania.com/browse/ASP-5422

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
