### PR TITLE
ASP-5422 Fix DSLS parser with warning line in output

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
 * Updated Agent to find .env file [PENG-2499](https://sharing.clickup.com/t/h/c/18022949/PENG-2499/NJ7XCLHQ3O2MBAX)
+* Fix DSLS parser to handle outputs with a warning line [ASP-5422]
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-agent/lm_agent/parsing/dsls.py
+++ b/lm-agent/lm_agent/parsing/dsls.py
@@ -60,8 +60,13 @@ def parse(server_output: str) -> dict[str, ParsedFeatureItem]:
     """
     parsed_data: dict = {}
 
-    # Ignore the first 6 lines, which contain information about the DSLS license server
-    csv_data = csv.DictReader(server_output.splitlines()[6:])
+    # Ignore the lines that contain information about the DSLS license server
+    if "Warning" in server_output:  # Remove warning line with the information lines
+        offset = 7
+    else:
+        offset = 6
+
+    csv_data = csv.DictReader(server_output.splitlines()[offset:])
 
     for row in csv_data:
         parsed_feature = parse_feature_dict(row)

--- a/lm-agent/tests/conftest.py
+++ b/lm-agent/tests/conftest.py
@@ -1385,6 +1385,45 @@ def dsls_output_no_licenses():
 
 
 @fixture
+def dsls_output_with_warning():
+    """Some DSLS output with a warning message to parse."""
+    return dedent(
+        """\
+        License Administration Tool Version 6.425.4 Built on May 2, 2023, 6:45:36 PM.
+        admin >	Software version: 6.425.4
+            Build date: May 2, 2023, 6:45:36 PM
+            Standalone mode
+            Ready: yes
+            Server name: localhost   Server id: ZSD-123
+        Warning: restricted connection, some operations are not permitted; due to an existing connection in full access from localhost(127.0.0.1)
+        admin >Editor,EditorId,Feature,Model,Commercial Type,Max Release Number,Max Release Date,Pricing Structure,Max Casual Duration,Expiration Date,Customer ID,Count,Inuse,Tokens,Casual Usage (mn),Host,User,Internal ID,Active Process,Client Code Version,Session ID,Granted Since,Last Used At,Granted At,Queue Position,
+        Dassault Systemes,5E756A80,PAC,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,1,0,
+        Dassault Systemes,5E756A80,PAJ,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,6,0,
+        Dassault Systemes,5E756A80,PCA,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,4,0,
+        Dassault Systemes,5E756A80,PCO,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PD5,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,1,0,
+        Dassault Systemes,5E756A80,PD6,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,1,0,
+        Dassault Systemes,5E756A80,PD8,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,10000,0,
+        Dassault Systemes,5E756A80,PEX,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,5,0,
+        Dassault Systemes,5E756A80,PIG,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,1,0,
+        Dassault Systemes,5E756A80,PIN,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,5,0,
+        Dassault Systemes,5E756A80,PT5,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PT6,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PTC,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PTI,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PTL,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,6,0,
+        Dassault Systemes,5E756A80,PTS,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PV5,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,5,0,
+        Dassault Systemes,5E756A80,PV6,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,7,0,
+        Dassault Systemes,5E756A80,PVG,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2,0,
+        Dassault Systemes,5E756A80,PW7,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2000,0,
+        Dassault Systemes,5E756A80,PW8,Token,STD,8,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2000,0,
+        Dassault Systemes,5E756A80,SRU,Token,STD,423,2025-01-01 00:59:00,YLC,0,2025-01-01 00:59:00,100000000001723,2374,493,493,,nid001234 (263.0)/127.0.0.1,user_1,SRU,,,,2024-12-09 03:02:19,2024-12-10 02:21:33,,
+        """
+    )
+
+
+@fixture
 def dsls_output_bad():
     """Some unparseable DSLS output."""
     return dedent(

--- a/lm-agent/tests/server_interfaces/test_dsls.py
+++ b/lm-agent/tests/server_interfaces/test_dsls.py
@@ -80,6 +80,27 @@ async def test_dsls_get_report_item_with_bad_output(
 
 @mark.asyncio
 @mock.patch("lm_agent.server_interfaces.dsls.DSLSLicenseServer.get_output_from_server")
+async def test_dsls_get_report_item_with_warning_message(
+    get_output_from_server_mock: mock.MagicMock, dsls_server: DSLSLicenseServer, dsls_output_with_warning: str
+):
+    """
+    Do the DSLS server interface parse the output when the warning line is present?
+    """
+    get_output_from_server_mock.return_value = dsls_output_with_warning
+
+    assert await dsls_server.get_report_item(1, "powerflow.sru") == LicenseReportItem(
+        feature_id=1,
+        product_feature="powerflow.sru",
+        used=493,
+        total=2374,
+        uses=[
+            LicenseUsesItem(username="user_1", lead_host="nid001234", booked=493),
+        ],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.dsls.DSLSLicenseServer.get_output_from_server")
 async def test_dsls_get_report_item_with_no_used_licenses(
     get_output_from_server_mock: mock.MagicMock,
     dsls_server: DSLSLicenseServer,


### PR DESCRIPTION
#### What
Fix the DSLS parser to take into consideration a warning line that can appear when there are multiple connections opened into the license server.

#### Why
The warning line was causing an intermittent issue with the reconciliation of DSLS licenses

`Task`: https://jira.scania.com/browse/ASP-5422

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
