### PR TITLE
chore(api, agent): PENG-2592 adjust sentry sample rates api API and add setings for customising in the agent

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
-
+* Added configuration settings for customising Sentry's sample rates [[PENG-2592](https://sharing.clickup.com/t/h/c/18022949/PENG-2592/QQUQ1ABLAP6QSYX)]
 
 ## 4.2.2 -- 2024-11-19
 * Updated Agent to find .env file [PENG-2499](https://sharing.clickup.com/t/h/c/18022949/PENG-2499/NJ7XCLHQ3O2MBAX)

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -1,9 +1,9 @@
 import sys
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Annotated
 
-from pydantic import AnyHttpUrl, Field
+from pydantic import AnyHttpUrl, Field, confloat
 from pydantic_core import ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -84,7 +84,9 @@ class Settings(BaseSettings):
 
     # Sentry specific settings
     SENTRY_DSN: Optional[str] = None
-    SENTRY_SAMPLE_RATE: Optional[float] = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, confloat(gt=0, le=1.0)] = 0.01
+    SENTRY_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.25
+    SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # OIDC config for machine-to-machine security
     OIDC_DOMAIN: str

--- a/lm-agent/lm_agent/main.py
+++ b/lm-agent/lm_agent/main.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing
 
 import sentry_sdk
 
@@ -13,7 +12,9 @@ from lm_agent.services.reconciliation import reconcile
 if settings.SENTRY_DSN:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
-        sample_rate=typing.cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
+        sample_rate=settings.SENTRY_SAMPLE_RATE,
+        profiles_sample_rate=settings.SENTRY_PROFILING_SAMPLE_RATE,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
         environment=settings.DEPLOY_ENV,
     )
 

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager API`.
 
 ## Unreleased
-
+* Adjusted the default values of Sentry's sample rates [[PENG-2592](https://sharing.clickup.com/t/h/c/18022949/PENG-2592/QQUQ1ABLAP6QSYX)]
 
 ## 4.2.2 -- 2024-11-19
 * Bumped version to keep in sync with agent

--- a/lm-api/lm_api/config.py
+++ b/lm-api/lm_api/config.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Optional, Annotated
 
-from pydantic import Field
+from pydantic import Field, confloat
 
 from lm_api.constants import LogLevelEnum
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -15,9 +15,9 @@ class Settings(BaseSettings):
 
     # Sentry settings
     SENTRY_DSN: Optional[str] = None
-    SENTRY_SAMPLE_RATE: Optional[float] = Field(1.0, gt=0.0, le=1.0)
-    SENTRY_PROFILING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
-    SENTRY_TRACING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, confloat(gt=0, le=1.0)] = 0.01
+    SENTRY_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.25
+    SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # vv should be specified as something like /staging
     # to match where the API is deployed in API Gateway

--- a/lm-api/lm_api/main.py
+++ b/lm-api/lm_api/main.py
@@ -50,7 +50,7 @@ if settings.SENTRY_DSN:
         sample_rate=cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
         environment=settings.DEPLOY_ENV,
         profiles_sample_rate=settings.SENTRY_PROFILING_SAMPLE_RATE,
-        traces_sample_rate=settings.SENTRY_TRACING_SAMPLE_RATE,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
     )
     subapp.add_middleware(SentryAsgiMiddleware)
 


### PR DESCRIPTION
This PR modifies the default values for the following configurations in the API:
* SENTRY_TRACES_SAMPLE_RATE
* SENTRY_SAMPLE_RATE
* SENTRY_PROFILING_SAMPLE_RATE

As well as, these same configurations have been added in the agent.

The values were adjusted according to the task's acceptance criteria.