### PR TITLE
chore(agent): PENG-2622 Change Sentry event level to CRITICAL

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 * Updated Agent to find .env file [PENG-2499](https://sharing.clickup.com/t/h/c/18022949/PENG-2499/NJ7XCLHQ3O2MBAX)
 * Fix DSLS parser to handle outputs with a warning line [ASP-5422]
 * Fix License Report module to generate the correct feature report when the get_report_item fails [ASP-5422]
+* Update Sentry integration to send only CRITICAL events [PENG-2622](https://sharing.clickup.com/t/h/c/18022949/PENG-2622/S2UYYUP3WLPE6WO)
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -117,7 +117,7 @@ def init_settings() -> Settings:
         return Settings()  # type: ignore[call-arg]
     except ValidationError as e:
         logger = logging.getLogger("lm_agent.config")
-        logger.error(f"Failed to load settings: {str(e)}")
+        logger.critical(f"Failed to load settings: {str(e)}")
         sys.exit(1)
 
 

--- a/lm-agent/lm_agent/main.py
+++ b/lm-agent/lm_agent/main.py
@@ -1,7 +1,9 @@
 import asyncio
+import logging
 import typing
 
 import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from lm_agent.backend_utils.utils import check_backend_health, report_cluster_status
 from lm_agent.config import settings
@@ -15,6 +17,12 @@ if settings.SENTRY_DSN:
         dsn=settings.SENTRY_DSN,
         sample_rate=typing.cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
         environment=settings.DEPLOY_ENV,
+        integrations=[
+            LoggingIntegration(
+                level=settings.LOG_LEVEL,
+                event_level=logging.CRITICAL,
+            ),
+        ],
     )
 
 

--- a/lm-agent/lm_agent/main.py
+++ b/lm-agent/lm_agent/main.py
@@ -19,7 +19,7 @@ if settings.SENTRY_DSN:
         environment=settings.DEPLOY_ENV,
         integrations=[
             LoggingIntegration(
-                level=settings.LOG_LEVEL,
+                level=logging.INFO,
                 event_level=logging.CRITICAL,
             ),
         ],

--- a/lm-agent/lm_agent/services/license_report.py
+++ b/lm-agent/lm_agent/services/license_report.py
@@ -130,7 +130,7 @@ async def update_features() -> typing.List[LicenseReportItem]:
     license_report = await report()
 
     if not license_report:
-        logger.error(
+        logger.critical(
             "No license data could be collected, check that tools are installed "
             "correctly and the right hosts/ports are configured in settings"
         )

--- a/lm-agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/slurmctld_epilog.py
@@ -26,13 +26,13 @@ async def epilog():
         try:
             await reconcile()
         except Exception as e:
-            logger.error(f"Failed to call reconcile with {e}")
+            logger.critical(f"Failed to call reconcile with {e}")
             sys.exit(1)
 
     try:
         required_licenses = get_required_licenses_for_job(job_licenses)
     except Exception as e:
-        logger.error(f"Failed to call get_required_licenses_for_job with {e}")
+        logger.critical(f"Failed to call get_required_licenses_for_job with {e}")
         sys.exit(1)
 
     if not required_licenses:

--- a/lm-agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
+++ b/lm-agent/lm_agent/workload_managers/slurm/slurmctld_prolog.py
@@ -38,7 +38,7 @@ async def prolog():
     try:
         required_licenses = get_required_licenses_for_job(job_licenses)
     except Exception as e:
-        logger.error(f"Failed to call get_required_licenses_for_job with {e}")
+        logger.critical(f"Failed to call get_required_licenses_for_job with {e}")
         sys.exit(1)
 
     if not required_licenses:
@@ -55,7 +55,7 @@ async def prolog():
         try:
             entries = await get_cluster_configs_from_backend()
         except Exception as e:
-            logger.error(f"Failed to call get_config_from_backend with {e}")
+            logger.critical(f"Failed to call get_config_from_backend with {e}")
             sys.exit(1)
 
         for entry in entries:
@@ -83,7 +83,7 @@ async def prolog():
             try:
                 await reconcile()
             except Exception as e:
-                logger.error(f"Failed to call reconcile with {e}")
+                logger.critical(f"Failed to call reconcile with {e}")
                 sys.exit(1)
 
         booking_request = await make_booking_request(tracked_license_booking_request)


### PR DESCRIPTION
Raise `Sentry` integration event level from `ERROR` to `CRITICAL`.

The logs for failures we want to track on `Sentry` were updated from `ERROR` to `CRITICAL`, since we don't want to send each `ERROR` event to `Sentry`. This was done to prevent blowing up the quota.