### PR TITLE
ci: Replace personal token for GitHub token

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -86,7 +86,7 @@ jobs:
         name: Create Pull Request
         id: cpr
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Prepared release ${{ steps.agent-package.outputs.version }}"
           branch: "prepare-release/${{ steps.agent-package.outputs.version }}"
           title: "Release ${{ steps.agent-package.outputs.version }}"

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -24,6 +24,10 @@ on:
         - premajor
         - prerelease
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag_on_merged_pull_request.yaml
+++ b/.github/workflows/tag_on_merged_pull_request.yaml
@@ -13,6 +13,9 @@ on:
       - release/**
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     if: (github.event.pull_request.merged && startsWith(github.head_ref, 'prepare-release/'))

--- a/.github/workflows/tag_on_merged_pull_request.yaml
+++ b/.github/workflows/tag_on_merged_pull_request.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: bluwy/substitute-string-action@v1
         name: Get Tag


### PR DESCRIPTION
Replace the `personal token` for `GitHub token` to make it clear that the changes were done via `GitHub Action`.