### PR TITLE
ci(docs): Add --no-root to poetry install in lm-docs to comply with Poetry 2.0.1

### DIFF
--- a/lm-docs/Makefile
+++ b/lm-docs/Makefile
@@ -7,7 +7,7 @@ PACKAGE_NAME:=src
 
 .PHONY: install
 install:
-	poetry install
+	poetry install --no-root
 
 .PHONY: docs
 docs: install


### PR DESCRIPTION
Add `--no-root` to `poetry install` in `lm-docs` to comply with Poetry 2.0.1.

Since the `Gr1N/setup-poetry@v8` action was updated to use Poetry 2.0.1, the `build_and_publish_docs` action was failing in the `lm-docs` project. We do not need to install it as a package, so adding `--no-root` solves the issue.