### PR TITLE
cherry-pick: PENG-2592 adjust sentry sample rates api API and add settings for customising in the agent

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -7,6 +7,7 @@ This file keeps track of all notable changes to `License Manager Agent`.
 * Fix DSLS parser to handle outputs with a warning line [ASP-5422]
 * Fix License Report module to generate the correct feature report when the get_report_item fails [ASP-5422]
 * Update Sentry integration to send only CRITICAL events [PENG-2622](https://sharing.clickup.com/t/h/c/18022949/PENG-2622/S2UYYUP3WLPE6WO)
+* Added configuration settings for customising Sentry's sample rates [[PENG-2592](https://sharing.clickup.com/t/h/c/18022949/PENG-2592/QQUQ1ABLAP6QSYX)]
 
 ## 4.2.0 -- 2024-11-18
 * Bumped version to keep in sync with LM-API

--- a/lm-agent/lm_agent/config.py
+++ b/lm-agent/lm_agent/config.py
@@ -1,9 +1,9 @@
 import sys
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Annotated
 
-from pydantic import AnyHttpUrl, Field
+from pydantic import AnyHttpUrl, Field, confloat
 from pydantic_core import ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -84,7 +84,9 @@ class Settings(BaseSettings):
 
     # Sentry specific settings
     SENTRY_DSN: Optional[str] = None
-    SENTRY_SAMPLE_RATE: Optional[float] = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, confloat(gt=0, le=1.0)] = 0.01
+    SENTRY_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.25
+    SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # OIDC config for machine-to-machine security
     OIDC_DOMAIN: str

--- a/lm-agent/lm_agent/main.py
+++ b/lm-agent/lm_agent/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import typing
 
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -15,7 +14,9 @@ from lm_agent.services.reconciliation import reconcile
 if settings.SENTRY_DSN:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
-        sample_rate=typing.cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
+        sample_rate=settings.SENTRY_SAMPLE_RATE,
+        profiles_sample_rate=settings.SENTRY_PROFILING_SAMPLE_RATE,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
         environment=settings.DEPLOY_ENV,
         integrations=[
             LoggingIntegration(

--- a/lm-api/CHANGELOG.md
+++ b/lm-api/CHANGELOG.md
@@ -4,6 +4,7 @@ This file keeps track of all notable changes to `License Manager API`.
 
 ## Unreleased
 * Use `pydantic_extra_types.pendulum_dt` to parse the `last_reported` field in `ClusterStatusSchema`
+* Adjusted the default values of Sentry's sample rates [[PENG-2592](https://sharing.clickup.com/t/h/c/18022949/PENG-2592/QQUQ1ABLAP6QSYX)]
 
 ## 4.2.0 -- 2024-11-18
 * Fix lifespan initialization in FastAPI app

--- a/lm-api/lm_api/config.py
+++ b/lm-api/lm_api/config.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Optional, Annotated
 
-from pydantic import Field
+from pydantic import Field, confloat
 
 from lm_api.constants import LogLevelEnum
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -15,9 +15,9 @@ class Settings(BaseSettings):
 
     # Sentry settings
     SENTRY_DSN: Optional[str] = None
-    SENTRY_SAMPLE_RATE: Optional[float] = Field(1.0, gt=0.0, le=1.0)
-    SENTRY_PROFILING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
-    SENTRY_TRACING_SAMPLE_RATE: float = Field(1.0, gt=0.0, le=1.0)
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, confloat(gt=0, le=1.0)] = 0.01
+    SENTRY_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.25
+    SENTRY_PROFILING_SAMPLE_RATE: Annotated[float, confloat(gt=0.0, le=1.0)] = 0.01
 
     # vv should be specified as something like /staging
     # to match where the API is deployed in API Gateway

--- a/lm-api/lm_api/main.py
+++ b/lm-api/lm_api/main.py
@@ -50,7 +50,7 @@ if settings.SENTRY_DSN:
         sample_rate=cast(float, settings.SENTRY_SAMPLE_RATE),  # The cast silences mypy
         environment=settings.DEPLOY_ENV,
         profiles_sample_rate=settings.SENTRY_PROFILING_SAMPLE_RATE,
-        traces_sample_rate=settings.SENTRY_TRACING_SAMPLE_RATE,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
     )
     subapp.add_middleware(SentryAsgiMiddleware)
 


### PR DESCRIPTION
This PR modifies the default values for the following configurations in the API:
* SENTRY_TRACES_SAMPLE_RATE
* SENTRY_SAMPLE_RATE
* SENTRY_PROFILING_SAMPLE_RATE

As well as, these same configurations have been added in the agent.

The values were adjusted according to the task's acceptance criteria.

Original Commit: afbbaf642f3d288dbd90f85950cf95d09c30be85