### PR TITLE
ci: Change token on create tag action to use QA user

### DIFF
--- a/.github/workflows/tag_on_merged_pull_request.yaml
+++ b/.github/workflows/tag_on_merged_pull_request.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN }}
 
       - uses: bluwy/substitute-string-action@v1
         name: Get Tag


### PR DESCRIPTION
Change `GITHUB_TOKEN` by Omnivector QA `PAT` on `tag_on_merged_pr` Action.

The GitHub Action `publish_on_tag` can't be triggered automatically if the tag was created by the `github-action` bot.

[Reference](https://github.com/orgs/community/discussions/27028#discussioncomment-3254360)