### PR TITLE
chore(lm-api,lm-simulator-api) [ASP-6607] remove version from docker-compose.yaml files

### DIFF
--- a/lm-api/docker-compose.yaml
+++ b/lm-api/docker-compose.yaml
@@ -1,6 +1,4 @@
-version: "3.9"
 services:
-
   license-manager:
     build:
       context: .

--- a/lm-simulator-api/docker-compose.yaml
+++ b/lm-simulator-api/docker-compose.yaml
@@ -1,6 +1,4 @@
-version: "3.9"
 services:
-
   db:
     image: postgres:14.1
     environment:


### PR DESCRIPTION
The `version` parameter on `docker-compose` was deprecated and it was raising warnings when running the projects.