### PR TITLE
fix(agent): add exception treatment to check next server when the first fails

### DIFF
--- a/lm-agent/CHANGELOG.md
+++ b/lm-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file keeps track of all notable changes to `License Manager Agent`.
 
 ## Unreleased
-
+* Add exception treatment to server interfaces to ensure the next server will be reached if the first one fails to respond [ASP-6723] 
 
 ## 4.4.0 -- 2025-04-04
 * Pin APScheduler version to 3.10.4 to avoid breaking changes [ASP-6607]

--- a/lm-agent/lm_agent/server_interfaces/dsls.py
+++ b/lm-agent/lm_agent/server_interfaces/dsls.py
@@ -3,7 +3,8 @@ import typing
 
 from lm_agent.models import LicenseServerSchema, LicenseReportItem
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
+from lm_agent.logs import logger
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.parsing import dsls
 from lm_agent.utils import run_command
@@ -36,7 +37,11 @@ class DSLSLicenseServer(LicenseServerInterface):
 
         # run each command in the list, one at a time, until one succeds
         for cmd in commands_to_run:
-            output = await run_command(command_line_parts=cmd["command"], stdin_str=cmd["input"])
+            try:
+                output = await run_command(command_line_parts=cmd["command"], stdin_str=cmd["input"])
+            except CommandFailedToExecute as e:
+                logger.debug(f"Command {cmd} failed to execute: {e}")
+                continue
 
             # try the next server if the previous didn't return the expected data
             if not output:

--- a/lm-agent/lm_agent/server_interfaces/flexlm.py
+++ b/lm-agent/lm_agent/server_interfaces/flexlm.py
@@ -5,7 +5,8 @@ from buzz import check_expressions
 
 from lm_agent.models import LicenseServerSchema, LicenseReportItem
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
+from lm_agent.logs import logger
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.parsing import flexlm
 from lm_agent.utils import run_command
@@ -43,7 +44,11 @@ class FlexLMLicenseServer(LicenseServerInterface):
         for cmd in commands_to_run:
             (_, feature) = product_feature.split(".")
             cmd.append(feature)
-            output = await run_command(cmd)
+            try:
+                output = await run_command(cmd)
+            except CommandFailedToExecute as e:
+                logger.debug(f"Command {cmd} failed to execute: {e}")
+                continue
 
             # try the next server if the previous didn't return the expected data
             if not output:

--- a/lm-agent/lm_agent/server_interfaces/lmx.py
+++ b/lm-agent/lm_agent/server_interfaces/lmx.py
@@ -3,7 +3,8 @@ import typing
 
 from lm_agent.models import LicenseServerSchema, LicenseReportItem
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
+from lm_agent.logs import logger
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.parsing import lmx
 from lm_agent.utils import run_command
@@ -41,7 +42,11 @@ class LMXLicenseServer(LicenseServerInterface):
 
         # run each command in the list, one at a time, until one succeds
         for cmd in commands_to_run:
-            output = await run_command(cmd)
+            try:
+                output = await run_command(cmd)
+            except CommandFailedToExecute as e:
+                logger.debug(f"Command {cmd} failed to execute: {e}")
+                continue
 
             # try the next server if the previous didn't return the expected data
             if not output:

--- a/lm-agent/lm_agent/server_interfaces/lsdyna.py
+++ b/lm-agent/lm_agent/server_interfaces/lsdyna.py
@@ -3,7 +3,8 @@ import typing
 
 from lm_agent.models import LicenseServerSchema, LicenseReportItem
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
+from lm_agent.logs import logger
 from lm_agent.parsing import lsdyna
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.utils import run_command
@@ -39,7 +40,11 @@ class LSDynaLicenseServer(LicenseServerInterface):
 
         # run each command in the list, one at a time, until one succeds
         for cmd in commands_to_run:
-            output = await run_command(cmd)
+            try:
+                output = await run_command(cmd)
+            except CommandFailedToExecute as e:
+                logger.debug(f"Command {cmd} failed to execute: {e}")
+                continue
 
             # try the next server if the previous didn't return the expected data
             if not output:

--- a/lm-agent/lm_agent/server_interfaces/olicense.py
+++ b/lm-agent/lm_agent/server_interfaces/olicense.py
@@ -3,7 +3,8 @@ import typing
 
 from lm_agent.models import LicenseServerSchema, LicenseReportItem
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
+from lm_agent.logs import logger
 from lm_agent.parsing import olicense
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.utils import run_command
@@ -38,7 +39,11 @@ class OLicenseLicenseServer(LicenseServerInterface):
 
         # run each command in the list, one at a time, until one succeds
         for cmd in commands_to_run:
-            output = await run_command(cmd)
+            try:
+                output = await run_command(cmd)
+            except CommandFailedToExecute as e:
+                logger.debug(f"Command {cmd} failed to execute: {e}")
+                continue
 
             # try the next server if the previous didn't return the expected data
             if not output:

--- a/lm-agent/lm_agent/server_interfaces/rlm.py
+++ b/lm-agent/lm_agent/server_interfaces/rlm.py
@@ -3,7 +3,8 @@ import typing
 
 from lm_agent.models import LicenseServerSchema, LicenseReportItem
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
+from lm_agent.logs import logger
 from lm_agent.parsing import rlm
 from lm_agent.server_interfaces.license_server_interface import LicenseServerInterface
 from lm_agent.utils import run_command
@@ -40,7 +41,11 @@ class RLMLicenseServer(LicenseServerInterface):
 
         # run each command in the list, one at a time, until one succeds
         for cmd in commands_to_run:
-            output = await run_command(cmd)
+            try:
+                output = await run_command(cmd)
+            except CommandFailedToExecute as e:
+                logger.debug(f"Command {cmd} failed to execute: {e}")
+                continue
 
             # try the next server if the previous didn't return the expected data
             if not output:

--- a/lm-agent/tests/server_interfaces/test_flexlm.py
+++ b/lm-agent/tests/server_interfaces/test_flexlm.py
@@ -4,7 +4,7 @@ from unittest import mock
 from pytest import fixture, mark, raises
 
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
 from lm_agent.server_interfaces.flexlm import FlexLMLicenseServer
 from lm_agent.models import LicenseReportItem
 
@@ -101,4 +101,47 @@ async def test_flexlm_get_report_item_with_no_used_licenses(
         used=0,
         total=1000,
         uses=[],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.flexlm.run_command")
+@mock.patch("lm_agent.server_interfaces.flexlm.FlexLMLicenseServer.get_commands_list")
+async def test_flexlm_get_report_item_continues_on_exception(
+    get_commands_list_mock: mock.MagicMock,
+    run_command_mock: mock.MagicMock,
+    flexlm_server: FlexLMLicenseServer,
+    flexlm_output: str,
+):
+    """
+    Do the FlexLM server interface check the next command if the previous one fails?
+    """
+    get_commands_list_mock.return_value = [
+        [
+            f"{settings.LMUTIL_PATH}",
+            "lmstat",
+            "-c",
+            "2345@127.0.0.1",
+            "-f",
+        ],
+        [
+            f"{settings.LMUTIL_PATH}",
+            "lmstat",
+            "-c",
+            "3456@127.0.0.1",
+            "-f",
+        ],
+    ]
+    run_command_mock.side_effect = [CommandFailedToExecute("Command failed for first server"), flexlm_output]
+
+    assert await flexlm_server.get_report_item(1, "testproduct.testfeature") == LicenseReportItem(
+        feature_id=1,
+        product_feature="testproduct.testfeature",
+        used=93,
+        total=1000,
+        uses=[
+            {"username": "sdmfva", "lead_host": "myserver.example.com", "booked": 29},
+            {"username": "adfdna", "lead_host": "myserver.example.com", "booked": 27},
+            {"username": "sdmfva", "lead_host": "myserver.example.com", "booked": 37},
+        ],
     )

--- a/lm-agent/tests/server_interfaces/test_lmx.py
+++ b/lm-agent/tests/server_interfaces/test_lmx.py
@@ -1,10 +1,10 @@
-"""Test the LS-Dyna license server interface."""
+"""Test the LM-X license server interface."""
 from unittest import mock
 
 from pytest import fixture, mark, raises
 
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
 from lm_agent.models import LicenseReportItem
 from lm_agent.server_interfaces.lmx import LMXLicenseServer
 
@@ -100,4 +100,48 @@ async def test_lmx_get_report_item_with_no_used_licenses(
         used=0,
         total=1000000,
         used_licenses=[],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.lmx.run_command")
+@mock.patch("lm_agent.server_interfaces.lmx.LMXLicenseServer.get_commands_list")
+async def test_lmx_get_report_item_continues_on_exception(
+    get_commands_list_mock: mock.MagicMock,
+    run_command_mock: mock.MagicMock,
+    lmx_server: LMXLicenseServer,
+    lmx_output: str,
+):
+    """
+    Do the LM-X server interface check the next command if the previous one fails?
+    """
+    get_commands_list_mock.return_value = [
+        [
+            f"{settings.LMXENDUTIL_PATH}",
+            "-licstat",
+            "-host",
+            "127.0.0.1",
+            "-port",
+            "2345",
+        ],
+        [
+            f"{settings.LMXENDUTIL_PATH}",
+            "-licstat",
+            "-host",
+            "127.0.0.1",
+            "-port",
+            "3456",
+        ],
+    ]
+
+    run_command_mock.side_effect = [CommandFailedToExecute("Command failed for first server"), lmx_output]
+
+    assert await lmx_server.get_report_item(1, "hyperworks.hyperworks") == LicenseReportItem(
+        feature_id=1,
+        product_feature="hyperworks.hyperworks",
+        used=25000,
+        total=1000000,
+        uses=[
+            {"username": "sssaah", "lead_host": "RD0082406", "booked": 25000},
+        ],
     )

--- a/lm-agent/tests/server_interfaces/test_olicense.py
+++ b/lm-agent/tests/server_interfaces/test_olicense.py
@@ -4,7 +4,7 @@ from unittest import mock
 from pytest import fixture, mark, raises
 
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
 from lm_agent.models import LicenseReportItem
 from lm_agent.server_interfaces.olicense import OLicenseLicenseServer
 
@@ -101,4 +101,47 @@ async def test_olicense_get_report_item_with_no_used_licenses(
         used=0,
         total=4,
         used_licenses=[],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.olicense.run_command")
+@mock.patch("lm_agent.server_interfaces.olicense.OLicenseLicenseServer.get_commands_list")
+async def test_olicense_get_report_item_continues_on_exception(
+    get_commands_list_mock: mock.MagicMock,
+    run_command_mock: mock.MagicMock,
+    olicense_server: OLicenseLicenseServer,
+    olicense_output: str,
+):
+    """
+    Do the OLicense server interface check the next command if the previous one fails?
+    """
+    get_commands_list_mock.return_value = [
+        [
+            f"{settings.OLIXTOOL_PATH}",
+            "-sv",
+            "127.0.0.1:2345",
+        ],
+        [
+            f"{settings.OLIXTOOL_PATH}",
+            "-sv",
+            "127.0.1:3456",
+        ],
+    ]
+
+    run_command_mock.side_effect = [
+        CommandFailedToExecute("Command failed for first server"),
+        olicense_output,
+    ]
+
+    assert await olicense_server.get_report_item(1, "cosin.ftire_adams") == LicenseReportItem(
+        feature_id=1,
+        product_feature="cosin.ftire_adams",
+        used=3,
+        total=4,
+        uses=[
+            {"username": "sbhyma", "lead_host": "RD0087712", "booked": 1},
+            {"username": "sbhyma", "lead_host": "RD0087713", "booked": 1},
+            {"username": "user22", "lead_host": "RD0087713", "booked": 1},
+        ],
     )

--- a/lm-agent/tests/server_interfaces/test_rlm.py
+++ b/lm-agent/tests/server_interfaces/test_rlm.py
@@ -4,7 +4,7 @@ from unittest import mock
 from pytest import fixture, mark, raises
 
 from lm_agent.config import settings
-from lm_agent.exceptions import LicenseManagerBadServerOutput
+from lm_agent.exceptions import CommandFailedToExecute, LicenseManagerBadServerOutput
 from lm_agent.models import LicenseReportItem
 from lm_agent.server_interfaces.rlm import RLMLicenseServer
 
@@ -100,4 +100,50 @@ async def test_rlm_get_report_item_with_no_used_licenses(
         used=0,
         total=1000,
         used_licenses=[],
+    )
+
+
+@mark.asyncio
+@mock.patch("lm_agent.server_interfaces.rlm.run_command")
+@mock.patch("lm_agent.server_interfaces.rlm.RLMLicenseServer.get_commands_list")
+async def test_rlm_get_report_item_continues_on_exception(
+    get_commands_list_mock: mock.MagicMock,
+    run_command_mock: mock.MagicMock,
+    rlm_server: RLMLicenseServer,
+    rlm_output: str,
+):
+    """
+    Do the RLM server interface check the next command if the previous one fails?
+    """
+    get_commands_list_mock.return_value = [
+        [
+            f"{settings.RLMUTIL_PATH}",
+            "rlmstat",
+            "-c",
+            "2345@127.0.0.1",
+            "-a",
+            "-p",
+        ],
+        [
+            f"{settings.RLMUTIL_PATH}",
+            "rlmstat",
+            "-c",
+            "3456@127.0.0.1",
+            "-a",
+            "-p",
+        ],
+    ]
+
+    run_command_mock.side_effect = [CommandFailedToExecute("Command failed for first server"), rlm_output]
+
+    assert await rlm_server.get_report_item(1, "converge.converge_super") == LicenseReportItem(
+        feature_id=1,
+        product_feature="converge.converge_super",
+        used=93,
+        total=1000,
+        uses=[
+            {"username": "asdj13", "lead_host": "myserver.example.com", "booked": 29},
+            {"username": "cddcp2", "lead_host": "myserver.example.com", "booked": 27},
+            {"username": "asdj13", "lead_host": "myserver.example.com", "booked": 37},
+        ],
     )

--- a/lm-agent/tests/services/test_license_report.py
+++ b/lm-agent/tests/services/test_license_report.py
@@ -570,7 +570,7 @@ async def test_license_report_empty_on_exception_raised_with_multiple_features(
             ],
             grace_time=60,
             type=LicenseServerType.RLM,
-        )
+        ),
     ]
     get_report_item_mock.side_effect = Exception("Something is wrong with the license server!")
 


### PR DESCRIPTION
The `agent` was not checking the next server in the license configuration when the first one raised an exception.