### PR TITLE
ci: Fix for code scanning alert 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -1,4 +1,6 @@
 name: Publish on Tag
+permissions:
+  contents: read
 
 # This action:
 #   - Is triggered when a new version is tagged;


### PR DESCRIPTION
Potential fix for [https://github.com/omnivector-solutions/license-manager/security/code-scanning/1](https://github.com/omnivector-solutions/license-manager/security/code-scanning/1)

The best practice is to set an explicit `permissions` block at the workflow or job level that grants only the minimal rights the workflow requires. For publishing to PyPI (using credentials in `secrets`) and pushing docker images (with third-party credentials/identity), the workflow likely only requires read access to repository contents to allow code checkout and workflow operation. Set `permissions: contents: read` at the root of the workflow (top-level, after `name:` and before `on:`), which will apply to all jobs unless overridden, and will fulfill the recommendations with minimal changes and zero risk of breaking workflow functionality. No imports or method changes are needed; only a one-line change early in the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
