### PR TITLE
ci: Fix for code scanning alert 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -15,6 +15,8 @@ on:
       - closed
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/omnivector-solutions/license-manager/security/code-scanning/2](https://github.com/omnivector-solutions/license-manager/security/code-scanning/2)

To fix the problem, add a `permissions:` block to the workflow or the individual job so that the `GITHUB_TOKEN` used in this job has the minimum required scope. Since the job deploys documentation to GitHub Pages (which requires pushing content), the job needs the `contents: write` permission. Placing the block at the job level guarantees least privilege. Add this block under the `build` job (just before or after `runs-on:`):

```yaml
permissions:
  contents: write
```

No further code changes are required. You do not need to change imports, nor add new definitions. The change must be made in the `.github/workflows/build_and_publish_docs.yaml` file, beneath the `build:` job header (between lines 17 and 18).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
