### PR TITLE
ci: Fix for code scanning alert 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -68,6 +68,8 @@ jobs:
 
   publish-to-ecr:
     name: Publish to ECR
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Potential fix for [https://github.com/omnivector-solutions/license-manager/security/code-scanning/3](https://github.com/omnivector-solutions/license-manager/security/code-scanning/3)

To remediate this, we should explicitly restrict the GITHUB_TOKEN permissions used by the relevant job. The most secure approach is to add a `permissions:` block to the specific job (`publish-to-ecr`) granting only the minimal required scope, which for these steps is almost always `contents: read`. This addition should not interfere with the workflow since the job uses AWS credentials for AWS-specific actions and does not use GITHUB_TOKEN for write actions on the repository.

- Edit the `.github/workflows/publish_on_tag.yaml` file.
- Add the following directly under the `name` property of the `publish-to-ecr` job:  
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
