### PR TITLE
Add write permission to publish docs GitHub Action

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -16,7 +16,7 @@ on:
       - closed
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 jobs:


### PR DESCRIPTION
The GitHub Action to deploy the documentation needs to write the content to the docs folder.