### PR TITLE
fix(lm-agent): make FlexLM parser aware of singular licenses

### DIFF
--- a/changes/agent/483.fixed.md
+++ b/changes/agent/483.fixed.md
@@ -1,0 +1,1 @@
+Fixed FlexLM parser to parse "license" in the singular

--- a/lm-agent/lm_agent/parsing/flexlm.py
+++ b/lm-agent/lm_agent/parsing/flexlm.py
@@ -23,9 +23,9 @@ FEATURE_LINE = (
     rf"(?P<feature>{FEATURE_NAME}):  "
     r"\(Total of "
     rf"(?P<total>{INT}) "
-    r"licenses issued;  Total of "
+    r"license(?:s)? issued;  Total of "
     rf"(?P<used>{INT}) "
-    rf"license(?P<plural>s)? in use\)$"
+    r"license(?:s)? in use\)$"
 )
 
 USAGE_LINE_1 = (

--- a/lm-agent/tests/parsing/test_flexlm.py
+++ b/lm-agent/tests/parsing/test_flexlm.py
@@ -28,6 +28,14 @@ from lm_agent.parsing.flexlm import parse, parse_feature_line, parse_usage_line
             },
         ),
         (
+            "Users of TESTFEATURE:  (Total of 1 license issued;  Total of 1 license in use)",
+            {
+                "feature": "testfeature",
+                "total": 1,
+                "used": 1,
+            },
+        ),
+        (
             "not a feature line",
             None,
         ),


### PR DESCRIPTION
The parser for FlexLM was parsing `"licenses"` in the plural, which breaks when there's only one license.