### PR TITLE
backport(lm-api): Add ignore_audience on Armasec guard config

### DIFF
--- a/changes/api/503.changed.md
+++ b/changes/api/503.changed.md
@@ -1,0 +1,1 @@
+Updated Armasec guard to ignore the audience claim in the OIDC token

--- a/lm-api/lm_api/security.py
+++ b/lm-api/lm_api/security.py
@@ -18,6 +18,7 @@ guard = Armasec(
     domain=settings.ARMASEC_DOMAIN,
     debug_logger=logger.debug if settings.ARMASEC_DEBUG else None,
     use_https=settings.ARMASEC_USE_HTTPS,
+    ignore_audience=True,
 )
 
 

--- a/lm-api/pyproject.toml
+++ b/lm-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "asyncpg>=0.30.0",
     "uvicorn>=0.35.0",
     "python-dotenv>=1.1.1",
-    "armasec>=3.0.2",
+    "armasec>=3.0.3",
     "SQLAlchemy[mypy]>=2.0.43",
     "toml>=0.10.2",
     "py-buzz==7.3.0",

--- a/lm-api/uv.lock
+++ b/lm-api/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "armasec"
-version = "3.0.2"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "auto-name-enum" },
@@ -64,9 +64,9 @@ dependencies = [
     { name = "snick" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2f/c9063d10b5ce5b643d26e8d191db2bf056606c7116c7f2aa00a5ce8cf93c/armasec-3.0.2.tar.gz", hash = "sha256:8db828bc5626de02b33eea259489ae35f309be345e4919b382a654c3ef5e61d1", size = 2998180, upload-time = "2025-09-17T21:28:30.686Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/79/cdc45753b386878547872b8b787ded012fe5a701558294c5aa8d60bc27cb/armasec-3.0.3.tar.gz", hash = "sha256:a8c0e5edc38a1581ed607494a17fb8bfb4573f716efe5b53a9546f9e61c037bd", size = 3011915, upload-time = "2026-02-17T17:23:55.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e6/56eb7e2876d0f64f46e2f00468f8489ccf465ef3cb4955418fb930bf8ef2/armasec-3.0.2-py3-none-any.whl", hash = "sha256:da4cf534a1119c1e4a419757374e164cfb78ffc44205a14f3b90039823d32f5a", size = 35503, upload-time = "2025-09-17T21:28:29.458Z" },
+    { url = "https://files.pythonhosted.org/packages/92/50/6818db4ddb1e77164d0b696b6f24021e851fe9dea95e39564ce7b7202a85/armasec-3.0.3-py3-none-any.whl", hash = "sha256:76f5e09e43b04b83cd4fcbcfaa9ca81427b25134101edc3dde07796f7d5d2627", size = 35804, upload-time = "2026-02-17T17:23:56.797Z" },
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", marker = "extra == 'dev'", specifier = ">=1.16.5" },
-    { name = "armasec", specifier = ">=3.0.2" },
+    { name = "armasec", specifier = ">=3.0.3" },
     { name = "asgi-lifespan", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", extras = ["all"], specifier = ">=0.116.2" },

--- a/lm-api/uv.lock
+++ b/lm-api/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "armasec"
-version = "3.0.2"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "auto-name-enum" },
@@ -64,9 +64,9 @@ dependencies = [
     { name = "snick" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2f/c9063d10b5ce5b643d26e8d191db2bf056606c7116c7f2aa00a5ce8cf93c/armasec-3.0.2.tar.gz", hash = "sha256:8db828bc5626de02b33eea259489ae35f309be345e4919b382a654c3ef5e61d1", size = 2998180, upload-time = "2025-09-17T21:28:30.686Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/79/cdc45753b386878547872b8b787ded012fe5a701558294c5aa8d60bc27cb/armasec-3.0.3.tar.gz", hash = "sha256:a8c0e5edc38a1581ed607494a17fb8bfb4573f716efe5b53a9546f9e61c037bd", size = 3011915, upload-time = "2026-02-17T17:23:55.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e6/56eb7e2876d0f64f46e2f00468f8489ccf465ef3cb4955418fb930bf8ef2/armasec-3.0.2-py3-none-any.whl", hash = "sha256:da4cf534a1119c1e4a419757374e164cfb78ffc44205a14f3b90039823d32f5a", size = 35503, upload-time = "2025-09-17T21:28:29.458Z" },
+    { url = "https://files.pythonhosted.org/packages/92/50/6818db4ddb1e77164d0b696b6f24021e851fe9dea95e39564ce7b7202a85/armasec-3.0.3-py3-none-any.whl", hash = "sha256:76f5e09e43b04b83cd4fcbcfaa9ca81427b25134101edc3dde07796f7d5d2627", size = 35804, upload-time = "2026-02-17T17:23:56.797Z" },
 ]
 
 [[package]]
@@ -838,7 +838,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", marker = "extra == 'dev'", specifier = ">=1.16.5" },
-    { name = "armasec", specifier = ">=3.0.2" },
+    { name = "armasec", specifier = ">=3.0.3" },
     { name = "asgi-lifespan", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", extras = ["all"], specifier = ">=0.116.2" },


### PR DESCRIPTION
Backport the changes introduced in the `4.6` release branch.