### PR TITLE
fix(lm-agent): upgrade apscheduler to 4.0.0a6 and sentry-sdk to >=2.62.0

### DIFF
--- a/lm-agent/lm_agent/main.py
+++ b/lm-agent/lm_agent/main.py
@@ -42,14 +42,15 @@ def main():
     init_logging("license-manager-agent")
     logger.info("Starting License Manager Agent")
 
-    scheduler.start()
-    scheduler.add_job(scheduled_tasks)
+    async def _run():
+        async with scheduler:
+            await scheduler.add_job(scheduled_tasks)
+            await scheduler.run()
 
     try:
-        asyncio.get_event_loop().run_forever()
+        asyncio.run(_run())
     except KeyboardInterrupt:
         logger.info("Stopping License Manager Agent")
-        scheduler.stop()
 
 
 if __name__ == "__main__":

--- a/lm-agent/lm_agent/scheduler.py
+++ b/lm-agent/lm_agent/scheduler.py
@@ -1,21 +1,26 @@
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler import AsyncScheduler
+from apscheduler.triggers.interval import IntervalTrigger
 
 from lm_agent.config import settings
 
 
 class Scheduler:
     def __init__(self, interval=settings.STAT_INTERVAL):
-        self.scheduler = AsyncIOScheduler()
+        self._scheduler = AsyncScheduler()
         self.interval = interval
 
-    def add_job(self, func):
-        self.scheduler.add_job(func, "interval", seconds=self.interval)
+    async def __aenter__(self):
+        await self._scheduler.__aenter__()
+        return self
 
-    def start(self):
-        self.scheduler.start()
+    async def __aexit__(self, *args):
+        await self._scheduler.__aexit__(*args)
 
-    def stop(self):
-        self.scheduler.shutdown()
+    async def add_job(self, func):
+        await self._scheduler.add_schedule(func, IntervalTrigger(seconds=self.interval))
+
+    async def run(self):
+        await self._scheduler.run_until_stopped()
 
 
 scheduler = Scheduler()

--- a/lm-agent/pyproject.toml
+++ b/lm-agent/pyproject.toml
@@ -15,10 +15,10 @@ dependencies = [
     "httpx>=0.28.1",
     "PyJWT>=2.10.0",
     "pydantic>=2.12",
-    "sentry-sdk==2.38.0",
+    "sentry-sdk>=2.62.0",
     "py-buzz>=7.3.0",
     "pydantic-settings>=2.10.1",
-    "apscheduler==3.11.2",
+    "apscheduler==4.0.0a6",
 ]
 
 [project.optional-dependencies]

--- a/lm-agent/pyproject.toml
+++ b/lm-agent/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "sentry-sdk==2.38.0",
     "py-buzz>=7.3.0",
     "pydantic-settings>=2.10.1",
-    "apscheduler==3.10.4",
+    "apscheduler==3.11.2",
 ]
 
 [project.optional-dependencies]

--- a/lm-agent/uv.lock
+++ b/lm-agent/uv.lock
@@ -26,16 +26,14 @@ wheels = [
 
 [[package]]
 name = "apscheduler"
-version = "3.10.4"
+version = "3.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytz" },
-    { name = "six" },
     { name = "tzlocal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/34/5dcb368cf89f93132d9a31bd3747962a9dc874480e54333b0c09fa7d56ac/APScheduler-3.10.4.tar.gz", hash = "sha256:e6df071b27d9be898e486bc7940a7be50b4af2e9da7c08f0744a96d4bd4cef4a", size = 100832, upload-time = "2023-08-19T16:44:58.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/b5/7af0cb920a476dccd612fbc9a21a3745fb29b1fcd74636078db8f7ba294c/APScheduler-3.10.4-py3-none-any.whl", hash = "sha256:fb91e8a768632a4756a585f79ec834e0e27aad5860bac7eaa523d9ccefd87661", size = 59303, upload-time = "2023-08-19T16:44:56.814Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
 ]
 
 [[package]]
@@ -266,7 +264,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apscheduler", specifier = "==3.10.4" },
+    { name = "apscheduler", specifier = "==3.11.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.1" },
     { name = "py-buzz", specifier = ">=7.3.0" },
@@ -571,15 +569,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
-]
-
-[[package]]
 name = "respx"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -628,15 +617,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/22/60fd703b34d94d216b2387e048ac82de3e86b63bc28869fb076f8bb0204a/sentry_sdk-2.38.0.tar.gz", hash = "sha256:792d2af45e167e2f8a3347143f525b9b6bac6f058fb2014720b40b84ccbeb985", size = 348116, upload-time = "2025-09-15T15:00:37.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/84/bde4c4bbb269b71bc09316af8eb00da91f67814d40337cc12ef9c8742541/sentry_sdk-2.38.0-py2.py3-none-any.whl", hash = "sha256:2324aea8573a3fa1576df7fb4d65c4eb8d9929c8fa5939647397a07179eef8d0", size = 370346, upload-time = "2025-09-15T15:00:35.821Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrades `apscheduler` from `3.10.4` to `4.0.0a6` and relaxes `sentry-sdk` from `==2.38.0` to `>=2.62.0`.

### Motivation
- APScheduler 4.x is required to share a single virtual environment with `jobbergate-agent` (see omnivector-solutions/jobbergate#965)
- The 3.x API calls `asyncio.get_event_loop()` which raises `RuntimeError` on Python 3.14
- `sentry-sdk==2.38.0` conflicts with `jobbergate-agent`'s minimum of `>=2.47.0`; pinning `>=2.62.0` (latest) resolves this

## Changes

### `lm-agent/pyproject.toml`
- `apscheduler==3.11.2` → `apscheduler==4.0.0a6`
- `sentry-sdk==2.38.0` → `sentry-sdk>=2.62.0`

### `lm-agent/lm_agent/scheduler.py`
- Replace `AsyncIOScheduler` with `AsyncScheduler` (apscheduler 4.x)
- `Scheduler` class rewritten as async context manager
- `add_job` / `run` are now `async` using `add_schedule(fn, IntervalTrigger(...))` and `run_until_stopped()`
- `start()` / `stop()` methods removed

### `lm-agent/lm_agent/main.py`
- Replace `asyncio.get_event_loop().run_forever()` (deprecated/broken in Python 3.14) with `asyncio.run(_run())`
- `_run()` is an async function that uses `async with scheduler:` context manager