### PR TITLE
ci: add script to bump version

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -43,17 +43,8 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        subproject:
-          - lm-agent
-          - lm-api
-          - lm-cli
-          - lm-simulator
-          - lm-simulator-api
-
     outputs:
-      version: ${{ steps.capture-version.outputs.version }}
+      version: ${{ steps.compute-version.outputs.version }}
 
     steps:
       - name: Checkout repository
@@ -67,63 +58,39 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
 
-      - name: Validate version bump inputs
-        if: matrix.subproject == 'lm-agent'
+      - name: Compute new version
+        id: compute-version
         run: |
           BASE="${{ inputs.base_bump }}"
           STAGE="${{ inputs.stage_bump }}"
+          CURRENT=$(uv version --short --directory lm-agent)
+          NEW_VERSION=$(python3 scripts/bump_version.py "$CURRENT" "$BASE" "$STAGE")
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT -> $NEW_VERSION"
 
-          if [ -z "$BASE" ] && [ -z "$STAGE" ]; then
-            echo "Error: at least one of base_bump or stage_bump must be set"
-            exit 1
-          fi
-
-          if [ "$BASE" = "stable" ] && [ -n "$STAGE" ]; then
-            echo "Error: 'stable' must not be combined with stage_bump"
-            exit 1
-          fi
-
-          if [ -z "$BASE" ] && [ -n "$STAGE" ]; then
-            CURRENT_VERSION=$(uv version --short)
-            if ! echo "$CURRENT_VERSION" | grep -Eq '(a|b|rc|dev|post)[0-9]+$'; then
-              echo "Error: stage_bump without base_bump requires an existing prerelease"
-              echo "Current version: $CURRENT_VERSION"
-              exit 1
-            fi
-          fi
-
-      - name: Bump version
-        working-directory: ${{ matrix.subproject }}
+      - name: Set version on all subprojects
+        env:
+          NEW_VERSION: ${{ steps.compute-version.outputs.version }}
         run: |
-          if [ -n "${{ inputs.base_bump }}" ]; then
-            uv version --bump "${{ inputs.base_bump }}"
-          fi
-
-          if [ -n "${{ inputs.stage_bump }}" ]; then
-            uv version --bump "${{ inputs.stage_bump }}"
-          fi
-
-      - name: Capture version
-        id: capture-version
-        if: matrix.subproject == 'lm-agent'
-        working-directory: lm-agent
-        run: |
-          VERSION=$(uv version --short)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          for subproject in lm-agent lm-api lm-cli lm-simulator lm-simulator-api; do
+            echo "Setting version $NEW_VERSION on $subproject"
+            uv version "$NEW_VERSION" --no-sync --directory "$subproject"
+          done
 
       - name: Verify version consistency
-        if: matrix.subproject != 'lm-agent'
-        working-directory: ${{ matrix.subproject }}
+        env:
+          EXPECTED: ${{ steps.compute-version.outputs.version }}
         run: |
-          EXPECTED="${{ needs.bump-version.outputs.version }}"
-          CURRENT=$(uv version --short)
-
-          if [ "$CURRENT" != "$EXPECTED" ]; then
-            echo "Version mismatch in ${{ matrix.subproject }}"
-            echo "Expected: $EXPECTED"
-            echo "Found:    $CURRENT"
-            exit 1
-          fi
+          for subproject in lm-agent lm-api lm-cli lm-simulator lm-simulator-api; do
+            CURRENT=$(uv version --short --directory "$subproject")
+            if [ "$CURRENT" != "$EXPECTED" ]; then
+              echo "Version mismatch in $subproject"
+              echo "Expected: $EXPECTED"
+              echo "Found:    $CURRENT"
+              exit 1
+            fi
+            echo "$subproject: $CURRENT OK"
+          done
 
   update-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_on_tag.yaml
+++ b/.github/workflows/publish_on_tag.yaml
@@ -11,11 +11,12 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+a[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+b[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+.post[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+.dev[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+.post[0-9]+.dev[0-9]+'
 
 permissions:
   contents: read
@@ -44,7 +45,7 @@ jobs:
         working-directory: ${{ matrix.sub_project }}
         run: |
           echo "uv version is: $(uv version --short)"
-          echo "::set-output name=version::$(uv version --short)"
+          echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
 
       - name: Fail if package version doesn't match the tag
         if: ${{ github.ref_name != steps.uv-package-version.outputs.version }}
@@ -95,7 +96,7 @@ jobs:
         working-directory: lm-api
         run: |
           echo "uv version is: $(uv version --short)"
-          echo "::set-output name=version::$(uv version --short)"
+          echo "version=$(uv version --short)" >> "$GITHUB_OUTPUT"
 
       - name: Fail if uv package version doesn't match tag
         if: ${{ github.ref_name != steps.uv-package-version.outputs.version }}

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Compute a new version string from a current version and bump rules.
+
+Usage:
+    python bump_version.py CURRENT_VERSION BASE_BUMP STAGE_BUMP
+
+BASE_BUMP: major | minor | patch | stable | (empty)
+STAGE_BUMP: alpha | beta | rc | post | dev | (empty)
+
+Prints the resulting PEP 440 version to stdout.
+"""
+import re
+import sys
+
+STAGE_ORDER = {"a": 0, "alpha": 0, "b": 1, "beta": 1, "rc": 2}
+STAGE_CANONICAL = {"alpha": "a", "beta": "b", "rc": "rc", "post": "post", "dev": "dev"}
+
+VERSION_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)"
+    r"\.(?P<minor>0|[1-9]\d*)"
+    r"\.(?P<patch>0|[1-9]\d*)"
+    r"(?:(?P<pre_kind>a|alpha|b|beta|rc)(?P<pre_num>0|[1-9]\d*))?"
+    r"(?:\.post(?P<post>0|[1-9]\d*))?"
+    r"(?:\.dev(?P<dev>0|[1-9]\d*))?$"
+)
+
+
+def parse(version: str) -> dict:
+    m = VERSION_RE.match(version)
+    if not m:
+        raise ValueError(f"Invalid version: {version}")
+    return {
+        "major": int(m.group("major")),
+        "minor": int(m.group("minor")),
+        "patch": int(m.group("patch")),
+        "pre_kind": m.group("pre_kind"),
+        "pre_num": int(m.group("pre_num")) if m.group("pre_num") else None,
+        "post": int(m.group("post")) if m.group("post") else None,
+        "dev": int(m.group("dev")) if m.group("dev") else None,
+    }
+
+
+def format(v: dict) -> str:
+    s = f"{v['major']}.{v['minor']}.{v['patch']}"
+    if v["pre_kind"] is not None:
+        s += f"{STAGE_CANONICAL.get(v['pre_kind'], v['pre_kind'])}{v['pre_num']}"
+    if v["post"] is not None:
+        s += f".post{v['post']}"
+    if v["dev"] is not None:
+        s += f".dev{v['dev']}"
+    return s
+
+
+def is_prerelease(v: dict) -> bool:
+    return v["pre_kind"] is not None or v["post"] is not None or v["dev"] is not None
+
+
+def bump(v: dict, base: str, stage: str) -> dict:
+    v = dict(v)
+
+    if base == "stable":
+        v["pre_kind"] = None
+        v["pre_num"] = None
+        v["post"] = None
+        v["dev"] = None
+        return v
+
+    if base in ("major", "minor", "patch"):
+        if base == "major":
+            v["major"] += 1
+            v["minor"] = 0
+            v["patch"] = 0
+        elif base == "minor":
+            v["minor"] += 1
+            v["patch"] = 0
+        elif base == "patch":
+            if is_prerelease(v) and v["pre_kind"] is None:
+                pass
+            else:
+                v["patch"] += 1
+        v["pre_kind"] = None
+        v["pre_num"] = None
+        v["post"] = None
+        v["dev"] = None
+
+    if stage:
+        canonical = STAGE_CANONICAL.get(stage, stage)
+        if canonical in ("a", "b", "rc"):
+            if base:
+                v["pre_kind"] = canonical
+                v["pre_num"] = 1
+            else:
+                if v["pre_kind"] is not None and STAGE_CANONICAL.get(v["pre_kind"], v["pre_kind"]) == canonical:
+                    v["pre_num"] += 1
+                else:
+                    v["pre_kind"] = canonical
+                    v["pre_num"] = 1
+        elif canonical == "post":
+            if v["post"] is not None and not base:
+                v["post"] += 1
+            else:
+                v["post"] = 1
+        elif canonical == "dev":
+            if v["dev"] is not None and not base:
+                v["dev"] += 1
+            else:
+                v["dev"] = 1
+
+    return v
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+
+    current, base, stage = sys.argv[1], sys.argv[2].strip(), sys.argv[3].strip()
+
+    if not base and not stage:
+        print("Error: at least one of base_bump or stage_bump must be set", file=sys.stderr)
+        sys.exit(1)
+    if base == "stable" and stage:
+        print("Error: 'stable' must not be combined with stage_bump", file=sys.stderr)
+        sys.exit(1)
+
+    v = parse(current)
+
+    if not base and stage:
+        canonical = STAGE_CANONICAL.get(stage, stage)
+        if canonical in ("a", "b", "rc") and v["pre_kind"] is None:
+            msg = (
+                f"Error: stage_bump '{stage}' without base_bump requires "
+                f"an existing prerelease version (current: {current})"
+            )
+            print(msg, file=sys.stderr)
+            sys.exit(1)
+
+    new_v = bump(v, base, stage)
+    print(format(new_v))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
After the `uv` migration, the CI was not working as it used to with `Poetry`.