### PR TITLE
ci: add uv to run update-changelog

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -104,6 +104,9 @@ jobs:
         with:
           python-version: 3.12
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
+
       - name: Install Towncrier and build changelog
         run: |
           pipx install towncrier==24.8.0


### PR DESCRIPTION
The `uv` installation was missing from the `update-changelog` step.