### PR TITLE
ci: run prepare_release on a single runner

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -40,11 +40,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  bump-version:
+  prepare-release:
     runs-on: ubuntu-latest
-
-    outputs:
-      version: ${{ steps.compute-version.outputs.version }}
 
     steps:
       - name: Checkout repository
@@ -92,42 +89,19 @@ jobs:
             echo "$subproject: $CURRENT OK"
           done
 
-  update-changelog:
-    runs-on: ubuntu-latest
-    needs: bump-version
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.12
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
-
       - name: Install Towncrier and build changelog
         run: |
           pipx install towncrier==24.8.0
           make changelog-build
-
-  create-pr:
-    runs-on: ubuntu-latest
-    needs: bump-version
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79 # v7
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Prepared release ${{ needs.bump-version.outputs.version }}"
-          branch: prepare-release/${{ needs.bump-version.outputs.version }}
-          title: Release ${{ needs.bump-version.outputs.version }}
+          commit-message: "Prepared release ${{ steps.compute-version.outputs.version }}"
+          branch: prepare-release/${{ steps.compute-version.outputs.version }}
+          title: Release ${{ steps.compute-version.outputs.version }}
           draft: true
           delete-branch: true
           body: |


### PR DESCRIPTION
The `prepare_release` action was running on two separate runners, making the changes in the previous step not visible to the next one.